### PR TITLE
Preserve original artifacts for URL captures

### DIFF
--- a/extensions/llm-wiki/lib/source-packet.ts
+++ b/extensions/llm-wiki/lib/source-packet.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { extname, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { appendEvent } from "./metadata.js";
 import { type VaultPaths, exec, fmtDate, nextSourceId, readText, writeJson } from "./utils.js";
@@ -52,6 +52,39 @@ function pdfExtractionFailureMessage(source: string): string {
   return `_PDF content could not be converted to markdown from ${source}. Try increasing WIKI_MARKITDOWN_TIMEOUT_MS._\n`;
 }
 
+const URL_ORIGINAL_EXTENSIONS = new Set([".html", ".htm", ".md", ".pdf", ".txt", ".xml", ".json"]);
+
+function originalFileNameForUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const ext = extname(parsed.pathname).toLowerCase();
+    if (URL_ORIGINAL_EXTENSIONS.has(ext)) return `source${ext}`;
+  } catch {
+    const path = url.split(/[?#]/, 1)[0] ?? "";
+    const ext = extname(path).toLowerCase();
+    if (URL_ORIGINAL_EXTENSIONS.has(ext)) return `source${ext}`;
+  }
+
+  return "source.html";
+}
+
+async function preserveUrlOriginal(
+  pi: ExtensionAPI,
+  packetPath: string,
+  url: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const originalPath = join(packetPath, "original", originalFileNameForUrl(url));
+  try {
+    await exec(pi, "curl", ["-sL", "--max-time", "30", "-o", originalPath, url], {
+      signal,
+      timeout: 35_000,
+    });
+  } catch {
+    // Preserve best-effort extraction behavior even when the original artifact cannot be saved.
+  }
+}
+
 /** Capture a URL into a source packet. */
 export async function captureUrl(
   pi: ExtensionAPI,
@@ -64,6 +97,8 @@ export async function captureUrl(
   mkdirSync(packetPath, { recursive: true });
   mkdirSync(join(packetPath, "original"), { recursive: true });
   mkdirSync(join(packetPath, "attachments"), { recursive: true });
+
+  await preserveUrlOriginal(pi, packetPath, url, signal);
 
   // Try to fetch and extract content
   let extracted = "";

--- a/test/llm-wiki.test.ts
+++ b/test/llm-wiki.test.ts
@@ -244,14 +244,20 @@ describe("source packet capture", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("should render Original URLs as clickable Markdown links", async () => {
+  it("should preserve the original artifact for URL captures and render clickable links", async () => {
     const paths = getVaultPaths(join(tempDir, "wiki-root"));
     ensureVaultStructure(paths);
 
     const html = "<html><head><title>Example Page</title></head><body>Hello</body></html>";
     const pi = {
-      exec: async (command: string) => {
+      exec: async (command: string, args: string[]) => {
         if (command === "sh") return { stdout: "no\n", stderr: "", code: 0 };
+        if (command === "curl" && args.includes("-o")) {
+          const outputPath = args[args.indexOf("-o") + 1];
+          writeFileSync(outputPath, html, "utf-8");
+          return { stdout: "", stderr: "", code: 0 };
+        }
+
         if (command === "curl") return { stdout: html, stderr: "", code: 0 };
         throw new Error(`Unexpected command: ${command}`);
       },
@@ -259,8 +265,14 @@ describe("source packet capture", () => {
 
     const url = "https://example.com/article";
     const result = await captureUrl(pi as never, paths, url);
-    const sourcePage = readFile(result.sourcePagePath);
 
+    // Original artifact preserved
+    expect(existsSync(join(result.packetPath, "original", "source.html"))).toBe(true);
+    expect(readFile(join(result.packetPath, "original", "source.html"))).toBe(html);
+    expect(readFile(join(result.packetPath, "extracted.md"))).toBe(html);
+
+    // Clickable URL in source page
+    const sourcePage = readFile(result.sourcePagePath);
     expect(sourcePage).toContain(`> _Original: [${url}](${url})_`);
   });
 });


### PR DESCRIPTION
## Summary

- preserve a fetched URL payload under `original/source.*` during URL capture
- choose a stable filename extension from common URL path extensions, defaulting to `source.html`
- add a regression test that URL capture writes the original artifact as well as `extracted.md`

Fixes #8.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run lint`
