### PR TITLE
Convert XML files to readable markdown on capture

### DIFF
--- a/extensions/llm-wiki/lib/source-packet.ts
+++ b/extensions/llm-wiki/lib/source-packet.ts
@@ -206,12 +206,20 @@ export async function captureFile(
   mkdirSync(join(packetPath, "original"), { recursive: true });
   mkdirSync(join(packetPath, "attachments"), { recursive: true });
 
-  const isPdf = filePath.toLowerCase().endsWith(".pdf");
+  const lowerPath = filePath.toLowerCase();
+  const isPdf = lowerPath.endsWith(".pdf");
+  const isXml = lowerPath.endsWith(".xml");
   const content = isPdf ? "" : readText(filePath);
   const fileName = filePath.split("/").pop() || "unknown";
 
-  // Try MarkItDown for PDFs.
   let extracted = content;
+
+  // Convert XML to markdown
+  if (isXml && content) {
+    extracted = xmlToMarkdown(content);
+  }
+
+  // Try MarkItDown for PDFs.
   if (isPdf) {
     const markitdown = await exec(
       pi,
@@ -363,12 +371,49 @@ status: skeleton
 `;
 }
 
+/** Basic XML to markdown conversion: strip tags while preserving text structure. */
+function xmlToMarkdown(xml: string): string {
+  // Extract title from first <title> or root element
+  let title = "";
+  const titleMatch = xml.match(/<title[^>]*>([^<]*)<\/title>/i);
+  if (titleMatch) title = titleMatch[1].trim();
+
+  // Strip XML declaration and doctype
+  let text = xml.replace(/<\?xml[^>]*\?>\s*/gi, "");
+  text = text.replace(/<!DOCTYPE[^>]*>\s*/gi, "");
+
+  // Replace block-level tags with newlines
+  text = text.replace(/<\/(p|div|section|article|li|h\d|tr|blockquote|pre|br\s*\/?)>/gi, "\n");
+  text = text.replace(/<br\s*\/?>/gi, "\n");
+
+  // Replace remaining tags with nothing
+  text = text.replace(/<[^>]*>/g, "");
+
+  // Decode common XML entities
+  text = text.replace(/&amp;/g, "&");
+  text = text.replace(/&lt;/g, "<");
+  text = text.replace(/&gt;/g, ">");
+  text = text.replace(/&quot;/g, '"');
+  text = text.replace(/&#\d+;/g, (m) => String.fromCodePoint(Number.parseInt(m.slice(2, -1))));
+
+  // Clean up excessive blank lines
+  text = text.replace(/\n{3,}/g, "\n\n").trim();
+
+  if (!text) return xml; // fallback: return raw if stripping produced nothing
+
+  const lines = [];
+  if (title) lines.push(`# ${title}\n`);
+  lines.push(text);
+  return lines.join("\n\n");
+}
+
 function guessFormat(filePath: string): string {
   const lower = filePath.toLowerCase();
   if (lower.endsWith(".pdf")) return "pdf";
   if (lower.endsWith(".md")) return "markdown";
   if (lower.endsWith(".txt")) return "text";
   if (lower.endsWith(".html") || lower.endsWith(".htm")) return "html";
+  if (lower.endsWith(".xml")) return "xml";
   if (lower.endsWith(".docx")) return "docx";
   return "file";
 }

--- a/extensions/llm-wiki/lib/source-packet.ts
+++ b/extensions/llm-wiki/lib/source-packet.ts
@@ -383,18 +383,27 @@ function xmlToMarkdown(xml: string): string {
   text = text.replace(/<!DOCTYPE[^>]*>\s*/gi, "");
 
   // Replace block-level tags with newlines
-  text = text.replace(/<\/(p|div|section|article|li|h\d|tr|blockquote|pre|br\s*\/?)>/gi, "\n");
+  text = text.replace(/<\/(p|div|section|article|li|h\d|tr|blockquote|pre)>/gi, "\n");
   text = text.replace(/<br\s*\/?>/gi, "\n");
 
-  // Replace remaining tags with nothing
-  text = text.replace(/<[^>]*>/g, "");
+  // Strip remaining tags — match < followed by tag name characters to >
+  // Using a loop to handle malformed/broken tags that lack a closing >
+  let prev = "";
+  while (prev !== text) {
+    prev = text;
+    text = text.replace(/<[a-zA-Z\/!?][^>]*>/g, "");
+  }
+  // Remove any stray < that didn't form a complete tag
+  text = text.replace(/</g, "");
 
-  // Decode common XML entities
-  text = text.replace(/&amp;/g, "&");
-  text = text.replace(/&lt;/g, "<");
-  text = text.replace(/&gt;/g, ">");
-  text = text.replace(/&quot;/g, '"');
-  text = text.replace(/&#\d+;/g, (m) => String.fromCodePoint(Number.parseInt(m.slice(2, -1))));
+  // Decode XML entities in a single pass to avoid double-unescaping
+  text = text.replace(/&(?:amp|lt|gt|quot|#\d+);/gi, (entity) => {
+    const map: Record<string, string> = { "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"' };
+    const lower = entity.toLowerCase();
+    if (map[lower]) return map[lower];
+    if (lower.startsWith("&#")) return String.fromCodePoint(Number.parseInt(entity.slice(2, -1)));
+    return entity;
+  });
 
   // Clean up excessive blank lines
   text = text.replace(/\n{3,}/g, "\n\n").trim();

--- a/test/llm-wiki.test.ts
+++ b/test/llm-wiki.test.ts
@@ -388,6 +388,56 @@ describe("source packet capture", () => {
     // Original file should be preserved
     expect(existsSync(join(result.packetPath, "original", "notes.md"))).toBe(true);
   });
+
+  it("should convert XML files to readable markdown in extracted.md", async () => {
+    const paths = makePaths();
+    const xmlContent = `<?xml version="1.0" encoding="UTF-8"?>
+<document>
+  <title>Project Report</title>
+  <section>
+    <heading>Findings</heading>
+    <p>The analysis revealed several key insights.</p>
+    <list>
+      <item>First finding</item>
+      <item>Second finding</item>
+    </list>
+  </section>
+</document>`;
+    const xmlPath = join(tempDir, "report.xml");
+    writeFileSync(xmlPath, xmlContent, "utf-8");
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, xmlPath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    // Should have extracted title
+    expect(extracted).toContain("Project Report");
+    // Should have extracted text content
+    expect(extracted).toContain("The analysis revealed several key insights.");
+    expect(extracted).toContain("First finding");
+    expect(extracted).toContain("Second finding");
+    // Should NOT contain raw XML tags
+    expect(extracted).not.toContain("<?xml");
+    expect(extracted).not.toContain("<document>");
+    expect(extracted).not.toContain("</document>");
+
+    // Original file should be preserved
+    expect(existsSync(join(result.packetPath, "original", "report.xml"))).toBe(true);
+  });
+
+  it("should fall back to raw XML content when tag stripping produces nothing", async () => {
+    const paths = makePaths();
+    const xmlContent = `<?xml version="1.0"?><data><![CDATA[Hello]]></data>`;
+    const xmlPath = join(tempDir, "minimal.xml");
+    writeFileSync(xmlPath, xmlContent, "utf-8");
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, xmlPath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    // Should have the text content at minimum
+    expect(extracted).toContain("Hello");
+  });
 });
 
 describe("wiki directory structure", () => {


### PR DESCRIPTION
## Summary

Local XML file captures write raw XML to `extracted.md` instead of normalized markdown.

Fixes #3

## Changes

**`source-packet.ts`**
- Add `xmlToMarkdown()` function: strips XML tags while preserving text content (titles, paragraphs, lists, entities)
- Add `.xml` to `guessFormat()` for proper format metadata
- Detect `.xml` files in `captureFile()` and convert before writing to `extracted.md`
- Fallback: if tag stripping produces no text, returns raw XML as-is

**Tests (36 → 36, 2 new)**
- XML file with structure → title and text extracted, no raw tags
- Minimal XML with only CDATA → text content preserved

## Validation

- `npm test` — 36 tests pass
- `npm run typecheck` — clean
- `npm run lint` — clean

Issue #4 (typed extraction pipeline) is a broader design goal — this PR fixes the concrete bug.
