### PR TITLE
Phase 1: Automatic wiki recall — surface relevant knowledge at session start

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -1,5 +1,8 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
+import { formatRecallContext, registerWikiRecall, searchWiki } from "./lib/recall.js";
 import {
   registerWikiBootstrap,
   registerWikiCaptureSource,
@@ -12,25 +15,22 @@ import {
   registerWikiStatus,
   registerWikiWatch,
 } from "./lib/tools.js";
+import { getVaultPaths, resolveVaultRoot } from "./lib/utils.js";
 
 /**
  * @zosmaai/pi-llm-wiki — LLM Wiki extension for Pi
  *
- * Registers 10 custom tools and installs guardrails:
- * - wiki_bootstrap      Initialize a new vault
- * - wiki_capture_source Capture URL/file/text into source packet
- * - wiki_ingest         Get batch of sources needing synthesis
- * - wiki_ensure_page    Create canonical page from template
- * - wiki_search         Search generated registry
- * - wiki_lint           Health check with auto-fix
- * - wiki_status         Instant stats from registry
- * - wiki_rebuild_meta   Force metadata rebuild
- * - wiki_log_event      Append event and regenerate log
- * - wiki_watch          Schedule auto-updates
+ * Registers 11 custom tools and installs guardrails:
+ * All 10 original tools + wiki_recall (auto-recall at session start)
  *
  * Guardrails:
  * - Blocks direct edits to raw/** and meta/**
  * - Auto-rebuilds metadata after wiki/** edits
+ *
+ * Auto-recall:
+ * - before_agent_start hook searches wiki for pages relevant to user prompt
+ * - Injects matching knowledge as system context
+ * - wiki_recall tool available for explicit deep searches
  */
 
 export default function (pi: ExtensionAPI) {
@@ -44,10 +44,35 @@ export default function (pi: ExtensionAPI) {
   registerWikiRebuildMeta(pi);
   registerWikiLogEvent(pi);
   registerWikiWatch(pi);
+  registerWikiRecall(pi);
 
   installGuardrails(pi);
 
   pi.on("session_start", async (_event, ctx) => {
-    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (10 tools, guardrails active)");
+    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (11 tools, auto-recall active)");
+  });
+
+  // ─── Auto-recall hook ──────────────────────────────
+  // Before each agent turn, search the wiki for pages relevant
+  // to the user's prompt and inject them as system context.
+  pi.on("before_agent_start", async (event, _ctx) => {
+    const root = resolveVaultRoot(process.cwd());
+    if (!existsSync(join(root, ".wiki", "config.json"))) {
+      return; // No wiki vault — nothing to recall
+    }
+
+    const paths = getVaultPaths(root);
+    const prompt = event.prompt || "";
+    if (!prompt.trim()) return;
+
+    const results = searchWiki(paths, prompt);
+    if (results.length === 0) return;
+
+    const context = formatRecallContext(results);
+    if (!context) return;
+
+    return {
+      systemPrompt: `${event.systemPrompt}\n\n${context}`,
+    };
   });
 }

--- a/extensions/llm-wiki/lib/recall.ts
+++ b/extensions/llm-wiki/lib/recall.ts
@@ -1,0 +1,208 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+import type { Registry } from "./metadata.js";
+import { type VaultPaths, getVaultPaths, readJson, readText, resolveVaultRoot } from "./utils.js";
+
+// ─── Public API ────────────────────────────────────────
+
+export interface RecallResult {
+  /** Page identifier (folder-qualified, e.g. "concepts/rag") */
+  id: string;
+  /** Page title */
+  title: string;
+  /** Page type: source, entity, concept, synthesis, analysis */
+  type: string;
+  /** First N chars of page content for context */
+  preview: string;
+  /** Relative path from wiki root */
+  path: string;
+}
+
+/**
+ * Search the wiki registry for pages matching a query.
+ * Returns up to `maxResults` matches, each with a content preview.
+ */
+export function searchWiki(paths: VaultPaths, query: string, maxResults = 5): RecallResult[] {
+  const registry = readJson<Registry>(join(paths.meta, "registry.json"), {
+    version: "1.0",
+    last_updated: "",
+    pages: {},
+  });
+
+  const q = query.toLowerCase();
+  const terms = q
+    .split(/\s+/)
+    .filter((t) => t.length > 2)
+    .slice(0, 10);
+
+  if (terms.length === 0) return [];
+
+  type Scored = { id: string; entry: Registry["pages"][string]; score: number };
+  const scored: Scored[] = [];
+
+  for (const [id, entry] of Object.entries(registry.pages)) {
+    let score = 0;
+    const title = String(entry.title || "").toLowerCase();
+    const type = String(entry.type || "").toLowerCase();
+
+    for (const term of terms) {
+      if (id.toLowerCase().includes(term)) score += 3;
+      if (title.includes(term)) score += 4;
+      if (type.includes(term)) score += 1;
+    }
+
+    // Boost if query terms appear in tags/categories
+    const tags = String(entry.tags || entry.category || entry.domain || "");
+    for (const term of terms) {
+      if (tags.toLowerCase().includes(term)) score += 2;
+    }
+
+    if (score > 0) {
+      scored.push({ id, entry, score });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  const top = scored.slice(0, maxResults);
+
+  return top.map(({ id, entry }) => {
+    // Try to read page content for preview
+    let preview = "";
+    const pagePath = join(paths.wiki, `${id}.md`);
+    if (existsSync(pagePath)) {
+      const content = readFileSync(pagePath, "utf-8");
+      // Strip frontmatter
+      const body = content.replace(/^---[\s\S]*?---\n/, "").trim();
+      preview = body.slice(0, 200).replace(/\n/g, " ");
+    }
+
+    return {
+      id,
+      title: String(entry.title || id),
+      type: String(entry.type || "page"),
+      preview,
+      path: pagePath,
+    };
+  });
+}
+
+/**
+ * Format recall results as a compact system-prompt section.
+ */
+export function formatRecallContext(results: RecallResult[]): string {
+  if (results.length === 0) return "";
+
+  const lines: string[] = [
+    "## Relevant Wiki Knowledge",
+    "",
+    `_${results.length} page(s) matched your query — reviewed automatically by LLM Wiki._`,
+    "",
+  ];
+
+  for (const r of results) {
+    lines.push(`- **[[${r.id}]]** — *${r.type}* — ${r.title}`);
+    if (r.preview) {
+      // Truncate preview to one line
+      const preview = r.preview.length > 120 ? `${r.preview.slice(0, 120)}…` : r.preview;
+      lines.push(`  ${preview}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    "Use `read` to view full pages. Add new findings via wiki_ensure_page or wiki_retro.",
+    "",
+  );
+
+  return lines.join("\n");
+}
+
+// ─── Tool Registration ──────────────────────────────────
+
+/**
+ * Register the `wiki_recall` tool.
+ * The model can call this explicitly to search the wiki.
+ * It is also called automatically via before_agent_start hook.
+ */
+export function registerWikiRecall(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "wiki_recall",
+    label: "Wiki Recall",
+    description:
+      "Search the wiki for pages relevant to a query. " +
+      "Returns matching page IDs, titles, types, and content previews. " +
+      "Called automatically at session start — use explicitly to dig deeper.",
+    promptSnippet: "Recall wiki knowledge relevant to the current task",
+    promptGuidelines: [
+      "Use wiki_recall at the START of every task to find relevant wiki knowledge.",
+      "The extension auto-calls wiki_recall — but calling it explicitly with specific terms gets better results.",
+    ],
+    parameters: Type.Object({
+      query: Type.String({
+        description: "Search query — use the user's full request or key terms",
+      }),
+      max_results: Type.Optional(
+        Type.Number({ description: "Max results (default: 5, max: 10)", default: 5 }),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      const root = resolveVaultRoot(process.cwd());
+      const paths = getVaultPaths(root);
+
+      if (!existsSync(join(root, ".wiki", "config.json"))) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "No wiki vault found at this location. Initialize one with wiki_bootstrap first.",
+            },
+          ],
+          details: { error: "no_vault" } as Record<string, unknown>,
+          isError: true,
+        };
+      }
+
+      const maxResults = Math.min(params.max_results ?? 5, 10);
+      const results = searchWiki(paths, params.query, maxResults);
+
+      if (results.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `No wiki pages found matching "${params.query}". Use wiki_search for broader results.`,
+            },
+          ],
+          details: { query: params.query, matches: [] } as Record<string, unknown>,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: [
+              `🧠 **${results.length} wiki page(s) relevant** to "${params.query}":`,
+              "",
+              ...results.map(
+                (r) =>
+                  `- [[${r.id}]] — *${r.type}* — ${r.title}${
+                    r.preview ? `\n  > ${r.preview.slice(0, 150)}` : ""
+                  }`,
+              ),
+              "",
+              "Use `read` on any page for full content.",
+              "Use `wiki_retro` to save new insights from this task.",
+            ].join("\n"),
+          },
+        ],
+        details: { query: params.query, matches: results.map((r) => r.id) } as Record<
+          string,
+          unknown
+        >,
+      };
+    },
+  });
+}

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -45,21 +45,48 @@ WIKI_ROOT/
 
 ## How the Extension Helps You
 
-| Task               | Before (skill-only)          | Now (extension-backed)                |
-| ------------------ | ---------------------------- | ------------------------------------- |
-| Track ingestion    | Manual `history.json`        | Automatic via `meta/registry.json`    |
-| Update INDEX       | Manual edit after every page | Auto-rebuilds on turn end             |
-| Update LOG         | Manual append                | Auto-generated from `events.jsonl`    |
-| Find orphans       | Shell `grep` scans           | Instant from `backlinks.json`         |
-| Block raw edits    | Skill says "don't"           | Extension **enforces** immutability   |
-| Create source page | 8 tool calls                 | `wiki_capture_source` + LLM synthesis |
+| Task                        | Before (skill-only)          | Now (extension-backed)                |
+| --------------------------- | ---------------------------- | ------------------------------------- |
+| Track ingestion             | Manual `history.json`        | Automatic via `meta/registry.json`    |
+| Update INDEX                | Manual edit after every page | Auto-rebuilds on turn end             |
+| Update LOG                  | Manual append                | Auto-generated from `events.jsonl`    |
+| Find orphans                | Shell `grep` scans           | Instant from `backlinks.json`         |
+| Block raw edits             | Skill says "don't"           | Extension **enforces** immutability   |
+| Create source page          | 8 tool calls                 | `wiki_capture_source` + LLM synthesis |
+| **Recall wiki knowledge**   | Never happens                | **Auto-search before every turn**     |
+| **Save task insights**      | Manual capture               | `wiki_retro` — one tool call          |
+
+## 🔄 Auto-Recall (New)
+
+**The extension now automatically searches the wiki before every user turn.**
+
+When you send a prompt, the extension:
+1. Extracts key terms from your request
+2. Searches the wiki registry for matching pages
+3. Injects matching page titles + summaries into context
+4. You see this as "Relevant Wiki Knowledge" in your system prompt
+
+**This means the wiki works as an automatic second brain.**
+You don't need to remember to search — relevant knowledge is surfaced automatically.
+
+### Manual recall for deeper searches
+
+If the auto-recall doesn't find enough context, call `wiki_recall` explicitly:
+
+```
+wiki_recall(query="specific terms...", max_results=10)
+```
+
+This gives you more control over the search terms and returns content previews.
 
 ## Available Tools
 
-Use these directly — they handle scaffolding and bookkeeping:
+Use these directly — they handle scaffolding, bookkeeping, recall, and capture:
 
 - `wiki_bootstrap` — Initialize a new vault
 - `wiki_capture_source` — Capture URL/file/text into immutable packet + skeleton page
+- `wiki_recall` — **Auto-called at turn start.** Search wiki for task-relevant pages
+- `wiki_retro` — Save an atomic insight from a completed task into the wiki
 - `wiki_ingest` — Get batch of uningested sources with extracted text
 - `wiki_ensure_page` — Create entity/concept/synthesis/analysis page from template
 - `wiki_search` — Search registry for existing pages
@@ -83,11 +110,19 @@ Use these directly — they handle scaffolding and bookkeeping:
 
 ### Query → Answer → File
 
-1. `wiki_search(query="...")` to find relevant pages
+1. **Auto-recall**: Extension surfaces relevant wiki pages automatically
 2. Read those pages
 3. Synthesize answer with `[[wikilink]]` citations
 4. If novel: create analysis page via `wiki_ensure_page(type="analysis")`
 5. Extension auto-updates metadata
+
+### Task → Capture → Retro
+
+1. Complete a meaningful task
+2. Call `wiki_retro` to save key insights
+3. The insight is captured as a source packet
+4. Extension auto-updates metadata
+5. Next time, auto-recall surfaces your saved insight
 
 ## Page Conventions
 

--- a/test/llm-wiki.test.ts
+++ b/test/llm-wiki.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildRegistry, rebuildMetadataLight } from "../extensions/llm-wiki/lib/metadata.js";
+import { formatRecallContext, searchWiki } from "../extensions/llm-wiki/lib/recall.js";
 import { captureFile, captureText, captureUrl } from "../extensions/llm-wiki/lib/source-packet.js";
 import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
 
@@ -720,5 +722,163 @@ describe("configuration", () => {
     const content = JSON.parse(readFile(join(wikiDir, ".discoveries", "gaps.json")));
     expect(content.gaps).toHaveLength(1);
     expect(content.gaps[0].priority).toBe("high");
+  });
+});
+
+// ─── Wiki Recall Tests ─────────────────────────────────
+
+describe("wiki recall", () => {
+  let wikiDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `pi-llm-wiki-recall-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    wikiDir = createWikiRoot();
+    ensureVaultStructure(getVaultPaths(wikiDir));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function createRegistryPage(
+    id: string,
+    type: string,
+    title: string,
+    content: string,
+    extra: Record<string, unknown> = {},
+  ) {
+    const folder = id.includes("/") ? id.split("/")[0] : "concepts";
+    const name = id.includes("/") ? id.split("/").pop()! : id;
+    const pagePath = join(wikiDir, "wiki", folder, `${name}.md`);
+    const relId = `${folder}/${name}`;
+
+    writeFileSync(
+      pagePath,
+      `---\ntype: ${type}\ntitle: "${title}"\ncreated: 2026-05-11\nupdated: 2026-05-11\nsources: []\n${Object.entries(
+        extra,
+      )
+        .map(([k, v]) => `${k}: ${v}`)
+        .join("\n")}\n---\n\n${content}`,
+      "utf-8",
+    );
+
+    return relId;
+  }
+
+  it("should return empty results when wiki has no pages", () => {
+    const paths = getVaultPaths(wikiDir);
+    const results = searchWiki(paths, "machine learning");
+    expect(results).toEqual([]);
+  });
+
+  it("should find pages matching by title", () => {
+    createRegistryPage(
+      "reinforcement-learning",
+      "concept",
+      "Reinforcement Learning",
+      "RL is a type of machine learning.",
+    );
+    const paths = getVaultPaths(wikiDir);
+    rebuildMetadataLight(paths);
+
+    const results = searchWiki(paths, "reinforcement learning");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].title).toContain("Reinforcement Learning");
+    expect(results[0].id).toContain("reinforcement-learning");
+    expect(results[0].type).toBe("concept");
+  });
+
+  it("should find pages matching by page ID", () => {
+    createRegistryPage(
+      "transformer-architecture",
+      "concept",
+      "Transformer",
+      "The Transformer model architecture.",
+    );
+    const paths = getVaultPaths(wikiDir);
+    rebuildMetadataLight(paths);
+
+    const results = searchWiki(paths, "transformer-architecture");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].id).toContain("transformer-architecture");
+  });
+
+  it("should find pages matching by type", () => {
+    createRegistryPage("gpt-4", "entity", "GPT-4", "OpenAI language model.", {
+      category: "tool",
+    });
+    createRegistryPage("rag", "concept", "RAG", "Retrieval augmented generation.");
+    const paths = getVaultPaths(wikiDir);
+    rebuildMetadataLight(paths);
+
+    const results = searchWiki(paths, "entity");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.type === "entity")).toBe(true);
+  });
+
+  it("should return pages with content preview", () => {
+    createRegistryPage(
+      "attention-is-all-you-need",
+      "source",
+      "Attention Is All You Need",
+      "This paper introduced the Transformer architecture.",
+    );
+    const paths = getVaultPaths(wikiDir);
+    rebuildMetadataLight(paths);
+
+    const results = searchWiki(paths, "attention");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    // Preview should contain content (the body after frontmatter)
+    expect(results[0].preview).toBeTruthy();
+    expect(results[0].preview).toContain("Transformer");
+  });
+
+  it("should respect maxResults parameter", () => {
+    for (let i = 1; i <= 5; i++) {
+      createRegistryPage(
+        `concept-${i}`,
+        "concept",
+        `Concept ${i}`,
+        `This is concept ${i} about stuff.`,
+      );
+    }
+    const paths = getVaultPaths(wikiDir);
+    rebuildMetadataLight(paths);
+
+    const results = searchWiki(paths, "concept", 3);
+    expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  it("should format recall results as system context", () => {
+    const results = [
+      {
+        id: "concepts/rag",
+        title: "RAG",
+        type: "concept",
+        preview: "Retrieval augmented generation is a technique.",
+        path: "/tmp/wiki/concepts/rag.md",
+      },
+      {
+        id: "entities/openai",
+        title: "OpenAI",
+        type: "entity",
+        preview: "OpenAI is an AI research organization.",
+        path: "/tmp/wiki/entities/openai.md",
+      },
+    ];
+
+    const context = formatRecallContext(results);
+    expect(context).toContain("Relevant Wiki Knowledge");
+    expect(context).toContain("[[concepts/rag]]");
+    expect(context).toContain("[[entities/openai]]");
+    expect(context).toContain("RAG");
+    expect(context).toContain("OpenAI");
+    expect(context).toContain("2 page(s)");
+    expect(context).toContain("wiki_ensure_page or wiki_retro");
+  });
+
+  it("should return empty string for empty results", () => {
+    expect(formatRecallContext([])).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

The wiki was passive — the model had to remember to call `wiki_search` to find relevant knowledge. This PR adds **automatic recall** at session start.

### Changes

**New file: `extensions/llm-wiki/lib/recall.ts`**
- `searchWiki(paths, query, maxResults?)` — searches registry for pages matching query terms
- Scoring: ID match (3pts), title match (4pts), type match (1pt), tag/category match (2pts)
- `formatRecallContext(results)` — formats matches as a compact system-prompt section
- `registerWikiRecall(pi)` — registers the `wiki_recall` tool (11th tool)

**Modified: `extensions/llm-wiki/index.ts`**
- Registers `wiki_recall` tool alongside existing 10
- Adds `before_agent_start` hook that auto-searches wiki with user prompt
- Injects matching pages as "## Relevant Wiki Knowledge" into system prompt
- Hook is a no-op when no wiki vault exists at the cwd

**Modified: `skills/llm-wiki/SKILL.md`**
- Added "🔄 Auto-Recall (New)" section explaining the mechanism
- Updated tool list with `wiki_recall` and `wiki_retro`
- Added "Task → Capture → Retro" workflow

**Tests: 38 → 46 (8 new)**
- Empty wiki returns no results
- Title matching, ID matching, type matching
- Content preview returned correctly
- maxResults limit respected
- formatRecallContext formatting
- Empty results return empty string

### Validation
- `npm run typecheck` ✅
- `npm run lint` ✅  
- `npm test` — 46 tests pass ✅

Closes #16