### PR TITLE
Wiki commands respect .gitignore when scanning directories

### DIFF
--- a/prompts/wiki-ingest.md
+++ b/prompts/wiki-ingest.md
@@ -19,7 +19,7 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand th
 
 1. Read `.llm-wiki/config.yaml` and `.llm-wiki/.discoveries/history.json`
 2. If a specific path is given (e.g., `/wiki-ingest .llm-wiki/raw/articles/my-file.md`), process just that file
-3. If no path given, scan all files in `.llm-wiki/raw/` and find ones not in history
+3. If no path given, scan all files in `.llm-wiki/raw/` (respecting `.gitignore` — skip any matched files) and find ones not in history
 4. For each new source:
    a. Read the full content
    b. Briefly discuss with the user: "This is about [topic]. Key points: [summary]. Any specific emphasis?"

--- a/prompts/wiki-lint.md
+++ b/prompts/wiki-lint.md
@@ -17,7 +17,7 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand th
 
 ## Steps
 
-1. Scan all files in `.llm-wiki/wiki/`
+1. Scan all files in `.llm-wiki/wiki/` (respecting `.gitignore` — skip any matched files)
 2. Check for:
    - **Contradictions:** Conflicting claims between pages
    - **Orphans:** Pages with zero inbound `[[wikilinks]]`

--- a/prompts/wiki-status.md
+++ b/prompts/wiki-status.md
@@ -11,8 +11,8 @@ Show a quick overview of wiki health and statistics.
 
 ## Steps
 
-1. Count sources in `.llm-wiki/raw/` (recursive)
-2. Count pages in `.llm-wiki/wiki/` (by type: entities, concepts, sources, syntheses)
+1. Count sources in `.llm-wiki/raw/` (recursive, respecting `.gitignore`)
+2. Count pages in `.llm-wiki/wiki/` (by type: entities, concepts, sources, syntheses, respecting `.gitignore`)
 3. Check `.llm-wiki/wiki/LOG.md` for last ingest, lint, and discover dates
 4. Check for orphan pages (zero inbound links)
 5. Read `.llm-wiki/.discoveries/gaps.json` for known gaps


### PR DESCRIPTION
## Summary

Closes #24. When wiki prompt templates tell the LLM to scan directories (for ingest, lint, or status), they now instruct the LLM to skip any files matched by `.gitignore`.

## Changes

| Template | Step | Change |
|----------|------|--------|
| `wiki-ingest.md` | 3 — scan `raw/` for new sources | Added `(respecting .gitignore — skip any matched files)` |
| `wiki-lint.md` | 1 — scan `wiki/` for pages | Added `(respecting .gitignore — skip any matched files)` |
| `wiki-status.md` | 1-2 — count sources/pages | Added `(respecting .gitignore)` to both count steps |

## Rationale

The extension tools (`wiki_ingest`, `wiki_lint`) operate on fixed structured paths under `.llm-wiki/` and don't scan arbitrary user directories. The `.gitignore` awareness is best placed in the prompt templates where the LLM is instructed to scan — the LLM can read `.gitignore` and skip matched files naturally.

## Testing

- `npx biome check .` — clean
- `npx vitest run` — 55/55 pass
- 3 prompt template files changed, 4 insertions, 4 deletions
