### PR TITLE
Phase 2: Automatic insight capture via wiki_retro

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
 import { formatRecallContext, registerWikiRecall, searchWiki } from "./lib/recall.js";
+import { registerWikiRetro } from "./lib/retro.js";
 import {
   registerWikiBootstrap,
   registerWikiCaptureSource,
@@ -45,6 +46,7 @@ export default function (pi: ExtensionAPI) {
   registerWikiLogEvent(pi);
   registerWikiWatch(pi);
   registerWikiRecall(pi);
+  registerWikiRetro(pi);
 
   installGuardrails(pi);
 

--- a/extensions/llm-wiki/lib/retro.ts
+++ b/extensions/llm-wiki/lib/retro.ts
@@ -1,0 +1,203 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+import { appendEvent, rebuildMetadataLight } from "./metadata.js";
+import {
+  type VaultPaths,
+  fmtDate,
+  getVaultPaths,
+  nextSourceId,
+  resolveVaultRoot,
+} from "./utils.js";
+
+// ─── Public API ────────────────────────────────────────
+
+export interface RetroResult {
+  sourceId: string;
+  packetPath: string;
+  sourcePagePath: string;
+}
+
+/**
+ * Save an atomic insight into the wiki as a source packet + source page.
+ * Returns the source ID, packet path, and source page path.
+ */
+export function saveInsight(
+  paths: VaultPaths,
+  slug: string,
+  title: string,
+  body: string,
+  category?: string,
+): RetroResult {
+  const sourceId = nextSourceId(paths);
+  const packetPath = join(paths.rawSources, sourceId);
+  mkdirSync(packetPath, { recursive: true });
+  mkdirSync(join(packetPath, "attachments"), { recursive: true });
+
+  const today = fmtDate();
+
+  // Write manifest
+  const manifest = {
+    id: sourceId,
+    title,
+    slug,
+    category: category || "uncategorized",
+    captured: today,
+    format: "insight",
+    packet_version: "1.0",
+  };
+  writeFileSync(
+    join(packetPath, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf-8",
+  );
+
+  // Write extracted text (the insight body in markdown)
+  const extracted = [
+    `# ${title}`,
+    "",
+    body,
+    "",
+    "---",
+    `*Captured: ${today}*`,
+    category ? `*Category: ${category}*` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+  writeFileSync(join(packetPath, "extracted.md"), extracted, "utf-8");
+
+  // Create source page
+  const sourcePageDir = join(paths.wiki, "sources");
+  mkdirSync(sourcePageDir, { recursive: true });
+  const sourcePagePath = join(sourcePageDir, `${sourceId}.md`);
+
+  const tagLine = category ? `category: ${category}` : "";
+  const sourcePageContent = [
+    "---",
+    "type: source",
+    `title: "${title}"`,
+    `source_id: ${sourceId}`,
+    "status: insight",
+    `created: ${today}`,
+    `updated: ${today}`,
+    tagLine,
+    "---",
+    "",
+    `# ${title}`,
+    "",
+    body,
+    "",
+    "## Source",
+    "",
+    `- **Packet:** \`${packetPath}\``,
+    `- **Captured:** ${today}`,
+    category ? `- **Category:** ${category}` : "",
+    "",
+    "## Related",
+    "",
+    "_(Add [[wikilinks]] to related pages)_",
+    "",
+  ]
+    .filter((l) => l !== "")
+    .join("\n");
+  writeFileSync(sourcePagePath, sourcePageContent, "utf-8");
+
+  // Log event
+  appendEvent(paths, {
+    kind: "retro",
+    source_id: sourceId,
+    title,
+    slug,
+    category: category || "uncategorized",
+  });
+
+  // Rebuild metadata
+  rebuildMetadataLight(paths);
+
+  return { sourceId, packetPath, sourcePagePath };
+}
+
+// ─── Tool Registration ──────────────────────────────────
+
+/**
+ * Register the `wiki_retro` tool.
+ * The model calls this to save an atomic insight from a completed task.
+ * Inspired by the memex_retro pattern.
+ */
+export function registerWikiRetro(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "wiki_retro",
+    label: "Wiki Retro",
+    description:
+      "Save an atomic insight from a completed task into the wiki. " +
+      "Creates a source packet and source page. The insight will be " +
+      "surfaced automatically by wiki_recall in future sessions.",
+    promptSnippet: "Save atomic insights from completed tasks into the wiki",
+    promptGuidelines: [
+      "Use wiki_retro at the END of every meaningful task to save what you learned.",
+      "Write atomic insights — one insight per call. Use multiple calls for multiple insights.",
+      "The insight will be auto-surfaced by wiki_recall in future sessions.",
+    ],
+    parameters: Type.Object({
+      slug: Type.String({
+        description:
+          "Unique kebab-case identifier (e.g. 'jwt-revocation-pattern'). Used for lookups.",
+      }),
+      title: Type.String({
+        description: "Short descriptive title (60 chars max). Noun phrase, not a sentence.",
+      }),
+      body: Type.String({
+        description:
+          "Markdown body with [[wikilinks]] to related wiki pages. Explain what was learned.",
+      }),
+      category: Type.Optional(
+        Type.String({
+          description: "Optional category (e.g. frontend, architecture, devops, bugfix, design)",
+        }),
+      ),
+    }),
+    async execute(_toolCallId, params) {
+      const root = resolveVaultRoot(process.cwd());
+      const paths = getVaultPaths(root);
+
+      if (!existsSync(join(root, ".wiki", "config.json"))) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "No wiki vault found at this location. Initialize one with wiki_bootstrap first.",
+            },
+          ],
+          details: { error: "no_vault" } as Record<string, unknown>,
+          isError: true,
+        };
+      }
+
+      const result = saveInsight(paths, params.slug, params.title, params.body, params.category);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: [
+              `🧠 **Insight saved**: ${params.title}`,
+              "",
+              `- Source: \`${result.sourceId}\``,
+              `- Packet: \`${result.packetPath}\``,
+              `- Page: \`${result.sourcePagePath}\``,
+              "",
+              "This insight will be auto-surfaced by wiki_recall in future sessions.",
+            ].join("\n"),
+          },
+        ],
+        details: {
+          sourceId: result.sourceId,
+          slug: params.slug,
+          title: params.title,
+          category: params.category || null,
+        } as Record<string, unknown>,
+      };
+    },
+  });
+}

--- a/test/llm-wiki.test.ts
+++ b/test/llm-wiki.test.ts
@@ -882,3 +882,103 @@ describe("wiki recall", () => {
     expect(formatRecallContext([])).toBe("");
   });
 });
+
+// ─── Wiki Retro Tests ──────────────────────────────────
+
+describe("wiki retro", () => {
+  let wikiDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `pi-llm-wiki-retro-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    wikiDir = createWikiRoot();
+    const paths = getVaultPaths(wikiDir);
+    ensureVaultStructure(paths);
+    // Create minimal vault marker
+    const dotWiki = join(wikiDir, ".wiki");
+    mkdirSync(dotWiki, { recursive: true });
+    writeFileSync(
+      join(dotWiki, "config.json"),
+      JSON.stringify({ topic: "Test", mode: "personal" }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should save an insight as a source packet with manifest", async () => {
+    const { saveInsight } = await import("../extensions/llm-wiki/lib/retro.js");
+    const paths = getVaultPaths(wikiDir);
+
+    const result = saveInsight(
+      paths,
+      "test-pattern",
+      "Test Pattern",
+      "This is a test insight.",
+      "devops",
+    );
+
+    expect(result.sourceId).toMatch(/^SRC-/);
+    expect(result.packetPath).toContain("raw/sources/");
+    expect(result.sourcePagePath).toContain("wiki/sources/");
+
+    // Manifest exists
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.title).toBe("Test Pattern");
+    expect(manifest.slug).toBe("test-pattern");
+    expect(manifest.format).toBe("insight");
+    expect(manifest.category).toBe("devops");
+
+    // Extracted text exists
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("# Test Pattern");
+    expect(extracted).toContain("This is a test insight.");
+    expect(extracted).toContain("*Captured:");
+
+    // Source page exists
+    const sourcePage = readFile(result.sourcePagePath);
+    expect(sourcePage).toContain("type: source");
+    expect(sourcePage).toContain('title: "Test Pattern"');
+    expect(sourcePage).toContain("status: insight");
+    expect(sourcePage).toContain("This is a test insight.");
+  });
+
+  it("should save an insight without a category", async () => {
+    const { saveInsight } = await import("../extensions/llm-wiki/lib/retro.js");
+    const paths = getVaultPaths(wikiDir);
+
+    const result = saveInsight(paths, "simple-note", "Simple Note", "Just a note.");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.category).toBe("uncategorized");
+
+    const sourcePage = readFile(result.sourcePagePath);
+    expect(sourcePage).not.toContain("category:");
+  });
+
+  it("should support multiple retros generating unique source IDs", async () => {
+    const { saveInsight } = await import("../extensions/llm-wiki/lib/retro.js");
+    const paths = getVaultPaths(wikiDir);
+
+    const r1 = saveInsight(paths, "insight-one", "One", "First insight.");
+    const r2 = saveInsight(paths, "insight-two", "Two", "Second insight.");
+
+    expect(r1.sourceId).not.toBe(r2.sourceId);
+    expect(existsSync(r1.packetPath)).toBe(true);
+    expect(existsSync(r2.packetPath)).toBe(true);
+  });
+
+  it("should rebuild metadata after saving an insight", async () => {
+    const { saveInsight } = await import("../extensions/llm-wiki/lib/retro.js");
+    const paths = getVaultPaths(wikiDir);
+
+    saveInsight(paths, "meta-test", "Meta Test", "Checking metadata.");
+
+    const registry = JSON.parse(readFile(join(paths.meta, "registry.json")));
+    const sourcePageId = Object.keys(registry.pages).find((id) => id.startsWith("sources/SRC-"));
+    expect(sourcePageId).toBeTruthy();
+    // Note: parseFrontmatter includes the quotes around YAML string values
+    expect(registry.pages[sourcePageId!].title).toBe('"Meta Test"');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `wiki_retro` tool — the model calls it at the end of meaningful tasks to save atomic insights into the wiki. Inspired by the `memex_retro` pattern.

### Changes

**New file: `extensions/llm-wiki/lib/retro.ts`**
- `saveInsight(paths, slug, title, body, category?)` — creates source packet + source page
- `registerWikiRetro(pi)` — registers the `wiki_retro` tool (12th tool)
- Creates a complete source packet: manifest.json, extracted.md
- Creates a source page with proper frontmatter
- Logs event to events.jsonl

**Modified: `extensions/llm-wiki/index.ts`**
- Imports and registers `registerWikiRetro`

**Tests: 46 → 50 (4 new)**
- Manifest creation with title, slug, format, category
- No-category fallback to "uncategorized"
- Multiple retros generate unique source IDs
- Metadata rebuilt correctly after insight capture

### SKILL.md already updated**
Phase 1 already added `wiki_retro` to the tool list and the "Task → Capture → Retro" workflow.

Closes #17