### PR TITLE
Fix slash command prompt argument forwarding

### DIFF
--- a/prompts/wiki-digest.md
+++ b/prompts/wiki-digest.md
@@ -1,6 +1,6 @@
 ---
 description: Generate a daily or weekly digest of wiki changes — new sources, pages, insights, and gaps.
-args: [--period daily|weekly]
+argument-hint: "[--period daily|weekly]"
 section: LLM Wiki
 topLevelCli: true
 ---
@@ -8,6 +8,10 @@ topLevelCli: true
 # /wiki-digest
 
 Generate a digest of recent wiki activity.
+
+## User Arguments
+
+$ARGUMENTS
 
 ## Steps
 

--- a/prompts/wiki-discover.md
+++ b/prompts/wiki-discover.md
@@ -1,6 +1,6 @@
 ---
 description: Auto-discover new sources from the web. Searches based on config topics and known knowledge gaps.
-args: [--topic <topic>]
+argument-hint: "[--topic <topic>]"
 section: LLM Wiki
 topLevelCli: true
 ---
@@ -8,6 +8,10 @@ topLevelCli: true
 # /wiki-discover
 
 Find new source material for the wiki by searching the web.
+
+## User Arguments
+
+$ARGUMENTS
 
 Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first. Also read `config.yaml` for topics and feeds.
 

--- a/prompts/wiki-ingest.md
+++ b/prompts/wiki-ingest.md
@@ -1,6 +1,6 @@
 ---
 description: Process new source files in raw/ and update the wiki. Creates summaries, entities, concepts, and cross-references.
-args: [path]
+argument-hint: "[path]"
 section: LLM Wiki
 topLevelCli: true
 ---
@@ -8,6 +8,10 @@ topLevelCli: true
 # /wiki-ingest
 
 Process new files in `raw/` and integrate them into the wiki.
+
+## User Arguments
+
+$ARGUMENTS
 
 Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand the full schema, page formats, and conventions.
 

--- a/prompts/wiki-init.md
+++ b/prompts/wiki-init.md
@@ -1,6 +1,6 @@
 ---
 description: Initialize a new LLM Wiki in the current directory. Creates the full directory structure, config, and template files.
-args: <topic> [--mode personal|company]
+argument-hint: "<topic> [--mode personal|company]"
 section: LLM Wiki
 topLevelCli: true
 ---
@@ -8,6 +8,10 @@ topLevelCli: true
 # /wiki-init
 
 Initialize a new LLM Wiki in the current directory.
+
+## User Arguments
+
+$ARGUMENTS
 
 Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` (or wherever the skill is installed) first to understand the full schema and conventions.
 

--- a/prompts/wiki-lint.md
+++ b/prompts/wiki-lint.md
@@ -1,6 +1,6 @@
 ---
 description: Health check the wiki. Detects contradictions, orphans, missing pages, stale claims, and knowledge gaps.
-args: [--fix]
+argument-hint: "[--fix]"
 section: LLM Wiki
 topLevelCli: true
 ---
@@ -8,6 +8,10 @@ topLevelCli: true
 # /wiki-lint
 
 Run a comprehensive health check on the wiki.
+
+## User Arguments
+
+$ARGUMENTS
 
 Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand the full schema and conventions.
 

--- a/prompts/wiki-query.md
+++ b/prompts/wiki-query.md
@@ -1,6 +1,6 @@
 ---
 description: Ask questions against the wiki. Synthesizes answers from wiki pages with cross-reference citations.
-args: <question>
+argument-hint: "<question>"
 section: LLM Wiki
 topLevelCli: true
 ---
@@ -8,6 +8,10 @@ topLevelCli: true
 # /wiki-query
 
 Ask a question and get an answer synthesized from wiki content.
+
+## User Question
+
+$ARGUMENTS
 
 Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand the full schema and conventions.
 

--- a/prompts/wiki-run.md
+++ b/prompts/wiki-run.md
@@ -1,6 +1,6 @@
 ---
 description: Run the full wiki cycle: discover → ingest → lint. Optionally schedule for auto-updates.
-args: [--schedule daily|weekly]
+argument-hint: "[--schedule daily|weekly]"
 section: LLM Wiki
 topLevelCli: true
 ---
@@ -8,6 +8,10 @@ topLevelCli: true
 # /wiki-run
 
 Run the complete wiki maintenance cycle: discover new sources, ingest them, and lint for health.
+
+## User Arguments
+
+$ARGUMENTS
 
 Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first.
 

--- a/prompts/wiki-status.md
+++ b/prompts/wiki-status.md
@@ -1,6 +1,6 @@
 ---
 description: Show wiki health overview — source count, page stats, orphan count, last activity dates.
-args: []
+argument-hint: ""
 section: LLM Wiki
 topLevelCli: true
 ---

--- a/test/llm-wiki.test.ts
+++ b/test/llm-wiki.test.ts
@@ -111,9 +111,31 @@ describe("package structure", () => {
       expect(existsSync(path)).toBe(true);
       const content = readFile(path);
       expect(content).toContain("description:");
+      expect(content).toContain("argument-hint:");
       expect(content).toContain("section: LLM Wiki");
       expect(content).toContain("topLevelCli: true");
+      expect(content).not.toContain("\nargs:");
     }
+  });
+
+  it("should include prompt arguments in templates that accept them", () => {
+    const promptsWithArgs = [
+      "wiki-init.md",
+      "wiki-ingest.md",
+      "wiki-query.md",
+      "wiki-lint.md",
+      "wiki-discover.md",
+      "wiki-run.md",
+      "wiki-digest.md",
+    ];
+    for (const prompt of promptsWithArgs) {
+      const content = readFile(join(rootDir, "prompts", prompt));
+      expect(content).toContain("$ARGUMENTS");
+    }
+
+    const query = readFile(join(rootDir, "prompts", "wiki-query.md"));
+    expect(query).toContain("## User Question");
+    expect(query).toContain("$ARGUMENTS");
   });
 
   it("should have all wiki template files", () => {


### PR DESCRIPTION
## Summary

- replace non-standard `args:` prompt frontmatter with pi-supported `argument-hint:`
- add `$ARGUMENTS` sections to prompt templates that accept user arguments
- make `/wiki-query <question>` include the actual question under `## User Question`
- add regression tests so prompt templates keep argument hints and argument interpolation

Fixes #6.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
