### PR TITLE
Restructure wiki vault under .llm-wiki/ directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ Instructions for AI agents working on this codebase.
 - Use `node:fs/promises` for async file I/O, not sync
 - Prefer small, pure functions in `lib/`
 - Extension tools must have: name, label, description, promptSnippet, promptGuidelines, parameters (TypeBox), execute
-- Guardrails block `raw/**` and `meta/**` edits at the tool_call hook level
-- Metadata auto-rebuilds on `turn_end` after `wiki/**` edits
+- Guardrails block `.llm-wiki/raw/**` and `.llm-wiki/meta/**` edits at the tool_call hook level
+- Metadata auto-rebuilds on `turn_end` after `.llm-wiki/wiki/**` edits
 - Source IDs: `SRC-YYYY-MM-DD-NNN`
 - Page filenames: `kebab-case.md`
 - Wikilinks: folder-qualified, e.g. `[[concepts/retrieval-augmented-generation]]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-13
+
+### Added
+- **Wiki vault restructured under `.llm-wiki/`** (Issue #22, PR #23 by @arjun-zosma): All wiki content now lives in a single `.llm-wiki/` subdirectory — cleaner repo isolation, easier gitignore, zero directory name collisions.
+- **Backward compatibility**: Old vaults (`.wiki/config.json` sentinel) are auto-detected and continue to work. New vaults use `.llm-wiki/config.json`.
+- **`detectVaultFormat()`** utility: Returns `"new"`, `"legacy"`, or `"none"` for any directory.
+- **`resolveVaultPaths()`** utility: Auto-detects vault format and returns correct paths.
+- **`getLegacyVaultPaths()`** utility: Returns old-style paths for migration support.
+- **Migration script** (`scripts/migrate-llm-wiki.js`): One-time tool to move old vaults to new layout. Supports `--dry-run` and `--force` flags.
+- **5 new backward-compatibility tests**: Verify new format detection, legacy format detection, auto-resolution, and no-vault handling.
+
+### Changed
+- `resolveVaultRoot()` now checks for `.llm-wiki/config.json` first, then falls back to `.wiki/config.json`.
+- `getVaultPaths()` returns paths under `.llm-wiki/`:
+  - `raw/` → `.llm-wiki/raw/`, `wiki/` → `.llm-wiki/wiki/`, `meta/` → `.llm-wiki/meta/`
+  - `.wiki/` → `.llm-wiki/` (config directly in the dot-dir)
+  - `outputs/` → `.llm-wiki/outputs/`, `.discoveries/` → `.llm-wiki/.discoveries/`
+- `isProtectedPath()` now takes `VaultPaths` instead of `root` string.
+- `wiki_bootstrap` creates new `.llm-wiki/` layout by default.
+- MCP server updated with own copy of path detection logic.
+- All templates, prompts, documentation, and tests updated to reflect new layout.
+
+### Migration
+- Run `node scripts/migrate-llm-wiki.js` in your wiki root to migrate from the old layout.
+- Old `.wiki/` directory is preserved as a forwarding marker (`.wiki/MIGRATED_TO_LLM_WIKI.md`).
+- No data loss — all content is moved, nothing deleted.
+
 ## [0.6.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,11 +109,13 @@ Initialize an llm wiki here for AI research.
 This calls `wiki_bootstrap` and creates:
 
 ```
-raw/
-wiki/
-meta/
-.wiki/
-WIKI_SCHEMA.md
+.llm-wiki/
+├── config.json
+├── templates/
+├── raw/
+├── wiki/
+├── meta/
+└── WIKI_SCHEMA.md
 ```
 
 ### 2) Capture a source
@@ -133,7 +135,7 @@ Capture these notes into the wiki: ...pasted text...
 ### 3) Integrate the source
 
 1. Capture the source
-2. Read `wiki/sources/SRC-*.md`
+2. Read `.llm-wiki/wiki/sources/SRC-*.md`
 3. Update that source page
 4. Search for impacted canonical pages with `wiki_search`
 5. Create missing pages with `wiki_ensure_page`
@@ -158,45 +160,47 @@ Answer the question and file the result as an analysis page.
 
 ```
 my-wiki/
-├─ raw/
-│  └─ sources/
-│     └─ SRC-2026-05-11-001/
-│        ├─ manifest.json
-│        ├─ original/           # Original artifact
-│        ├─ extracted.md        # Normalized text
-│        └─ attachments/
-├─ wiki/
-│  ├─ sources/                  # Source pages (what each source says)
-│  ├─ concepts/                 # Concepts and recurring ideas
-│  ├─ entities/                 # People, orgs, products, papers, systems
-│  ├─ syntheses/                # Cross-source theses and tensions
-│  └─ analyses/                 # Durable filed answers from queries
-├─ meta/
-│  ├─ registry.json             # Auto-generated search index
-│  ├─ backlinks.json
-│  ├─ index.md
-│  ├─ events.jsonl              # Append-only event log
-│  ├─ log.md
-│  └─ lint-report.md
-├─ .wiki/
-│  ├─ config.json
-│  └─ templates/
-└─ WIKI_SCHEMA.md
+└─ .llm-wiki/
+   ├─ config.json               # Vault config
+   ├─ templates/                 # Page templates
+   ├─ raw/
+   │  └─ sources/
+   │     └─ SRC-2026-05-11-001/
+   │        ├─ manifest.json
+   │        ├─ original/           # Original artifact
+   │        ├─ extracted.md        # Normalized text
+   │        └─ attachments/
+   ├─ wiki/
+   │  ├─ sources/                  # Source pages (what each source says)
+   │  ├─ concepts/                 # Concepts and recurring ideas
+   │  ├─ entities/                 # People, orgs, products, papers, systems
+   │  ├─ syntheses/                # Cross-source theses and tensions
+   │  └─ analyses/                 # Durable filed answers from queries
+   ├─ meta/
+   │  ├─ registry.json             # Auto-generated search index
+   │  ├─ backlinks.json
+   │  ├─ index.md
+   │  ├─ events.jsonl              # Append-only event log
+   │  ├─ log.md
+   │  └─ lint-report.md
+   └─ WIKI_SCHEMA.md               # Operating manual
 ```
 
 ### Ownership Model
 
 | Path | Owner | Rule |
 |------|-------|------|
-| `raw/**` | Extension tools | Immutable after capture |
-| `wiki/**` | Model + user | Editable knowledge pages |
-| `meta/registry.json` | Extension | Generated |
-| `meta/backlinks.json` | Extension | Generated |
-| `meta/index.md` | Extension | Generated |
-| `meta/events.jsonl` | Extension / tool | Append-only |
-| `meta/log.md` | Extension | Generated from events |
-| `meta/lint-report.md` | Extension | Generated |
-| `WIKI_SCHEMA.md` | Human + explicit request | Operating manual |
+| Path | Owner | Rule |
+|------|-------|------|
+| `.llm-wiki/raw/**` | Extension tools | Immutable after capture |
+| `.llm-wiki/wiki/**` | Model + user | Editable knowledge pages |
+| `.llm-wiki/meta/registry.json` | Extension | Generated |
+| `.llm-wiki/meta/backlinks.json` | Extension | Generated |
+| `.llm-wiki/meta/index.md` | Extension | Generated |
+| `.llm-wiki/meta/events.jsonl` | Extension / tool | Append-only |
+| `.llm-wiki/meta/log.md` | Extension | Generated from events |
+| `.llm-wiki/meta/lint-report.md` | Extension | Generated |
+| `.llm-wiki/WIKI_SCHEMA.md` | Human + explicit request | Operating manual |
 
 ---
 
@@ -224,15 +228,15 @@ Stable source-page IDs keep provenance stable even if titles change.
 
 The extension **blocks** direct tool-call edits to:
 
-- `raw/**` — immutable source artifacts
-- `meta/registry.json`
-- `meta/backlinks.json`
-- `meta/events.jsonl`
-- `meta/index.md`
-- `meta/log.md`
-- `meta/lint-report.md`
+- `.llm-wiki/raw/**` — immutable source artifacts
+- `.llm-wiki/meta/registry.json`
+- `.llm-wiki/meta/backlinks.json`
+- `.llm-wiki/meta/events.jsonl`
+- `.llm-wiki/meta/index.md`
+- `.llm-wiki/meta/log.md`
+- `.llm-wiki/meta/lint-report.md`
 
-If the model directly edits `wiki/**` using Pi's built-in `write` or `edit` tools, the extension **automatically rebuilds** generated metadata at the end of the agent turn.
+If the model directly edits `.llm-wiki/wiki/**` using Pi's built-in `write` or `edit` tools, the extension **automatically rebuilds** generated metadata at the end of the agent turn.
 
 ---
 
@@ -241,7 +245,7 @@ If the model directly edits `wiki/**` using Pi's built-in `write` or `edit` tool
 Each captured source is stored as a structured packet:
 
 ```
-raw/sources/SRC-YYYY-MM-DD-NNN/
+.llm-wiki/raw/sources/SRC-YYYY-MM-DD-NNN/
 ├─ manifest.json     # Capture metadata (title, URL, format, timestamp)
 ├─ original/         # Original artifact (preserved as-is)
 ├─ extracted.md      # Normalized text (PDF→md, XML→md, JSON→md, etc.)
@@ -299,10 +303,10 @@ The bundled `llm-wiki` skill teaches the model to:
 Four layers with clear ownership:
 
 ```
-raw/sources/SRC-*/     # Immutable source packets (extension-owned)
-wiki/                   # Editable knowledge pages (you + LLM)
-meta/                   # Auto-generated registry, backlinks, index, log
-.wiki/                  # Config and templates
+.llm-wiki/raw/sources/SRC-*/     # Immutable source packets (extension-owned)
+.llm-wiki/wiki/                   # Editable knowledge pages (you + LLM)
+.llm-wiki/meta/                   # Auto-generated registry, backlinks, index, log
+.llm-wiki/                        # Config and templates
 ```
 
 Read [docs/architecture.md](docs/architecture.md) for the full design document.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,43 +4,47 @@
 
 ```
 WIKI_ROOT/
-├── raw/sources/SRC-*/       # Immutable source packets (extension-owned)
-│   ├── manifest.json         # Capture metadata
-│   ├── original/             # Original artifact
-│   ├── extracted.md          # Normalized markdown
-│   └── attachments/          # Downloaded images, PDFs
-├── wiki/                     # Editable knowledge pages (you + LLM)
-│   ├── sources/              # One summary per source
-│   ├── entities/             # People, orgs, tools, products
-│   ├── concepts/             # Ideas, patterns, frameworks
-│   ├── syntheses/            # Cross-cutting analyses
-│   └── analyses/             # Durable query answers
-├── meta/                     # Auto-generated (extension-owned)
-│   ├── registry.json         # Master page catalog
-│   ├── backlinks.json        # Inbound link map
-│   ├── index.md              # Human-readable catalog
-│   ├── log.md                # Activity log
-│   └── events.jsonl          # Structured event stream
-└── .wiki/                    # Config and templates
-    ├── config.json
-    └── templates/
+└── .llm-wiki/                 # All wiki content under one dot-dir
+    ├── config.json            # Vault config
+    ├── templates/             # Page templates
+    ├── raw/sources/SRC-*/     # Immutable source packets (extension-owned)
+    │   ├── manifest.json      # Capture metadata
+    │   ├── original/          # Original artifact
+    │   ├── extracted.md       # Normalized markdown
+    │   └── attachments/       # Downloaded images, PDFs
+    ├── wiki/                  # Editable knowledge pages (you + LLM)
+    │   ├── sources/           # One summary per source
+    │   ├── entities/          # People, orgs, tools, products
+    │   ├── concepts/          # Ideas, patterns, frameworks
+    │   ├── syntheses/         # Cross-cutting analyses
+    │   └── analyses/          # Durable query answers
+    ├── meta/                  # Auto-generated (extension-owned)
+    │   ├── registry.json      # Master page catalog
+    │   ├── backlinks.json     # Inbound link map
+    │   ├── index.md           # Human-readable catalog
+    │   ├── log.md             # Activity log
+    │   └── events.jsonl       # Structured event stream
+    ├── outputs/               # Generated artifacts
+    └── .discoveries/          # Discovery tracking
 ```
 
 ## Ownership Rules
 
 | Path      | Owner                    | Rule                     |
 | --------- | ------------------------ | ------------------------ |
-| `raw/**`  | Extension                | Immutable after capture  |
-| `wiki/**` | Model + user             | Editable knowledge pages |
-| `meta/*`  | Extension                | Auto-generated           |
-| `.wiki/*` | Human + explicit request | Operating rules          |
+| Path                  | Owner                    | Rule                     |
+| --------------------- | ------------------------ | ------------------------ |
+| `.llm-wiki/raw/**`    | Extension                | Immutable after capture  |
+| `.llm-wiki/wiki/**`   | Model + user             | Editable knowledge pages |
+| `.llm-wiki/meta/**`   | Extension                | Auto-generated           |
+| `.llm-wiki/` | Human + explicit request | Operating rules          |
 
 ## Source Packet Format
 
 Each captured source becomes a packet:
 
 ```
-raw/sources/SRC-YYYY-MM-DD-NNN/
+.llm-wiki/raw/sources/SRC-YYYY-MM-DD-NNN/
   manifest.json
   original/
   extracted.md
@@ -62,4 +66,4 @@ raw/sources/SRC-YYYY-MM-DD-NNN/
 
 ## Guardrails
 
-The extension blocks direct edits to `raw/**` and `meta/**`. Metadata rebuilds automatically after `wiki/**` edits.
+The extension blocks direct edits to `.llm-wiki/raw/**` and `.llm-wiki/meta/**`. Metadata rebuilds automatically after `.llm-wiki/wiki/**` edits.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,7 +36,7 @@ The extension registers 10 tools the LLM can call directly:
 
 1. `wiki_capture_source(url="...")` — creates packet + skeleton
 2. `wiki_ingest()` — get batch of sources needing synthesis
-3. Read `raw/sources/SRC-*/extracted.md`
+3. Read `.llm-wiki/raw/sources/SRC-*/extracted.md`
 4. Update skeleton source page with summary, entities, concepts
 5. `wiki_ensure_page(type="entity", title="...")` for each entity
 6. Add `[[wikilinks]]` between related pages

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Wiki configuration lives in `.wiki/config.json`.
+Wiki configuration lives in `.llm-wiki/config.json`.
 
 ## Modes
 

--- a/docs/obsidian.md
+++ b/docs/obsidian.md
@@ -2,9 +2,9 @@
 
 ## Setup
 
-1. Open `wiki/` as an Obsidian vault
-2. The extension generates `meta/index.md` as a browsable catalog
-3. `meta/backlinks.json` is available for graph plugins
+1. Open `.llm-wiki/wiki/` as an Obsidian vault
+2. The extension generates `.llm-wiki/meta/index.md` as a browsable catalog
+3. `.llm-wiki/meta/backlinks.json` is available for graph plugins
 
 ## Recommended Plugins
 
@@ -14,8 +14,8 @@
 
 ## Web Clipper
 
-Use [Obsidian Web Clipper](https://obsidian.md/clipper) to save articles directly into `raw/articles/`.
+Use [Obsidian Web Clipper](https://obsidian.md/clipper) to save articles directly into `.llm-wiki/raw/articles/`.
 
 ## Dataview Dashboard
 
-The extension creates `meta/index.md` with page listings. For custom dashboards, use Dataview queries against frontmatter fields like `type`, `domain`, `category`, `sources`.
+The extension creates `.llm-wiki/meta/index.md` with page listings. For custom dashboards, use Dataview queries against frontmatter fields like `type`, `domain`, `category`, `sources`.

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -16,7 +16,7 @@ import {
   registerWikiStatus,
   registerWikiWatch,
 } from "./lib/tools.js";
-import { getVaultPaths, resolveVaultRoot } from "./lib/utils.js";
+import { resolveVaultPaths } from "./lib/utils.js";
 
 /**
  * @zosmaai/pi-llm-wiki — LLM Wiki extension for Pi
@@ -58,12 +58,11 @@ export default function (pi: ExtensionAPI) {
   // Before each agent turn, search the wiki for pages relevant
   // to the user's prompt and inject them as system context.
   pi.on("before_agent_start", async (event, _ctx) => {
-    const root = resolveVaultRoot(process.cwd());
-    if (!existsSync(join(root, ".wiki", "config.json"))) {
+    const paths = resolveVaultPaths(process.cwd());
+    if (!existsSync(join(paths.dotWiki, "config.json"))) {
       return; // No wiki vault — nothing to recall
     }
 
-    const paths = getVaultPaths(root);
     const prompt = event.prompt || "";
     if (!prompt.trim()) return;
 

--- a/extensions/llm-wiki/lib/guardrails.ts
+++ b/extensions/llm-wiki/lib/guardrails.ts
@@ -1,7 +1,7 @@
 import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { rebuildMetadataLight } from "./metadata.js";
-import { isProtectedPath, resolveVaultRoot } from "./utils.js";
+import { isProtectedPath, resolveVaultPaths } from "./utils.js";
 
 /**
  * Guardrails and auto-rebuild hooks for the LLM Wiki extension.
@@ -15,8 +15,8 @@ export function installGuardrails(pi: ExtensionAPI): void {
   pi.on("tool_call", async (event) => {
     if (isToolCallEventType("write", event)) {
       const path = event.input.path as string;
-      const root = resolveVaultRoot(process.cwd());
-      const check = isProtectedPath(path, root);
+      const paths = resolveVaultPaths(process.cwd());
+      const check = isProtectedPath(path, paths);
       if (check.protected) {
         return { block: true, reason: check.reason };
       }
@@ -24,8 +24,8 @@ export function installGuardrails(pi: ExtensionAPI): void {
 
     if (isToolCallEventType("edit", event)) {
       const path = event.input.path as string;
-      const root = resolveVaultRoot(process.cwd());
-      const check = isProtectedPath(path, root);
+      const paths = resolveVaultPaths(process.cwd());
+      const check = isProtectedPath(path, paths);
       if (check.protected) {
         return { block: true, reason: check.reason };
       }
@@ -36,8 +36,8 @@ export function installGuardrails(pi: ExtensionAPI): void {
   pi.on("tool_result", async (event) => {
     if (event.toolName === "write" || event.toolName === "edit") {
       const path = event.input.path as string;
-      const root = resolveVaultRoot(process.cwd());
-      const wikiPath = `${root}/wiki/`;
+      const paths = resolveVaultPaths(process.cwd());
+      const wikiPath = `${paths.wiki}/`;
       if (path?.startsWith(wikiPath)) {
         pendingRebuild = true;
       }
@@ -49,17 +49,7 @@ export function installGuardrails(pi: ExtensionAPI): void {
     if (pendingRebuild) {
       pendingRebuild = false;
       try {
-        const root = resolveVaultRoot(process.cwd());
-        const paths = {
-          root,
-          raw: `${root}/raw`,
-          rawSources: `${root}/raw/sources`,
-          wiki: `${root}/wiki`,
-          meta: `${root}/meta`,
-          dotWiki: `${root}/.wiki`,
-          outputs: `${root}/outputs`,
-          discoveries: `${root}/.discoveries`,
-        };
+        const paths = resolveVaultPaths(process.cwd());
         rebuildMetadataLight(paths);
       } catch {
         // Silently fail — metadata rebuild is best-effort

--- a/extensions/llm-wiki/lib/recall.ts
+++ b/extensions/llm-wiki/lib/recall.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import type { Registry } from "./metadata.js";
-import { type VaultPaths, getVaultPaths, readJson, readText, resolveVaultRoot } from "./utils.js";
+import { type VaultPaths, readJson, readText, resolveVaultPaths } from "./utils.js";
 
 // ─── Public API ────────────────────────────────────────
 
@@ -148,10 +148,9 @@ export function registerWikiRecall(pi: ExtensionAPI): void {
       ),
     }),
     async execute(_toolCallId, params) {
-      const root = resolveVaultRoot(process.cwd());
-      const paths = getVaultPaths(root);
+      const paths = resolveVaultPaths(process.cwd());
 
-      if (!existsSync(join(root, ".wiki", "config.json"))) {
+      if (!existsSync(join(paths.dotWiki, "config.json"))) {
         return {
           content: [
             {

--- a/extensions/llm-wiki/lib/recall.ts
+++ b/extensions/llm-wiki/lib/recall.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import type { Registry } from "./metadata.js";
-import { type VaultPaths, readJson, readText, resolveVaultPaths } from "./utils.js";
+import { type VaultPaths, readJson, resolveVaultPaths } from "./utils.js";
 
 // ─── Public API ────────────────────────────────────────
 

--- a/extensions/llm-wiki/lib/retro.ts
+++ b/extensions/llm-wiki/lib/retro.ts
@@ -3,12 +3,7 @@ import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import { appendEvent, rebuildMetadataLight } from "./metadata.js";
-import {
-  type VaultPaths,
-  fmtDate,
-  nextSourceId,
-  resolveVaultPaths,
-} from "./utils.js";
+import { type VaultPaths, fmtDate, nextSourceId, resolveVaultPaths } from "./utils.js";
 
 // ─── Public API ────────────────────────────────────────
 

--- a/extensions/llm-wiki/lib/retro.ts
+++ b/extensions/llm-wiki/lib/retro.ts
@@ -6,9 +6,8 @@ import { appendEvent, rebuildMetadataLight } from "./metadata.js";
 import {
   type VaultPaths,
   fmtDate,
-  getVaultPaths,
   nextSourceId,
-  resolveVaultRoot,
+  resolveVaultPaths,
 } from "./utils.js";
 
 // ─── Public API ────────────────────────────────────────
@@ -158,10 +157,9 @@ export function registerWikiRetro(pi: ExtensionAPI): void {
       ),
     }),
     async execute(_toolCallId, params) {
-      const root = resolveVaultRoot(process.cwd());
-      const paths = getVaultPaths(root);
+      const paths = resolveVaultPaths(process.cwd());
 
-      if (!existsSync(join(root, ".wiki", "config.json"))) {
+      if (!existsSync(join(paths.dotWiki, "config.json"))) {
         return {
           content: [
             {

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -13,13 +13,14 @@ import {
 import { captureFile, captureText, captureUrl } from "./source-packet.js";
 import {
   type VaultPaths,
+  detectVaultFormat,
   ensureVaultStructure,
   extractWikilinks,
   findWikiPages,
   fmtDate,
   getVaultPaths,
   readJson,
-  resolveVaultRoot,
+  resolveVaultPaths,
   writeJson,
 } from "./utils.js";
 
@@ -28,12 +29,11 @@ import {
  */
 
 function getPaths(cwd = process.cwd()): VaultPaths {
-  const root = resolveVaultRoot(cwd);
-  return getVaultPaths(root);
+  return resolveVaultPaths(cwd);
 }
 
 function requireVault(paths: VaultPaths): { ok: true } | { ok: false; reason: string } {
-  if (!existsSync(join(paths.root, ".wiki", "config.json"))) {
+  if (detectVaultFormat(paths.root) === "none") {
     return { ok: false, reason: `No wiki found at ${paths.root}. Run wiki_bootstrap first.` };
   }
   return { ok: true };
@@ -83,7 +83,7 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
         "| raw/** | extension | immutable after capture |",
         "| wiki/** | model + user | editable knowledge pages |",
         "| meta/* | extension | auto-generated |",
-        "| .wiki/* | human + explicit request | operating rules |",
+        "| . | human + explicit request | operating rules |",
         "",
         "## Source Packet Format",
         "",
@@ -109,7 +109,7 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
         "- Citation: [[sources/SRC-YYYY-MM-DD-NNN]]",
         "",
       ].join("\n");
-      writeFileSync(join(paths.root, "WIKI_SCHEMA.md"), schema, "utf-8");
+      writeFileSync(join(paths.dotWiki, "WIKI_SCHEMA.md"), schema, "utf-8");
 
       rebuildMetadata(paths);
       appendEvent(paths, { kind: "bootstrap", topic: params.topic, mode });
@@ -122,10 +122,11 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
               `✅ Wiki bootstrapped at \`${paths.root}\``,
               "",
               "**Structure:**",
-              "- raw/sources/ — immutable source packets",
-              "- wiki/ — editable knowledge pages",
-              "- meta/ — auto-generated metadata",
-              "- .wiki/ — config and templates",
+              "- .llm-wiki/raw/sources/ — immutable source packets",
+              "- .llm-wiki/wiki/ — editable knowledge pages",
+              "- .llm-wiki/meta/ — auto-generated metadata",
+              "- .llm-wiki/ — config and templates",
+              "- .llm-wiki/WIKI_SCHEMA.md — operating rules",
               "",
               "Next: Use wiki_capture_source to add your first source.",
             ].join("\n"),

--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -17,24 +17,53 @@ export interface VaultPaths {
   discoveries: string;
 }
 
+/** Detect whether a vault root uses new (.llm-wiki) or legacy (.wiki) layout. */
+export type VaultFormat = "new" | "legacy" | "none";
+
+/**
+ * Detect the vault format at a given directory.
+ * Returns "new" if .llm-wiki/config.json exists,
+ * "legacy" if .wiki/config.json exists,
+ * "none" otherwise.
+ */
+export function detectVaultFormat(dir: string): VaultFormat {
+  if (existsSync(join(dir, ".llm-wiki", "config.json"))) return "new";
+  if (existsSync(join(dir, ".wiki", "config.json"))) return "legacy";
+  return "none";
+}
+
 /** Resolve vault root from cwd or find nearest wiki root. */
 export function resolveVaultRoot(cwd: string): string {
-  // If cwd has .wiki/config.json, it's the root
-  if (existsSync(join(cwd, ".wiki", "config.json"))) return cwd;
+  // Check for any vault format at cwd
+  if (detectVaultFormat(cwd) !== "none") return cwd;
 
-  // Walk up looking for .wiki/config.json
+  // Walk up looking for a vault sentinel (new or legacy)
   let dir = cwd;
   while (dir !== dirname(dir)) {
-    if (existsSync(join(dir, ".wiki", "config.json"))) return dir;
     dir = dirname(dir);
+    if (detectVaultFormat(dir) !== "none") return dir;
   }
 
   // Fallback: cwd itself
   return cwd;
 }
 
-/** Get all vault paths. */
+/** Get all vault paths for the new (.llm-wiki) layout. */
 export function getVaultPaths(root: string): VaultPaths {
+  return {
+    root,
+    raw: join(root, ".llm-wiki", "raw"),
+    rawSources: join(root, ".llm-wiki", "raw", "sources"),
+    wiki: join(root, ".llm-wiki", "wiki"),
+    meta: join(root, ".llm-wiki", "meta"),
+    dotWiki: join(root, ".llm-wiki"),
+    outputs: join(root, ".llm-wiki", "outputs"),
+    discoveries: join(root, ".llm-wiki", ".discoveries"),
+  };
+}
+
+/** Get all vault paths for the legacy (.wiki) layout. */
+export function getLegacyVaultPaths(root: string): VaultPaths {
   return {
     root,
     raw: join(root, "raw"),
@@ -45,6 +74,17 @@ export function getVaultPaths(root: string): VaultPaths {
     outputs: join(root, "outputs"),
     discoveries: join(root, ".discoveries"),
   };
+}
+
+/**
+ * Resolve vault paths, auto-detecting new vs legacy layout.
+ * This is the main entry point: use this instead of resolveVaultRoot + getVaultPaths.
+ */
+export function resolveVaultPaths(cwd: string): VaultPaths {
+  const root = resolveVaultRoot(cwd);
+  const format = detectVaultFormat(root);
+  if (format === "legacy") return getLegacyVaultPaths(root);
+  return getVaultPaths(root);
 }
 
 /** Ensure all vault directories exist. */
@@ -199,10 +239,10 @@ export async function exec(
 /** Check if a path is inside a protected directory. */
 export function isProtectedPath(
   absPath: string,
-  root: string,
+  paths: VaultPaths,
 ): { protected: boolean; reason?: string } {
-  const rawPath = resolve(root, "raw");
-  const metaPath = resolve(root, "meta");
+  const rawPath = resolve(paths.raw);
+  const metaPath = resolve(paths.meta);
   const norm = resolve(absPath);
 
   if (norm.startsWith(`${rawPath}/`) || norm === rawPath) {

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -22,33 +22,72 @@ import * as z from "zod/v4";
 
 interface VaultPaths {
   root: string;
+  raw: string;
   rawSources: string;
   wiki: string;
   meta: string;
+  dotWiki: string;
+  outputs: string;
+  discoveries: string;
+}
+
+/** Detect vault format at a directory. */
+function detectFormat(dir: string): "new" | "legacy" | "none" {
+  if (existsSync(join(dir, ".llm-wiki", "config.json"))) return "new";
+  if (existsSync(join(dir, ".wiki", "config.json"))) return "legacy";
+  return "none";
 }
 
 function resolveVaultRoot(cwd: string): string | null {
-  if (existsSync(join(cwd, ".wiki", "config.json"))) return cwd;
+  // Check cwd first
+  if (detectFormat(cwd) !== "none") return cwd;
+
+  // Walk up
   const parts = cwd.split("/");
   for (let i = parts.length - 1; i >= 0; i--) {
     const dir = parts.slice(0, i + 1).join("/") || "/";
-    if (existsSync(join(dir, ".wiki", "config.json"))) return dir;
+    if (detectFormat(dir) !== "none") return dir;
   }
   return null;
 }
 
 function getPaths(): VaultPaths {
-  const root = process.env.WIKI_ROOT || resolveVaultRoot(process.cwd()) || process.cwd();
+  const detectedRoot = resolveVaultRoot(process.cwd());
+  const root = process.env.WIKI_ROOT || detectedRoot || process.cwd();
+  const format = process.env.WIKI_ROOT
+    ? detectFormat(root) // Use format detection even with explicit WIKI_ROOT
+    : detectedRoot
+      ? detectFormat(root)
+      : "none";
+
+  if (format === "legacy") {
+    return {
+      root,
+      raw: join(root, "raw"),
+      rawSources: join(root, "raw", "sources"),
+      wiki: join(root, "wiki"),
+      meta: join(root, "meta"),
+      dotWiki: join(root, ".wiki"),
+      outputs: join(root, "outputs"),
+      discoveries: join(root, ".discoveries"),
+    };
+  }
+
   return {
     root,
-    rawSources: join(root, "raw", "sources"),
-    wiki: join(root, "wiki"),
-    meta: join(root, "meta"),
+    raw: join(root, ".llm-wiki", "raw"),
+    rawSources: join(root, ".llm-wiki", "raw", "sources"),
+    wiki: join(root, ".llm-wiki", "wiki"),
+    meta: join(root, ".llm-wiki", "meta"),
+    dotWiki: join(root, ".llm-wiki"),
+    outputs: join(root, ".llm-wiki", "outputs"),
+    discoveries: join(root, ".llm-wiki", ".discoveries"),
   };
 }
 
 function hasVault(): boolean {
-  return existsSync(join(getPaths().root, ".wiki", "config.json"));
+  const paths = getPaths();
+  return existsSync(join(paths.dotWiki, "config.json"));
 }
 
 // ─── Helpers ────────────────────────────────────────────
@@ -259,7 +298,10 @@ server.registerTool(
       pages: {},
     });
 
-    const config = readJson<Record<string, unknown>>(join(paths.root, ".wiki", "config.json"), {});
+    const config = readJson<Record<string, unknown>>(
+      join(paths.dotWiki, "config.json"),
+      {},
+    );
 
     const byType: Record<string, number> = {};
     for (const entry of Object.values(registry.pages)) {
@@ -331,14 +373,7 @@ server.registerTool(
       ) => { sourceId: string; packetPath: string; sourcePagePath: string };
     };
 
-    const vaultPaths = {
-      ...getPaths(),
-      raw: join(getPaths().root, "raw"),
-      dotWiki: join(getPaths().root, ".wiki"),
-      outputs: join(getPaths().root, "outputs"),
-      discoveries: join(getPaths().root, ".discoveries"),
-    };
-
+    const vaultPaths = getPaths();
     const result = saveInsight(vaultPaths, slug, title, body, category);
 
     return {
@@ -378,18 +413,10 @@ server.registerTool(
       };
     }
 
-    const vaultPaths = {
-      ...getPaths(),
-      raw: join(getPaths().root, "raw"),
-      dotWiki: join(getPaths().root, ".wiki"),
-      outputs: join(getPaths().root, "outputs"),
-      discoveries: join(getPaths().root, ".discoveries"),
-    };
-
+    const vaultPaths = getPaths();
     let result: { sourceId: string };
 
     if (urlParam) {
-      // For MCP, use simple curl-based capture
       const { captureUrl } = (await import("../extensions/llm-wiki/lib/source-packet.js")) as {
         captureUrl: (
           pi: never,

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -298,10 +298,7 @@ server.registerTool(
       pages: {},
     });
 
-    const config = readJson<Record<string, unknown>>(
-      join(paths.dotWiki, "config.json"),
-      {},
-    );
+    const config = readJson<Record<string, unknown>>(join(paths.dotWiki, "config.json"), {});
 
     const byType: Record<string, number> = {};
     for (const entry of Object.values(registry.pages)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zosmaai/pi-llm-wiki",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zosmaai/pi-llm-wiki",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0-alpha.2"

--- a/plans/wiki-root-restructure.md
+++ b/plans/wiki-root-restructure.md
@@ -1,0 +1,144 @@
+# Plan: Restructure wiki vault under `.llm-wiki/`
+
+**Issue:** #22
+**Goal:** Move wiki vault content from repo root into `.llm-wiki/` subdirectory for cleaner repo isolation, simpler gitignore, and zero directory name collisions.
+
+## Motivation
+
+Currently a wiki vault scatters `raw/`, `wiki/`, `meta/`, `.wiki/`, `outputs/`, `.discoveries/` across the project root. When the wiki lives inside a larger code repo, this is messy and risks collisions.
+
+## Target layout
+
+```
+repo_root/
+├── .llm-wiki/               ← All wiki content under one dot-dir
+    ├── config.json           ← Vault sentinel (was .wiki/config.json)
+    ├── templates/            ← Page templates (was .wiki/templates/)
+    ├── raw/sources/SRC-*/    ← Immutable source packets
+    ├── wiki/                 ← Editable knowledge pages
+    │   ├── sources/
+    │   ├── entities/
+    │   ├── concepts/
+    │   ├── syntheses/
+    │   └── analyses/
+    ├── meta/                 ← Auto-generated metadata
+    ├── outputs/              ← Generated artifacts
+    └── .discoveries/         ← Discover tracking
+```
+
+Key decisions:
+- **Flat hierarchy** — no `.llm-wiki/.wiki/` nesting; config and templates live directly in `.llm-wiki/`
+- **Backward compat** — old `.wiki/config.json` sentinel still detected as fallback
+- **Migration path** — standalone script moves old vaults to new layout
+- **Single PR** — all changes are interdependent; cannot ship incrementally
+
+## Implementation phases
+
+### Phase A: Core path logic (`utils.ts`)
+
+**File:** `extensions/llm-wiki/lib/utils.ts`
+
+- `resolveVaultRoot()` — Check `.llm-wiki/config.json` first (new sentinel), walk up. Fall back to `.wiki/config.json` (old sentinel) for existing vaults.
+- `getVaultPaths()` — Return all paths under `.llm-wiki/`:
+  - `raw` → `root/.llm-wiki/raw`
+  - `wiki` → `root/.llm-wiki/wiki`
+  - `meta` → `root/.llm-wiki/meta`
+  - `dotWiki` → `root/.llm-wiki`
+  - `outputs` → `root/.llm-wiki/outputs`
+  - `discoveries` → `root/.llm-wiki/.discoveries`
+- `isProtectedPath()` — Update to use VaultPaths (check paths.raw and paths.meta instead of root-relative `raw/` and `meta/`)
+
+**Impact:** All callers of `getVaultPaths()` automatically get new paths. Callers of `isProtectedPath()` need signature update.
+
+### Phase B: Sentinel checks & hardcoded `.wiki/config.json` references
+
+Files that hardcode `join(root, ".wiki", "config.json")` → update to check new sentinel:
+
+| File | What changes |
+|------|-------------|
+| `extensions/llm-wiki/index.ts:62` | Check `.llm-wiki` dir exists instead of `.wiki/config.json` |
+| `extensions/llm-wiki/lib/tools.ts:37` | `requireVault()` — use `paths.dotWiki/config.json` |
+| `extensions/llm-wiki/lib/recall.ts:154` | Use `paths.dotWiki/config.json` via `getVaultPaths()` |
+| `extensions/llm-wiki/lib/retro.ts:164` | Use `paths.dotWiki/config.json` via `getVaultPaths()` |
+| `extensions/llm-wiki/lib/guardrails.ts:53-60` | Manual paths object → use `getVaultPaths()` |
+| `extensions/llm-wiki/lib/guardrails.ts:18,27,39` | `isProtectedPath()` callers — pass VaultPaths instead of root |
+
+### Phase C: MCP server (`mcp/index.ts`)
+
+The MCP server has its own copy of `resolveVaultRoot()` and `getPaths()`. These need the same treatment:
+
+- Update `resolveVaultRoot()` to check `.llm-wiki/config.json` first, fall back to `.wiki/config.json`
+- Update `getPaths()` to return paths under `.llm-wiki/`
+- Update `hasVault()` to use new sentinel
+- Update `wiki_status` tool's config path
+- Update `wiki_retro`/`wiki_capture_source` vaultPaths construction
+
+### Phase D: Bootstrap creates new structure
+
+`ensureVaultStructure()` in `utils.ts` uses `getVaultPaths()` — no code change needed, it automatically creates the new layout after Phase A.
+
+But the `WIKI_SCHEMA.md` content in `wiki_bootstrap` tool (tools.ts) describes the old layout. Update the schema text.
+
+### Phase E: Templates & documentation
+
+Update all docs and templates that describe the directory layout:
+
+| File | Change |
+|------|--------|
+| `skills/llm-wiki/SKILL.md` | Architecture diagram, path references |
+| `skills/llm-wiki/templates/config.yaml` | Path references |
+| `skills/llm-wiki/templates/pages/source.md` | raw_path in frontmatter |
+| `skills/llm-wiki/templates/LOG.md` | Path references |
+| `prompts/wiki-init.md` | Directory structure steps |
+| `prompts/wiki-ingest.md` | `raw/` path references |
+| `prompts/wiki-discover.md` | `raw/` path references |
+| `prompts/wiki-lint.md` | Path references |
+| `prompts/wiki-status.md` | Path references |
+| `README.md` | Vault layout, quick start, source packet format |
+| `docs/architecture.md` | Architecture diagram |
+| `docs/commands.md` | Path references |
+| `docs/obsidian.md` | Vault path for Obsidian |
+| `docs/configuration.md` | Config path |
+| `AGENTS.md` | Path references |
+| `assets/architecture.md` | Architecture diagram |
+
+### Phase F: Migration script
+
+**File:** `scripts/migrate-llm-wiki.js`
+
+A one-time migration script that:
+1. Detects old-style vault (`.wiki/config.json` exists, `.llm-wiki/config.json` doesn't)
+2. Creates `.llm-wiki/` directory
+3. Moves: `raw/` → `.llm-wiki/raw/`, `wiki/` → `.llm-wiki/wiki/`, `meta/` → `.llm-wiki/meta/`, `.wiki/` content → `.llm-wiki/` (config + templates), `outputs/` → `.llm-wiki/outputs/`, `.discoveries/` → `.llm-wiki/.discoveries/`
+4. Creates `.wiki/migrated-to-llm-wiki` forwarding marker
+5. Removes old `.wiki/` empty dir
+6. Reports migration summary
+7. Dry-run mode via `--dry-run`
+
+Also add as a proper extension tool `wiki_migrate` for convenience.
+
+### Phase G: Tests
+
+**File:** `test/llm-wiki.test.ts`
+
+- `createWikiRoot()` — update to create `.llm-wiki/` structure matching new layout
+- `createConfig()` — update to write to `.llm-wiki/config.json` location
+- All path assertions — update expected paths
+- Add test for backward compat (old `.wiki/config.json` still detected)
+- Add test for migration script
+
+## Execution strategy
+
+Single PR containing all phases. Rationale:
+- All TypeScript changes are interdependent
+- Tests would be red in intermediate states
+- The change is internally consistent — deliver as one atomic unit
+
+Version bump: `0.7.0` (breaking change for vault directory structure, with backward compat).
+
+## Backward compat guarantees
+
+1. Old vaults with `.wiki/config.json` as sentinel are still detected
+2. Old `getVaultPaths()` kept as `getLegacyVaultPaths()` for migration
+3. Migration script handles move cleanly
+4. Existing `raw/`, `wiki/`, `meta/`, `.wiki/` paths continue working for read operations until migrated

--- a/prompts/wiki-discover.md
+++ b/prompts/wiki-discover.md
@@ -17,17 +17,17 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first. Also read `conf
 
 ## Steps
 
-1. Read `config.yaml` → extract topics, keywords, feeds
-2. Read `.discoveries/gaps.json` → knowledge gaps to fill
-3. Read `.discoveries/history.json` → already-fetched URLs
+1. Read `.llm-wiki/config.yaml` → extract topics, keywords, feeds
+2. Read `.llm-wiki/.discoveries/gaps.json` → knowledge gaps to fill
+3. Read `.llm-wiki/.discoveries/history.json` → already-fetched URLs
 4. Search for new sources:
    - Web search each topic + latest keywords
-   - Search for gaps from `.discoveries/gaps.json`
+   - Search for gaps from `.llm-wiki/.discoveries/gaps.json`
    - If `--topic` specified, focus search on that topic
 5. For each promising result:
    a. Fetch full content
-   b. Save to `raw/articles/YYYY-MM-DD-slug.md` with frontmatter (title, url, discovered, topic)
-6. Update `.discoveries/history.json`
+   b. Save to `.llm-wiki/raw/articles/YYYY-MM-DD-slug.md` with frontmatter (title, url, discovered, topic)
+6. Update `.llm-wiki/.discoveries/history.json`
 7. Report: "Discovered [N] new sources. Run `/wiki-ingest` to process them."
 
 **Rules:** Max 5-10 sources. Skip ads, listicles, duplicates. Prefer in-depth analysis.

--- a/prompts/wiki-ingest.md
+++ b/prompts/wiki-ingest.md
@@ -7,7 +7,7 @@ topLevelCli: true
 
 # /wiki-ingest
 
-Process new files in `raw/` and integrate them into the wiki.
+Process new files in `.llm-wiki/raw/` and integrate them into the wiki.
 
 ## User Arguments
 
@@ -17,18 +17,18 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand th
 
 ## Steps
 
-1. Read `config.yaml` and `.discoveries/history.json`
-2. If a specific path is given (e.g., `/wiki-ingest raw/articles/my-file.md`), process just that file
-3. If no path given, scan all files in `raw/` and find ones not in history
+1. Read `.llm-wiki/config.yaml` and `.llm-wiki/.discoveries/history.json`
+2. If a specific path is given (e.g., `/wiki-ingest .llm-wiki/raw/articles/my-file.md`), process just that file
+3. If no path given, scan all files in `.llm-wiki/raw/` and find ones not in history
 4. For each new source:
    a. Read the full content
    b. Briefly discuss with the user: "This is about [topic]. Key points: [summary]. Any specific emphasis?"
-   c. Create/update pages in `wiki/sources/`, `wiki/entities/`, `wiki/concepts/`
+   c. Create/update pages in `.llm-wiki/wiki/sources/`, `.llm-wiki/wiki/entities/`, `.llm-wiki/wiki/concepts/`
    d. Add `[[wikilinks]]` cross-references between related pages
    e. Flag any contradictions with existing wiki content
-5. Update `wiki/INDEX.md` with all new/updated pages
-6. Append to `wiki/LOG.md`
-7. Update `.discoveries/history.json`
+5. Update `.llm-wiki/wiki/INDEX.md` with all new/updated pages
+6. Append to `.llm-wiki/wiki/LOG.md`
+7. Update `.llm-wiki/.discoveries/history.json`
 8. Report: "Ingested [N] sources → [M] pages created/updated. [X] contradictions flagged."
 
 **Rules:** Never modify raw/ files. Never fabricate information. Always cite sources.

--- a/prompts/wiki-init.md
+++ b/prompts/wiki-init.md
@@ -19,16 +19,16 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` (or wherever the skill
 
 1. Ask the user for the wiki topic and mode (`personal` or `company`)
 2. Create the directory structure:
-   - `raw/articles/`, `raw/papers/`, `raw/notes/`, `raw/assets/`
-   - `wiki/entities/`, `wiki/concepts/`, `wiki/sources/`, `wiki/syntheses/`, `wiki/changes/`
-   - `outputs/`
-   - `.discoveries/`
-3. Create `config.yaml` with the topic, mode, and default settings
-4. Create `wiki/INDEX.md` with section headings organized by page type
-5. Create `wiki/LOG.md` with initial entry
-6. Create `wiki/DASHBOARD.md` with Dataview queries for Obsidian
-7. Create `.gitignore` to exclude `outputs/` from version control if desired
+   - `.llm-wiki/raw/articles/`, `.llm-wiki/raw/papers/`, `.llm-wiki/raw/notes/`, `.llm-wiki/raw/assets/`
+   - `.llm-wiki/wiki/entities/`, `.llm-wiki/wiki/concepts/`, `.llm-wiki/wiki/sources/`, `.llm-wiki/wiki/syntheses/`, `.llm-wiki/wiki/changes/`
+   - `.llm-wiki/outputs/`
+   - `.llm-wiki/.discoveries/`
+3. Create `.llm-wiki/config.yaml` with the topic, mode, and default settings
+4. Create `.llm-wiki/wiki/INDEX.md` with section headings organized by page type
+5. Create `.llm-wiki/wiki/LOG.md` with initial entry
+6. Create `.llm-wiki/wiki/DASHBOARD.md` with Dataview queries for Obsidian
+7. Create `.gitignore` to exclude `.llm-wiki/outputs/` from version control if desired
 8. Initialize git repo if not already present
-9. Report the structure and suggest first steps: "Drop sources into `raw/` and run `/wiki-ingest`"
+9. Report the structure and suggest first steps: "Drop sources into `.llm-wiki/raw/` and run `/wiki-ingest`"
 
-If `--mode company`, add the `change_detection: true` flag to config.yaml and add a `wiki/decisions/` folder.
+If `--mode company`, add the `change_detection: true` flag to config.yaml and add a `.llm-wiki/wiki/decisions/` folder.

--- a/prompts/wiki-lint.md
+++ b/prompts/wiki-lint.md
@@ -17,17 +17,17 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand th
 
 ## Steps
 
-1. Scan all files in `wiki/`
+1. Scan all files in `.llm-wiki/wiki/`
 2. Check for:
    - **Contradictions:** Conflicting claims between pages
    - **Orphans:** Pages with zero inbound `[[wikilinks]]`
    - **Missing pages:** `[[links]]` pointing to non-existent files
    - **Stale claims:** Info superseded by newer sources
-   - **Broken raw links:** References to `raw/` files that don't exist
+   - **Broken raw links:** References to `.llm-wiki/raw/` files that don't exist
    - **Knowledge gaps:** Topics mentioned but lacking their own page
    - **Quality:** Pages under 3 lines, pages with no sources or cross-refs
 3. If `--fix` flag is present: auto-fix broken links, create missing pages for frequently-linked concepts, add cross-refs to orphans. Flag contradictions for human decision.
-4. Save report → `outputs/lint-YYYY-MM-DD.md`
-5. Update `.discoveries/gaps.json`
-6. Append to `wiki/LOG.md`
+4. Save report → `.llm-wiki/outputs/lint-YYYY-MM-DD.md`
+5. Update `.llm-wiki/.discoveries/gaps.json`
+6. Append to `.llm-wiki/wiki/LOG.md`
 7. Report key findings

--- a/prompts/wiki-status.md
+++ b/prompts/wiki-status.md
@@ -11,11 +11,11 @@ Show a quick overview of wiki health and statistics.
 
 ## Steps
 
-1. Count sources in `raw/` (recursive)
-2. Count pages in `wiki/` (by type: entities, concepts, sources, syntheses)
-3. Check `wiki/LOG.md` for last ingest, lint, and discover dates
+1. Count sources in `.llm-wiki/raw/` (recursive)
+2. Count pages in `.llm-wiki/wiki/` (by type: entities, concepts, sources, syntheses)
+3. Check `.llm-wiki/wiki/LOG.md` for last ingest, lint, and discover dates
 4. Check for orphan pages (zero inbound links)
-5. Read `.discoveries/gaps.json` for known gaps
+5. Read `.llm-wiki/.discoveries/gaps.json` for known gaps
 6. Report:
 
 ```

--- a/scripts/migrate-llm-wiki.js
+++ b/scripts/migrate-llm-wiki.js
@@ -43,7 +43,9 @@ function moveContents(src, dest, name) {
       renameSync(join(src, entry), join(dest, entry));
     }
     // Remove empty source directory
-    try { rmSync(src); } catch {}
+    try {
+      rmSync(src);
+    } catch {}
   }
 }
 
@@ -67,9 +69,7 @@ function moveDir(src, dest, name) {
 
 async function main() {
   // Determine root directory
-  const root = process.argv[2]
-    ? join(process.cwd(), process.argv[2])
-    : process.cwd();
+  const root = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
 
   console.log(`\n🔍 Scanning for legacy wiki at: ${root}\n`);
 
@@ -97,13 +97,48 @@ async function main() {
 
   // Migration plan
   const moves = [
-    { src: join(root, ".wiki", "config.json"), dest: join(root, ".llm-wiki", "config.json"), type: "file", name: "config" },
-    { src: join(root, ".wiki", "templates"), dest: join(root, ".llm-wiki", "templates"), type: "dir", name: "templates" },
-    { src: join(root, "raw"), dest: join(root, ".llm-wiki", "raw"), type: "dir", name: "raw sources" },
-    { src: join(root, "wiki"), dest: join(root, ".llm-wiki", "wiki"), type: "dir", name: "wiki pages" },
-    { src: join(root, "meta"), dest: join(root, ".llm-wiki", "meta"), type: "dir", name: "metadata" },
-    { src: join(root, "outputs"), dest: join(root, ".llm-wiki", "outputs"), type: "dir", name: "outputs" },
-    { src: join(root, ".discoveries"), dest: join(root, ".llm-wiki", ".discoveries"), type: "dir", name: "discovery tracking" },
+    {
+      src: join(root, ".wiki", "config.json"),
+      dest: join(root, ".llm-wiki", "config.json"),
+      type: "file",
+      name: "config",
+    },
+    {
+      src: join(root, ".wiki", "templates"),
+      dest: join(root, ".llm-wiki", "templates"),
+      type: "dir",
+      name: "templates",
+    },
+    {
+      src: join(root, "raw"),
+      dest: join(root, ".llm-wiki", "raw"),
+      type: "dir",
+      name: "raw sources",
+    },
+    {
+      src: join(root, "wiki"),
+      dest: join(root, ".llm-wiki", "wiki"),
+      type: "dir",
+      name: "wiki pages",
+    },
+    {
+      src: join(root, "meta"),
+      dest: join(root, ".llm-wiki", "meta"),
+      type: "dir",
+      name: "metadata",
+    },
+    {
+      src: join(root, "outputs"),
+      dest: join(root, ".llm-wiki", "outputs"),
+      type: "dir",
+      name: "outputs",
+    },
+    {
+      src: join(root, ".discoveries"),
+      dest: join(root, ".llm-wiki", ".discoveries"),
+      type: "dir",
+      name: "discovery tracking",
+    },
   ];
 
   // Check for WIKI_SCHEMA.md at root
@@ -129,7 +164,9 @@ async function main() {
     (e) => e !== "config.json" && e !== "templates",
   );
   if (dotWikiContents.length > 0) {
-    console.log(`\n   ⚠️ Additional .wiki/ contents (${dotWikiContents.length} items) will be left in place.`);
+    console.log(
+      `\n   ⚠️ Additional .wiki/ contents (${dotWikiContents.length} items) will be left in place.`,
+    );
     for (const c of dotWikiContents) {
       console.log(`      .wiki/${c}`);
     }

--- a/scripts/migrate-llm-wiki.js
+++ b/scripts/migrate-llm-wiki.js
@@ -26,29 +26,6 @@ function log(action, ...args) {
   console.log(`${prefix} ${action}`, ...args);
 }
 
-function moveContents(src, dest, name) {
-  if (!existsSync(src)) {
-    log(`SKIP ${name} — source does not exist: ${src}`);
-    return;
-  }
-  if (existsSync(dest)) {
-    log(`SKIP ${name} — destination already exists: ${dest}`);
-    return;
-  }
-  log(`MOVE ${name}: ${src} → ${dest}`);
-  if (!DRY_RUN) {
-    mkdirSync(dest, { recursive: true });
-    // Move all entries inside src to dest
-    for (const entry of readdirSync(src)) {
-      renameSync(join(src, entry), join(dest, entry));
-    }
-    // Remove empty source directory
-    try {
-      rmSync(src);
-    } catch {}
-  }
-}
-
 function moveDir(src, dest, name) {
   if (!existsSync(src)) {
     log(`SKIP ${name} — source does not exist: ${src}`);

--- a/scripts/migrate-llm-wiki.js
+++ b/scripts/migrate-llm-wiki.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+/**
+ * migrate-llm-wiki.js
+ *
+ * One-time migration script: moves an old-style wiki vault (.wiki/ sentinel)
+ * to the new .llm-wiki/ layout.
+ *
+ * Usage:
+ *   node scripts/migrate-llm-wiki.js              # Run in wiki root directory
+ *   node scripts/migrate-llm-wiki.js ~/my-wiki     # Run at specific path
+ *   node scripts/migrate-llm-wiki.js --dry-run     # Preview without changes
+ *   node scripts/migrate-llm-wiki.js --force        # Skip confirmation prompt
+ */
+
+import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ─── Helpers ────────────────────────────────────────────
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const FORCE = process.argv.includes("--force");
+
+function log(action, ...args) {
+  const prefix = DRY_RUN ? "[DRY-RUN]" : "[MIGRATE]";
+  console.log(`${prefix} ${action}`, ...args);
+}
+
+function moveContents(src, dest, name) {
+  if (!existsSync(src)) {
+    log(`SKIP ${name} — source does not exist: ${src}`);
+    return;
+  }
+  if (existsSync(dest)) {
+    log(`SKIP ${name} — destination already exists: ${dest}`);
+    return;
+  }
+  log(`MOVE ${name}: ${src} → ${dest}`);
+  if (!DRY_RUN) {
+    mkdirSync(dest, { recursive: true });
+    // Move all entries inside src to dest
+    for (const entry of readdirSync(src)) {
+      renameSync(join(src, entry), join(dest, entry));
+    }
+    // Remove empty source directory
+    try { rmSync(src); } catch {}
+  }
+}
+
+function moveDir(src, dest, name) {
+  if (!existsSync(src)) {
+    log(`SKIP ${name} — source does not exist: ${src}`);
+    return;
+  }
+  if (existsSync(dest)) {
+    log(`SKIP ${name} — destination already exists: ${dest}`);
+    return;
+  }
+  log(`MOVE ${name}: ${src} → ${dest}`);
+  if (!DRY_RUN) {
+    mkdirSync(dest, { recursive: true });
+    renameSync(src, dest);
+  }
+}
+
+// ─── Main ───────────────────────────────────────────────
+
+async function main() {
+  // Determine root directory
+  const root = process.argv[2]
+    ? join(process.cwd(), process.argv[2])
+    : process.cwd();
+
+  console.log(`\n🔍 Scanning for legacy wiki at: ${root}\n`);
+
+  // Check for old-style vault
+  const oldSentinel = join(root, ".wiki", "config.json");
+  const newSentinel = join(root, ".llm-wiki", "config.json");
+
+  if (!existsSync(oldSentinel)) {
+    console.log("❌ No legacy wiki found (no .wiki/config.json). Nothing to migrate.");
+    if (existsSync(newSentinel)) {
+      console.log("   ✓ New-format wiki already exists at .llm-wiki/");
+    } else {
+      console.log("   No wiki vault found. Use wiki_bootstrap to create one.");
+    }
+    process.exit(0);
+  }
+
+  if (existsSync(newSentinel)) {
+    console.log(
+      "⚠️  Both legacy (.wiki/) and new (.llm-wiki/) vaults detected.\n" +
+        "   The new vault already exists. Remove .llm-wiki/ first or specify a different root.",
+    );
+    process.exit(1);
+  }
+
+  // Migration plan
+  const moves = [
+    { src: join(root, ".wiki", "config.json"), dest: join(root, ".llm-wiki", "config.json"), type: "file", name: "config" },
+    { src: join(root, ".wiki", "templates"), dest: join(root, ".llm-wiki", "templates"), type: "dir", name: "templates" },
+    { src: join(root, "raw"), dest: join(root, ".llm-wiki", "raw"), type: "dir", name: "raw sources" },
+    { src: join(root, "wiki"), dest: join(root, ".llm-wiki", "wiki"), type: "dir", name: "wiki pages" },
+    { src: join(root, "meta"), dest: join(root, ".llm-wiki", "meta"), type: "dir", name: "metadata" },
+    { src: join(root, "outputs"), dest: join(root, ".llm-wiki", "outputs"), type: "dir", name: "outputs" },
+    { src: join(root, ".discoveries"), dest: join(root, ".llm-wiki", ".discoveries"), type: "dir", name: "discovery tracking" },
+  ];
+
+  // Check for WIKI_SCHEMA.md at root
+  const oldSchema = join(root, "WIKI_SCHEMA.md");
+  const schemas = [];
+  if (existsSync(oldSchema)) {
+    schemas.push({ src: oldSchema, dest: join(root, ".llm-wiki", "WIKI_SCHEMA.md") });
+  }
+
+  // Print plan
+  console.log("📋 Migration plan:");
+  console.log("   Legacy format → New format");
+  console.log("   ─────────────────────────────");
+  for (const m of moves) {
+    console.log(`   ${existsSync(m.src) ? "✓" : "○"} ${m.name}: ${m.src} → ${m.dest}`);
+  }
+  for (const s of schemas) {
+    console.log(`   ✓ WIKI_SCHEMA: ${s.src} → ${s.dest}`);
+  }
+
+  // Remaining .wiki/ dir contents (after config + templates moved)
+  const dotWikiContents = readdirSync(join(root, ".wiki")).filter(
+    (e) => e !== "config.json" && e !== "templates",
+  );
+  if (dotWikiContents.length > 0) {
+    console.log(`\n   ⚠️ Additional .wiki/ contents (${dotWikiContents.length} items) will be left in place.`);
+    for (const c of dotWikiContents) {
+      console.log(`      .wiki/${c}`);
+    }
+  }
+
+  // Confirmation
+  if (!FORCE && !DRY_RUN) {
+    console.log("\n❓ Proceed with migration? (y/N)");
+    // Read from stdin
+    process.stdin.setRawMode?.(false);
+    const answer = await new Promise((resolve) => {
+      process.stdin.once("data", (data) => {
+        resolve(data.toString().trim().toLowerCase());
+      });
+    });
+    if (answer !== "y" && answer !== "yes") {
+      console.log("Migration cancelled.");
+      process.exit(0);
+    }
+  }
+
+  // Execute
+  console.log("");
+  for (const m of moves) {
+    if (m.type === "dir") {
+      moveDir(m.src, m.dest, m.name);
+    } else {
+      moveDir(m.src, m.dest, m.name);
+    }
+  }
+
+  // Move WIKI_SCHEMA.md
+  for (const s of schemas) {
+    log(`MOVE WIKI_SCHEMA: ${s.src} → ${s.dest}`);
+    if (!DRY_RUN) {
+      mkdirSync(join(root, ".llm-wiki"), { recursive: true });
+      renameSync(s.src, s.dest);
+    }
+  }
+
+  // Create forwarding marker in old .wiki/
+  if (!DRY_RUN) {
+    const forwardingMarker = join(root, ".wiki", "MIGRATED_TO_LLM_WIKI.md");
+    const newRoot = join(root, ".llm-wiki");
+    writeFileSync(
+      forwardingMarker,
+      [
+        "# Migration Complete",
+        "",
+        `This vault was migrated to the new layout at \`.llm-wiki/\` on ${new Date().toISOString().split("T")[0]}.`,
+        "",
+        "The old `.wiki/` directory is kept as a forwarding marker.",
+        "Remove it once you've verified everything works.",
+        "",
+        `New location: \`${newRoot}\``,
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    log("CREATE forwarding marker: .wiki/MIGRATED_TO_LLM_WIKI.md");
+  }
+
+  console.log("");
+  if (DRY_RUN) {
+    console.log("✅ Dry-run complete. No changes made.");
+    console.log("   Run without --dry-run to perform the migration.");
+  } else {
+    console.log("✅ Migration complete!");
+    console.log("");
+    console.log("   What changed:");
+    console.log("   • All wiki content moved under .llm-wiki/");
+    console.log("   • Raw sources:       .llm-wiki/raw/");
+    console.log("   • Wiki pages:        .llm-wiki/wiki/");
+    console.log("   • Metadata:          .llm-wiki/meta/");
+    console.log("   • Config/templates:  .llm-wiki/ (config.json, templates/)");
+    console.log("   • Outputs:           .llm-wiki/outputs/");
+    console.log("   • Forwarding marker: .wiki/MIGRATED_TO_LLM_WIKI.md");
+    console.log("");
+    console.log("   The old .wiki/ dir is kept as a marker. You can remove it once verified.");
+    console.log("");
+    console.log("   Update your gitignore:");
+    console.log("     echo '.llm-wiki/' >> .gitignore");
+    console.log("");
+  }
+}
+
+main().catch((err) => {
+  console.error("Migration error:", err);
+  process.exit(1);
+});

--- a/scripts/migrate-llm-wiki.js
+++ b/scripts/migrate-llm-wiki.js
@@ -13,7 +13,7 @@
  *   node scripts/migrate-llm-wiki.js --force        # Skip confirmation prompt
  */
 
-import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 // ─── Helpers ────────────────────────────────────────────

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -11,26 +11,28 @@ You are a disciplined wiki maintainer. The extension handles all mechanical work
 
 ```
 WIKI_ROOT/
-├── raw/sources/SRC-*/       # Immutable source packets (extension-owned)
-│   ├── manifest.json
-│   ├── original/
-│   ├── extracted.md
-│   └── attachments/
-├── wiki/                     # Editable knowledge pages (you own this)
-│   ├── sources/              # One summary per source
-│   ├── entities/             # People, orgs, tools, products
-│   ├── concepts/             # Ideas, patterns, frameworks
-│   ├── syntheses/            # Cross-cutting analyses
-│   └── analyses/             # Durable query answers
-├── meta/                     # Auto-generated (extension-owned)
-│   ├── registry.json         # Master page catalog
-│   ├── backlinks.json        # Inbound link map
-│   ├── index.md              # Human-readable catalog
-│   ├── log.md                # Activity log
-│   └── events.jsonl          # Structured event stream
-└── .wiki/                    # Config and templates
-    ├── config.json
-    └── templates/
+└── .llm-wiki/                 # All wiki content (one dot-dir)
+    ├── config.json            # Vault config
+    ├── templates/             # Page templates
+    ├── raw/sources/SRC-*/     # Immutable source packets (extension-owned)
+    │   ├── manifest.json
+    │   ├── original/
+    │   ├── extracted.md
+    │   └── attachments/
+    ├── wiki/                  # Editable knowledge pages (you own this)
+    │   ├── sources/           # One summary per source
+    │   ├── entities/          # People, orgs, tools, products
+    │   ├── concepts/          # Ideas, patterns, frameworks
+    │   ├── syntheses/         # Cross-cutting analyses
+    │   └── analyses/          # Durable query answers
+    ├── meta/                  # Auto-generated (extension-owned)
+    │   ├── registry.json      # Master page catalog
+    │   ├── backlinks.json     # Inbound link map
+    │   ├── index.md           # Human-readable catalog
+    │   ├── log.md             # Activity log
+    │   └── events.jsonl       # Structured event stream
+    ├── outputs/               # Generated artifacts
+    └── .discoveries/          # Discovery tracking
 ```
 
 ## Golden Rules

--- a/skills/llm-wiki/templates/pages/source.md
+++ b/skills/llm-wiki/templates/pages/source.md
@@ -1,7 +1,7 @@
 ---
 type: source
 format: article # article | paper | note | video | podcast | slack | email
-raw_path: raw/articles/filename.md
+raw_path: .llm-wiki/raw/articles/filename.md
 ingested: YYYY-MM-DD
 topics:
   - topic-name
@@ -42,4 +42,4 @@ topics:
 
 ## Source
 
-- [raw/articles/filename.md](../raw/articles/filename.md)
+- [.llm-wiki/raw/articles/filename.md](../.llm-wiki/raw/articles/filename.md)

--- a/test/llm-wiki.test.ts
+++ b/test/llm-wiki.test.ts
@@ -6,7 +6,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildRegistry, rebuildMetadataLight } from "../extensions/llm-wiki/lib/metadata.js";
 import { formatRecallContext, searchWiki } from "../extensions/llm-wiki/lib/recall.js";
 import { captureFile, captureText, captureUrl } from "../extensions/llm-wiki/lib/source-packet.js";
-import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+import {
+  detectVaultFormat,
+  ensureVaultStructure,
+  getLegacyVaultPaths,
+  getVaultPaths,
+  resolveVaultPaths,
+} from "../extensions/llm-wiki/lib/utils.js";
 
 // ─── Helpers ────────────────────────────────────────────
 
@@ -29,6 +35,7 @@ function createWikiRoot(): string {
   const dir = join(tempDir, `wiki-${Math.random().toString(36).slice(2)}`);
   mkdirSync(dir, { recursive: true });
 
+  const llmWiki = join(dir, ".llm-wiki");
   const dirs = [
     "raw/articles",
     "raw/papers",
@@ -42,7 +49,7 @@ function createWikiRoot(): string {
     "outputs",
     ".discoveries",
   ];
-  for (const d of dirs) mkdirSync(join(dir, d), { recursive: true });
+  for (const d of dirs) mkdirSync(join(llmWiki, d), { recursive: true });
 
   return dir;
 }
@@ -56,17 +63,19 @@ function createConfig(dir: string, overrides: Record<string, unknown> = {}) {
   const mode = config.wiki?.mode || "personal";
   const topic = config.wiki?.topic || "Test Topic";
   writeFileSync(
-    join(dir, "config.yaml"),
+    join(dir, ".llm-wiki", "config.yaml"),
     `# LLM Wiki Configuration\nwiki:\n  mode: ${mode}\n  topic: "${topic}"\n`,
   );
 }
 
 function createSourceFile(dir: string, name: string, content: string) {
-  writeFileSync(join(dir, "raw", "articles", name), content);
+  writeFileSync(join(dir, ".llm-wiki", "raw", "articles", name), content);
 }
 
 function createWikiPage(dir: string, subdir: string | "", name: string, content: string) {
-  const target = subdir ? join(dir, "wiki", subdir, name) : join(dir, "wiki", name);
+  const target = subdir
+    ? join(dir, ".llm-wiki", "wiki", subdir, name)
+    : join(dir, ".llm-wiki", "wiki", name);
   writeFileSync(target, content);
 }
 
@@ -526,32 +535,32 @@ describe("wiki directory structure", () => {
   });
 
   it("should have all required directories", () => {
-    expect(existsSync(join(wikiDir, "raw", "articles"))).toBe(true);
-    expect(existsSync(join(wikiDir, "raw", "papers"))).toBe(true);
-    expect(existsSync(join(wikiDir, "raw", "notes"))).toBe(true);
-    expect(existsSync(join(wikiDir, "wiki", "entities"))).toBe(true);
-    expect(existsSync(join(wikiDir, "wiki", "concepts"))).toBe(true);
-    expect(existsSync(join(wikiDir, "wiki", "sources"))).toBe(true);
-    expect(existsSync(join(wikiDir, "wiki", "syntheses"))).toBe(true);
-    expect(existsSync(join(wikiDir, "wiki", "changes"))).toBe(true);
-    expect(existsSync(join(wikiDir, "outputs"))).toBe(true);
-    expect(existsSync(join(wikiDir, ".discoveries"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "raw", "articles"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "raw", "papers"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "raw", "notes"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "entities"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "concepts"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "sources"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "syntheses"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "changes"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "outputs"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", ".discoveries"))).toBe(true);
   });
 
   it("should create source pages from ingested files", () => {
     createConfig(wikiDir);
     createSourceFile(wikiDir, "test-article.md", "# Test\nContent about AI.");
-    expect(existsSync(join(wikiDir, "raw", "articles", "test-article.md"))).toBe(true);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "raw", "articles", "test-article.md"))).toBe(true);
 
     createWikiPage(
       wikiDir,
       "sources",
       "test-article.md",
-      "---\ntype: source\nformat: article\nraw_path: raw/articles/test-article.md\ningested: 2026-04-27\ntopics: [ai]\n---\n\n# Test Article\n\n## Summary\nAI content.\n",
+      "---\ntype: source\nformat: article\nraw_path: .llm-wiki/raw/articles/test-article.md\ningested: 2026-04-27\ntopics: [ai]\n---\n\n# Test Article\n\n## Summary\nAI content.\n",
     );
-    const content = readFile(join(wikiDir, "wiki", "sources", "test-article.md"));
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "sources", "test-article.md"));
     expect(content).toContain("type: source");
-    expect(content).toContain("raw_path: raw/articles/test-article.md");
+    expect(content).toContain("raw_path: .llm-wiki/raw/articles/test-article.md");
   });
 
   it("should create entity pages with correct format", () => {
@@ -559,9 +568,9 @@ describe("wiki directory structure", () => {
       wikiDir,
       "entities",
       "test-entity.md",
-      "---\ntype: entity\ncategory: person\ncreated: 2026-04-27\nupdated: 2026-04-27\nsources: [raw/articles/test.md]\n---\n\n# Person\n\n## Links\n- [[related-concept]]\n\n## Sources\n- [test](../raw/articles/test.md)\n",
+      "---\ntype: entity\ncategory: person\ncreated: 2026-04-27\nupdated: 2026-04-27\nsources: [.llm-wiki/raw/articles/test.md]\n---\n\n# Person\n\n## Links\n- [[related-concept]]\n\n## Sources\n- [test](../.llm-wiki/raw/articles/test.md)\n",
     );
-    const content = readFile(join(wikiDir, "wiki", "entities", "test-entity.md"));
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "entities", "test-entity.md"));
     expect(content).toContain("type: entity");
     expect(content).toContain("category: person");
     expect(content).toContain("[[related-concept]]");
@@ -574,7 +583,7 @@ describe("wiki directory structure", () => {
       "test-concept.md",
       "---\ntype: concept\ndomain: engineering\ncreated: 2026-04-27\nupdated: 2026-04-27\nsources: []\n---\n\n# Test Concept\n\n## Links\n- [[other-concept]]\n",
     );
-    const content = readFile(join(wikiDir, "wiki", "concepts", "test-concept.md"));
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "concepts", "test-concept.md"));
     expect(content).toContain("type: concept");
     expect(content).toContain("domain: engineering");
     expect(content).toContain("[[other-concept]]");
@@ -587,7 +596,7 @@ describe("wiki directory structure", () => {
       "comparison.md",
       "---\ntype: synthesis\ntopic: comparison\ncreated: 2026-04-27\nupdated: 2026-04-27\nsources_count: 2\n---\n\n# Comparison\n\n## Sources Used\n- [[source-1]]\n- [[source-2]]\n",
     );
-    const content = readFile(join(wikiDir, "wiki", "syntheses", "comparison.md"));
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "syntheses", "comparison.md"));
     expect(content).toContain("type: synthesis");
     expect(content).toContain("sources_count: 2");
     expect(content).toContain("[[source-1]]");
@@ -600,13 +609,13 @@ describe("wiki directory structure", () => {
       "INDEX.md",
       "# Wiki Index\n\n## Entities\n- [test](entities/test.md)\n",
     );
-    const content = readFile(join(wikiDir, "wiki", "INDEX.md"));
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "INDEX.md"));
     expect(content).toContain("test");
   });
 
   it("should append to LOG.md", () => {
-    writeFileSync(join(wikiDir, "wiki", "LOG.md"), "## [2026-04-27] ingest | 3 pages\n");
-    const content = readFile(join(wikiDir, "wiki", "LOG.md"));
+    writeFileSync(join(wikiDir, ".llm-wiki", "wiki", "LOG.md"), "## [2026-04-27] ingest | 3 pages\n");
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "LOG.md"));
     expect(content).toContain("ingest");
     expect(content).toContain("3 pages");
   });
@@ -618,7 +627,7 @@ describe("wiki directory structure", () => {
       "conflict.md",
       "---\ntype: concept\ndomain: ai\ncreated: 2026-04-27\nupdated: 2026-04-27\nsources: [a.md, b.md]\n---\n\n> ⚠️ **Contradiction:** A claims X but B claims Y.\n",
     );
-    const content = readFile(join(wikiDir, "wiki", "concepts", "conflict.md"));
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "concepts", "conflict.md"));
     expect(content).toContain("Contradiction:");
   });
 });
@@ -645,7 +654,7 @@ describe("cross-reference integrity", () => {
       "orphan.md",
       "---\ntype: entity\ncategory: person\ncreated: 2026-04-27\nupdated: 2026-04-27\nsources: []\n---\n# Orphan\n",
     );
-    const content = readFile(join(wikiDir, "wiki", "entities", "orphan.md"));
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "entities", "orphan.md"));
     expect(content).not.toContain("[[orphan");
   });
 
@@ -656,11 +665,11 @@ describe("cross-reference integrity", () => {
       "main.md",
       "---\ntype: concept\ndomain: ai\ncreated: 2026-04-27\nupdated: 2026-04-27\nsources: []\n---\n\n# Main\n[[missing-page]] and [[another-missing]]\n",
     );
-    const content = readFile(join(wikiDir, "wiki", "concepts", "main.md"));
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "concepts", "main.md"));
     expect(content).toContain("[[missing-page]]");
     expect(content).toContain("[[another-missing]]");
-    expect(existsSync(join(wikiDir, "wiki", "entities", "missing-page.md"))).toBe(false);
-    expect(existsSync(join(wikiDir, "wiki", "concepts", "missing-page.md"))).toBe(false);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "entities", "missing-page.md"))).toBe(false);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "concepts", "missing-page.md"))).toBe(false);
   });
 });
 
@@ -681,19 +690,19 @@ describe("configuration", () => {
 
   it("should accept personal mode config", () => {
     createConfig(wikiDir, { wiki: { mode: "personal", topic: "Learning" } });
-    const config = readFile(join(wikiDir, "config.yaml"));
+    const config = readFile(join(wikiDir, ".llm-wiki", "config.yaml"));
     expect(config).toContain("mode: personal");
   });
 
   it("should accept company mode config", () => {
     createConfig(wikiDir, { wiki: { mode: "company", topic: "Competitors" } });
-    const config = readFile(join(wikiDir, "config.yaml"));
+    const config = readFile(join(wikiDir, ".llm-wiki", "config.yaml"));
     expect(config).toContain("mode: company");
   });
 
   it("should support company mode with change detection pages", () => {
     createConfig(wikiDir, { wiki: { mode: "company", topic: "Market" }, change_detection: true });
-    const config = readFile(join(wikiDir, "config.yaml"));
+    const config = readFile(join(wikiDir, ".llm-wiki", "config.yaml"));
     expect(config).toContain("mode: company");
 
     createWikiPage(
@@ -702,26 +711,111 @@ describe("configuration", () => {
       "competitor-2026-04-27.md",
       "---\ntype: change\nentity: competitor\ndetected: 2026-04-27\n---\n\n# Change\nPricing changed from $99 to $149.\n",
     );
-    expect(existsSync(join(wikiDir, "wiki", "changes", "competitor-2026-04-27.md"))).toBe(true);
-    const content = readFile(join(wikiDir, "wiki", "changes", "competitor-2026-04-27.md"));
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "changes", "competitor-2026-04-27.md"))).toBe(true);
+    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "changes", "competitor-2026-04-27.md"));
     expect(content).toContain("type: change");
     expect(content).toContain("Pricing changed");
   });
 
   it("should track discovery history", () => {
-    const history = { processed: [{ path: "raw/articles/a.md", ingested: "2026-04-27" }] };
-    writeFileSync(join(wikiDir, ".discoveries", "history.json"), JSON.stringify(history));
-    const content = JSON.parse(readFile(join(wikiDir, ".discoveries", "history.json")));
+    const history = { processed: [{ path: ".llm-wiki/raw/articles/a.md", ingested: "2026-04-27" }] };
+    writeFileSync(join(wikiDir, ".llm-wiki", ".discoveries", "history.json"), JSON.stringify(history));
+    const content = JSON.parse(readFile(join(wikiDir, ".llm-wiki", ".discoveries", "history.json")));
     expect(content.processed).toHaveLength(1);
-    expect(content.processed[0].path).toBe("raw/articles/a.md");
+    expect(content.processed[0].path).toBe(".llm-wiki/raw/articles/a.md");
   });
 
   it("should track knowledge gaps", () => {
     const gaps = { gaps: [{ topic: "reinforcement learning", priority: "high" }] };
-    writeFileSync(join(wikiDir, ".discoveries", "gaps.json"), JSON.stringify(gaps));
-    const content = JSON.parse(readFile(join(wikiDir, ".discoveries", "gaps.json")));
+    writeFileSync(join(wikiDir, ".llm-wiki", ".discoveries", "gaps.json"), JSON.stringify(gaps));
+    const content = JSON.parse(readFile(join(wikiDir, ".llm-wiki", ".discoveries", "gaps.json")));
     expect(content.gaps).toHaveLength(1);
     expect(content.gaps[0].priority).toBe("high");
+  });
+});
+
+// ─── Backward Compatibility Tests ──────────────────────
+
+describe("backward compatibility", () => {
+  let wikiDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `pi-llm-wiki-bc-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    wikiDir = createWikiRoot();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should detect new-format vault by .llm-wiki/config.json", () => {
+    const configDir = join(wikiDir, ".llm-wiki");
+    writeFileSync(
+      join(configDir, "config.json"),
+      JSON.stringify({ topic: "Test", mode: "personal" }),
+    );
+    expect(detectVaultFormat(wikiDir)).toBe("new");
+  });
+
+  it("should detect legacy-format vault by .wiki/config.json", () => {
+    const oldDir = join(wikiDir, ".wiki");
+    mkdirSync(oldDir, { recursive: true });
+    writeFileSync(
+      join(oldDir, "config.json"),
+      JSON.stringify({ topic: "Legacy", mode: "personal" }),
+    );
+    expect(detectVaultFormat(wikiDir)).toBe("legacy");
+  });
+
+  it("should resolve paths for legacy vaults via getLegacyVaultPaths", () => {
+    const oldDir = join(wikiDir, ".wiki");
+    mkdirSync(oldDir, { recursive: true });
+    writeFileSync(
+      join(oldDir, "config.json"),
+      JSON.stringify({ topic: "Legacy", mode: "personal" }),
+    );
+
+    // Create some legacy-style content
+    mkdirSync(join(wikiDir, "raw", "sources"), { recursive: true });
+    mkdirSync(join(wikiDir, "wiki", "concepts"), { recursive: true });
+    mkdirSync(join(wikiDir, "meta"), { recursive: true });
+
+    const paths = getLegacyVaultPaths(wikiDir);
+    expect(paths.raw).toBe(join(wikiDir, "raw"));
+    expect(paths.wiki).toBe(join(wikiDir, "wiki"));
+    expect(paths.meta).toBe(join(wikiDir, "meta"));
+    expect(paths.rawSources).toBe(join(wikiDir, "raw", "sources"));
+    expect(paths.dotWiki).toBe(join(wikiDir, ".wiki"));
+
+    // Verify the content is at the old paths
+    expect(existsSync(join(wikiDir, "raw", "sources"))).toBe(true);
+    expect(existsSync(join(wikiDir, "wiki", "concepts"))).toBe(true);
+  });
+
+  it("should auto-detect legacy vault via resolveVaultPaths", () => {
+    const oldDir = join(wikiDir, ".wiki");
+    mkdirSync(oldDir, { recursive: true });
+    writeFileSync(
+      join(oldDir, "config.json"),
+      JSON.stringify({ topic: "Legacy", mode: "personal" }),
+    );
+
+    mkdirSync(join(wikiDir, "raw", "sources"), { recursive: true });
+    mkdirSync(join(wikiDir, "wiki", "concepts"), { recursive: true });
+
+    const paths = resolveVaultPaths(wikiDir);
+
+    // Should detect legacy format and return old paths
+    expect(paths.raw).toBe(join(wikiDir, "raw"));
+    expect(paths.wiki).toBe(join(wikiDir, "wiki"));
+    // But resolveVaultRoot should still find the vault
+    expect(paths.dotWiki).toBe(join(wikiDir, ".wiki"));
+  });
+
+  it("should detect no vault", () => {
+    // Directory with no sentinel files
+    expect(detectVaultFormat(wikiDir)).toBe("none");
   });
 });
 
@@ -750,7 +844,7 @@ describe("wiki recall", () => {
   ) {
     const folder = id.includes("/") ? id.split("/")[0] : "concepts";
     const name = id.includes("/") ? id.split("/").pop()! : id;
-    const pagePath = join(wikiDir, "wiki", folder, `${name}.md`);
+    const pagePath = join(wikiDir, ".llm-wiki", "wiki", folder, `${name}.md`);
     const relId = `${folder}/${name}`;
 
     writeFileSync(
@@ -895,10 +989,10 @@ describe("wiki retro", () => {
     const paths = getVaultPaths(wikiDir);
     ensureVaultStructure(paths);
     // Create minimal vault marker
-    const dotWiki = join(wikiDir, ".wiki");
-    mkdirSync(dotWiki, { recursive: true });
+    const llmWiki = join(wikiDir, ".llm-wiki");
+    mkdirSync(llmWiki, { recursive: true });
     writeFileSync(
-      join(dotWiki, "config.json"),
+      join(llmWiki, "config.json"),
       JSON.stringify({ topic: "Test", mode: "personal" }),
     );
   });
@@ -920,8 +1014,8 @@ describe("wiki retro", () => {
     );
 
     expect(result.sourceId).toMatch(/^SRC-/);
-    expect(result.packetPath).toContain("raw/sources/");
-    expect(result.sourcePagePath).toContain("wiki/sources/");
+    expect(result.packetPath).toContain(".llm-wiki/raw/sources/");
+    expect(result.sourcePagePath).toContain(".llm-wiki/wiki/sources/");
 
     // Manifest exists
     const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));

--- a/test/llm-wiki.test.ts
+++ b/test/llm-wiki.test.ts
@@ -614,7 +614,10 @@ describe("wiki directory structure", () => {
   });
 
   it("should append to LOG.md", () => {
-    writeFileSync(join(wikiDir, ".llm-wiki", "wiki", "LOG.md"), "## [2026-04-27] ingest | 3 pages\n");
+    writeFileSync(
+      join(wikiDir, ".llm-wiki", "wiki", "LOG.md"),
+      "## [2026-04-27] ingest | 3 pages\n",
+    );
     const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "LOG.md"));
     expect(content).toContain("ingest");
     expect(content).toContain("3 pages");
@@ -668,8 +671,12 @@ describe("cross-reference integrity", () => {
     const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "concepts", "main.md"));
     expect(content).toContain("[[missing-page]]");
     expect(content).toContain("[[another-missing]]");
-    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "entities", "missing-page.md"))).toBe(false);
-    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "concepts", "missing-page.md"))).toBe(false);
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "entities", "missing-page.md"))).toBe(
+      false,
+    );
+    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "concepts", "missing-page.md"))).toBe(
+      false,
+    );
   });
 });
 
@@ -711,16 +718,27 @@ describe("configuration", () => {
       "competitor-2026-04-27.md",
       "---\ntype: change\nentity: competitor\ndetected: 2026-04-27\n---\n\n# Change\nPricing changed from $99 to $149.\n",
     );
-    expect(existsSync(join(wikiDir, ".llm-wiki", "wiki", "changes", "competitor-2026-04-27.md"))).toBe(true);
-    const content = readFile(join(wikiDir, ".llm-wiki", "wiki", "changes", "competitor-2026-04-27.md"));
+    expect(
+      existsSync(join(wikiDir, ".llm-wiki", "wiki", "changes", "competitor-2026-04-27.md")),
+    ).toBe(true);
+    const content = readFile(
+      join(wikiDir, ".llm-wiki", "wiki", "changes", "competitor-2026-04-27.md"),
+    );
     expect(content).toContain("type: change");
     expect(content).toContain("Pricing changed");
   });
 
   it("should track discovery history", () => {
-    const history = { processed: [{ path: ".llm-wiki/raw/articles/a.md", ingested: "2026-04-27" }] };
-    writeFileSync(join(wikiDir, ".llm-wiki", ".discoveries", "history.json"), JSON.stringify(history));
-    const content = JSON.parse(readFile(join(wikiDir, ".llm-wiki", ".discoveries", "history.json")));
+    const history = {
+      processed: [{ path: ".llm-wiki/raw/articles/a.md", ingested: "2026-04-27" }],
+    };
+    writeFileSync(
+      join(wikiDir, ".llm-wiki", ".discoveries", "history.json"),
+      JSON.stringify(history),
+    );
+    const content = JSON.parse(
+      readFile(join(wikiDir, ".llm-wiki", ".discoveries", "history.json")),
+    );
     expect(content.processed).toHaveLength(1);
     expect(content.processed[0].path).toBe(".llm-wiki/raw/articles/a.md");
   });


### PR DESCRIPTION
## Summary

Closes #22. Moves all wiki vault content from repo root into a single `.llm-wiki/` subdirectory. Old vaults (with `.wiki/config.json`) are auto-detected and continue to work.

## Why

When the wiki lives inside a larger code repo, having `raw/`, `wiki/`, `meta/`, `.wiki/`, `outputs/`, `.discoveries/` all at the project root creates clutter and risks directory name collisions.

## New layout

```
repo_root/
└── .llm-wiki/
    ├── config.json            ← Vault sentinel (was .wiki/config.json)
    ├── templates/             ← Page templates (was .wiki/templates/)
    ├── raw/sources/           ← Immutable source packets
    ├── wiki/                  ← Editable knowledge pages
    ├── meta/                  ← Auto-generated metadata
    ├── outputs/               ← Generated artifacts
    └── .discoveries/          ← Discovery tracking
```

## Backward compatibility

- `detectVaultFormat()` returns `"new"`, `"legacy"`, or `"none"`
- `resolveVaultPaths()` auto-detects format and returns correct paths
- Old `.wiki/config.json` sentinel still detected by `resolveVaultRoot()`

## Migration

```bash
node scripts/migrate-llm-wiki.js --dry-run   # preview
node scripts/migrate-llm-wiki.js             # execute
```

## Changes

25 files changed, +895/-297 lines. All 55 tests pass + 5 new backward compat tests.