### PR TITLE
Make MarkItDown timeout configurable and avoid PDF byte fallback

### DIFF
--- a/extensions/llm-wiki/lib/source-packet.ts
+++ b/extensions/llm-wiki/lib/source-packet.ts
@@ -70,7 +70,7 @@ export async function captureUrl(
   let title = url;
   const isPdf = isPdfUrl(url);
 
-  // Try markitdown first
+  // Try MarkItDown first. The timeout is shared by all MarkItDown conversions.
   const markitdown = await exec(
     pi,
     "sh",
@@ -173,7 +173,7 @@ export async function captureFile(
   const content = isPdf ? "" : readText(filePath);
   const fileName = filePath.split("/").pop() || "unknown";
 
-  // Try markitdown for PDFs
+  // Try MarkItDown for PDFs. The timeout is shared by all MarkItDown conversions.
   let extracted = content;
   if (isPdf) {
     const markitdown = await exec(

--- a/extensions/llm-wiki/lib/source-packet.ts
+++ b/extensions/llm-wiki/lib/source-packet.ts
@@ -70,7 +70,7 @@ export async function captureUrl(
   let title = url;
   const isPdf = isPdfUrl(url);
 
-  // Try MarkItDown first. The timeout is shared by all MarkItDown conversions.
+  // Try MarkItDown first.
   const markitdown = await exec(
     pi,
     "sh",
@@ -99,31 +99,33 @@ export async function captureUrl(
 
   // Fallback: try fetch_content equivalent via curl for text/html sources.
   // Do not write binary PDF bytes into extracted.md when PDF conversion fails.
-  if (!extracted && isPdf) {
-    extracted = pdfExtractionFailureMessage(url);
-  } else if (!extracted) {
-    try {
-      const curlResult = await exec(
-        pi,
-        "curl",
-        ["-sL", "--max-time", String(DEFAULT_CURL_TIMEOUT_SECONDS), url],
-        {
-          signal,
-          timeout: (DEFAULT_CURL_TIMEOUT_SECONDS + 5) * 1_000,
-        },
-      );
-      if (curlResult.stdout) {
-        if (looksLikePdf(curlResult.stdout)) {
-          extracted = pdfExtractionFailureMessage(url);
-        } else {
-          extracted = curlResult.stdout;
-          // Try to extract title from HTML
-          const titleMatch = extracted.match(/<title>([^<]*)<\/title>/i);
-          if (titleMatch) title = titleMatch[1].trim();
+  if (!extracted) {
+    if (isPdf) {
+      extracted = pdfExtractionFailureMessage(url);
+    } else {
+      try {
+        const curlResult = await exec(
+          pi,
+          "curl",
+          ["-sL", "--max-time", String(DEFAULT_CURL_TIMEOUT_SECONDS), url],
+          {
+            signal,
+            timeout: (DEFAULT_CURL_TIMEOUT_SECONDS + 5) * 1_000,
+          },
+        );
+        if (curlResult.stdout) {
+          if (looksLikePdf(curlResult.stdout)) {
+            extracted = pdfExtractionFailureMessage(url);
+          } else {
+            extracted = curlResult.stdout;
+            // Try to extract title from HTML
+            const titleMatch = extracted.match(/<title>([^<]*)<\/title>/i);
+            if (titleMatch) title = titleMatch[1].trim();
+          }
         }
+      } catch {
+        // curl failed too
       }
-    } catch {
-      // curl failed too
     }
   }
 
@@ -173,7 +175,7 @@ export async function captureFile(
   const content = isPdf ? "" : readText(filePath);
   const fileName = filePath.split("/").pop() || "unknown";
 
-  // Try MarkItDown for PDFs. The timeout is shared by all MarkItDown conversions.
+  // Try MarkItDown for PDFs.
   let extracted = content;
   if (isPdf) {
     const markitdown = await exec(
@@ -196,6 +198,7 @@ export async function captureFile(
         extracted = pdfExtractionFailureMessage(filePath);
       }
     }
+    if (!extracted) extracted = pdfExtractionFailureMessage(filePath);
   }
 
   // Copy original to packet
@@ -205,8 +208,6 @@ export async function captureFile(
     // If cp fails, just write the content
     writeFileSync(join(packetPath, "original", fileName), content, "utf-8");
   }
-
-  if (isPdf && !extracted) extracted = pdfExtractionFailureMessage(filePath);
 
   // Write extracted text
   writeFileSync(join(packetPath, "extracted.md"), extracted, "utf-8");

--- a/extensions/llm-wiki/lib/source-packet.ts
+++ b/extensions/llm-wiki/lib/source-packet.ts
@@ -22,6 +22,36 @@ export interface CaptureResult {
   extracted: string;
 }
 
+const DEFAULT_MARKITDOWN_TIMEOUT_MS = 180_000;
+const DEFAULT_CURL_TIMEOUT_SECONDS = 30;
+
+function markitdownTimeoutMs(): number {
+  return positiveIntegerFromEnv("WIKI_MARKITDOWN_TIMEOUT_MS", DEFAULT_MARKITDOWN_TIMEOUT_MS);
+}
+
+function positiveIntegerFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isPdfUrl(url: string): boolean {
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith(".pdf");
+  } catch {
+    return url.toLowerCase().split(/[?#]/, 1)[0].endsWith(".pdf");
+  }
+}
+
+function looksLikePdf(content: string): boolean {
+  return content.trimStart().startsWith("%PDF-");
+}
+
+function pdfExtractionFailureMessage(source: string): string {
+  return `_PDF content could not be converted to markdown from ${source}. Try increasing WIKI_MARKITDOWN_TIMEOUT_MS._\n`;
+}
+
 /** Capture a URL into a source packet. */
 export async function captureUrl(
   pi: ExtensionAPI,
@@ -38,6 +68,7 @@ export async function captureUrl(
   // Try to fetch and extract content
   let extracted = "";
   let title = url;
+  const isPdf = isPdfUrl(url);
 
   // Try markitdown first
   const markitdown = await exec(
@@ -53,7 +84,7 @@ export async function captureUrl(
         pi,
         "sh",
         ["-c", `uvx --from 'markitdown[pdf]' markitdown "${url}" 2>/dev/null || echo ""`],
-        { signal, timeout: 30_000 },
+        { signal, timeout: markitdownTimeoutMs() },
       );
       if (mdResult.stdout.trim()) {
         extracted = mdResult.stdout;
@@ -66,18 +97,30 @@ export async function captureUrl(
     }
   }
 
-  // Fallback: try fetch_content equivalent via curl
-  if (!extracted) {
+  // Fallback: try fetch_content equivalent via curl for text/html sources.
+  // Do not write binary PDF bytes into extracted.md when PDF conversion fails.
+  if (!extracted && isPdf) {
+    extracted = pdfExtractionFailureMessage(url);
+  } else if (!extracted) {
     try {
-      const curlResult = await exec(pi, "curl", ["-sL", "--max-time", "30", url], {
-        signal,
-        timeout: 35_000,
-      });
+      const curlResult = await exec(
+        pi,
+        "curl",
+        ["-sL", "--max-time", String(DEFAULT_CURL_TIMEOUT_SECONDS), url],
+        {
+          signal,
+          timeout: (DEFAULT_CURL_TIMEOUT_SECONDS + 5) * 1_000,
+        },
+      );
       if (curlResult.stdout) {
-        extracted = curlResult.stdout;
-        // Try to extract title from HTML
-        const titleMatch = extracted.match(/<title>([^<]*)<\/title>/i);
-        if (titleMatch) title = titleMatch[1].trim();
+        if (looksLikePdf(curlResult.stdout)) {
+          extracted = pdfExtractionFailureMessage(url);
+        } else {
+          extracted = curlResult.stdout;
+          // Try to extract title from HTML
+          const titleMatch = extracted.match(/<title>([^<]*)<\/title>/i);
+          if (titleMatch) title = titleMatch[1].trim();
+        }
       }
     } catch {
       // curl failed too
@@ -126,12 +169,13 @@ export async function captureFile(
   mkdirSync(join(packetPath, "original"), { recursive: true });
   mkdirSync(join(packetPath, "attachments"), { recursive: true });
 
-  const content = readText(filePath);
+  const isPdf = filePath.toLowerCase().endsWith(".pdf");
+  const content = isPdf ? "" : readText(filePath);
   const fileName = filePath.split("/").pop() || "unknown";
 
   // Try markitdown for PDFs
   let extracted = content;
-  if (filePath.toLowerCase().endsWith(".pdf")) {
+  if (isPdf) {
     const markitdown = await exec(
       pi,
       "sh",
@@ -145,11 +189,11 @@ export async function captureFile(
           pi,
           "sh",
           ["-c", `uvx --from 'markitdown[pdf]' markitdown "${filePath}" 2>/dev/null || echo ""`],
-          { signal, timeout: 30_000 },
+          { signal, timeout: markitdownTimeoutMs() },
         );
         if (mdResult.stdout.trim()) extracted = mdResult.stdout;
       } catch {
-        // fallback to original
+        extracted = pdfExtractionFailureMessage(filePath);
       }
     }
   }
@@ -161,6 +205,8 @@ export async function captureFile(
     // If cp fails, just write the content
     writeFileSync(join(packetPath, "original", fileName), content, "utf-8");
   }
+
+  if (isPdf && !extracted) extracted = pdfExtractionFailureMessage(filePath);
 
   // Write extracted text
   writeFileSync(join(packetPath, "extracted.md"), extracted, "utf-8");

--- a/test/llm-wiki.test.ts
+++ b/test/llm-wiki.test.ts
@@ -157,6 +157,17 @@ describe("package structure", () => {
     }
   });
 
+  it("should keep PDF extraction timeout configurable and avoid PDF byte fallbacks", () => {
+    const sourcePacketPath = join(rootDir, "extensions", "llm-wiki", "lib", "source-packet.ts");
+    expect(existsSync(sourcePacketPath)).toBe(true);
+    const content = readFile(sourcePacketPath);
+    expect(content).toContain("WIKI_MARKITDOWN_TIMEOUT_MS");
+    expect(content).toContain("DEFAULT_MARKITDOWN_TIMEOUT_MS = 180_000");
+    expect(content).toContain("isPdfUrl(url)");
+    expect(content).toContain("looksLikePdf(curlResult.stdout)");
+    expect(content).toContain("pdfExtractionFailureMessage");
+  });
+
   it("should have a comprehensive README with install instructions", () => {
     const readme = readFile(join(rootDir, "README.md"));
     expect(readme).toContain("@zosmaai/pi-llm-wiki");

--- a/test/llm-wiki.test.ts
+++ b/test/llm-wiki.test.ts
@@ -157,7 +157,7 @@ describe("package structure", () => {
     }
   });
 
-  it("should keep PDF extraction timeout configurable and avoid PDF byte fallbacks", () => {
+  it("should keep MarkItDown timeout configurable and avoid PDF byte fallbacks", () => {
     const sourcePacketPath = join(rootDir, "extensions", "llm-wiki", "lib", "source-packet.ts");
     expect(existsSync(sourcePacketPath)).toBe(true);
     const content = readFile(sourcePacketPath);


### PR DESCRIPTION
## Summary

Fixes PDF capture behavior when MarkItDown takes longer than the previous hardcoded 30 second timeout.

Changes:

- increase the default MarkItDown timeout to 180 seconds;
- add `WIKI_MARKITDOWN_TIMEOUT_MS` so projects can tune the timeout for all MarkItDown conversions;
- apply the configured timeout to every MarkItDown invocation currently used by source capture;
- detect PDF URLs before falling back to `curl`;
- avoid writing raw PDF bytes into `extracted.md` when PDF extraction fails;
- detect `%PDF-` content from non-`.pdf` URLs and write a clear extraction failure message instead;
- avoid reading local PDFs as text before MarkItDown extraction;
- add regression coverage for the timeout/fallback safeguards.

Fixes #1
Fixes #2

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
