### PR TITLE
fix(contracts): update README and add /wiki-retro slash command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Instructions for AI agents working on this codebase.
 ## File Layout
 
 ```
-├── extensions/llm-wiki/     # TypeScript extension (10 tools + guardrails)
+├── extensions/llm-wiki/     # TypeScript extension (12 tools + guardrails)
 │   ├── index.ts             # Entry point
 │   └── lib/                 # tools.ts, metadata.ts, guardrails.ts, utils.ts, source-packet.ts
 ├── skills/llm-wiki/         # SKILL.md + templates

--- a/README.md
+++ b/README.md
@@ -84,9 +84,15 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 
 | Command | Description |
 |---------|-------------|
+| `/wiki-init <topic>` | Initialize a new LLM Wiki vault |
+| `/wiki-ingest [path]` | Process new source files and update the wiki |
+| `/wiki-query <question>` | Ask questions against the wiki with citations |
+| `/wiki-discover [--topic <topic>]` | Auto-discover new sources from the web |
+| `/wiki-run [--schedule daily\|weekly]` | Full cycle: discover → ingest → lint |
+| `/wiki-lint [--fix]` | Health check (orphans, contradictions, gaps) |
 | `/wiki-status` | Show a concise operational summary |
-| `/wiki-lint [mode]` | Run mechanical lint (`all`, `links`, `orphans`, `frontmatter`, `duplicates`, `coverage`, `staleness`) |
-| `/wiki-rebuild` | Force a full metadata rebuild |
+| `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
+| `/wiki-retro` | Save atomic insights from completed tasks |
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,15 +12,18 @@
 | `/wiki-run`      | Full cycle (discover → ingest → lint) |
 | `/wiki-status`   | Show wiki health                      |
 | `/wiki-digest`   | Daily/weekly summary                  |
+| `/wiki-retro`    | Save atomic insights from tasks        |
 
 ## Extension Tools
 
-The extension registers 10 tools the LLM can call directly:
+The extension registers 12 tools the LLM can call directly:
 
 | Tool                  | Purpose                                     |
 | --------------------- | ------------------------------------------- |
 | `wiki_bootstrap`      | Initialize a new vault                      |
 | `wiki_capture_source` | Capture URL/file/text into immutable packet |
+| `wiki_recall`         | 🔄 Auto-called at turn start — search wiki  |
+| `wiki_retro`          | Save atomic insights from completed tasks   |
 | `wiki_ingest`         | Get batch of uningested sources             |
 | `wiki_ensure_page`    | Create canonical page from template         |
 | `wiki_search`         | Search the wiki registry                    |

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -51,7 +51,7 @@ export default function (pi: ExtensionAPI) {
   installGuardrails(pi);
 
   pi.on("session_start", async (_event, ctx) => {
-    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (11 tools, auto-recall active)");
+    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (12 tools, auto-recall active)");
   });
 
   // ─── Auto-recall hook ──────────────────────────────

--- a/prompts/wiki-retro.md
+++ b/prompts/wiki-retro.md
@@ -1,0 +1,34 @@
+---
+description: Save an atomic insight from the current task into the wiki. Creates a source packet and source page for future auto-recall.
+argument-hint: "<title> [--category <category>]"
+section: LLM Wiki
+topLevelCli: true
+---
+
+# /wiki-retro
+
+Save an atomic insight from a completed task into the wiki.
+
+Captures what you learned as an immutable source packet + wiki source page so that `wiki_recall` automatically surfaces it in future sessions.
+
+## User Arguments
+
+$ARGUMENTS
+
+Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand the wiki conventions.
+
+## Steps
+
+1. Identify the key insight(s) from the current task — non-obvious learnings, patterns, or decisions worth preserving
+2. For each insight, call `wiki_retro` with:
+   - `slug`: unique kebab-case identifier (e.g., `jwt-revocation-pattern`)
+   - `title`: short descriptive phrase, ≤60 chars, noun phrase not a sentence
+   - `body`: markdown explanation with `[[wikilinks]]` to related wiki pages
+   - `category`: optional (frontend, architecture, devops, bugfix, design, etc.)
+3. Confirm the insight was saved and will be auto-surfaced in future sessions
+4. If the insight relates to existing wiki pages, update those pages with cross-references
+
+**Rules:**
+- One atomic insight per `wiki_retro` call. Use multiple calls for multiple insights.
+- Don't save obvious things. Save non-obvious patterns, tradeoffs, and design decisions.
+- Always add `[[wikilinks]]` to connect the new insight with existing wiki knowledge.

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-wiki
-description: Build and maintain a persistent, interlinked Obsidian-compatible markdown wiki using Karpathy's LLM Wiki pattern. Extension-backed with auto-generated metadata, guardrails, and 10 custom tools.
+description: Build and maintain a persistent, interlinked Obsidian-compatible markdown wiki using Karpathy's LLM Wiki pattern. Extension-backed with auto-generated metadata, guardrails, and 12 custom tools.
 ---
 
 # LLM Wiki for Pi


### PR DESCRIPTION
## Summary

Fixes #26 and #27 in one shot.

### Changes for #26 — Update contracts in README.md

**Problem:** The README Slash Commands table only listed 3 of 8 actual slash commands, and listed `/wiki-rebuild` which has no prompt file. The tool count in docs/commands.md was stuck at 10 (missing wiki_recall and wiki_retro).

**Fix:**
- README Slash Commands: expanded from 3 → 9 entries (all 8 existing + new wiki-retro)
- Removed phantom `/wiki-rebuild` entry (no prompt file exists)
- `docs/commands.md`: tool table now shows 12 tools (was 10)
- `SKILL.md`: description updated from "10 custom tools" → "12 custom tools"
- `AGENTS.md`: updated from "10 tools" → "12 tools"
- `extensions/index.ts`: status bar from "11 tools" → "12 tools"

### Changes for #27 — Add /wiki-retro command

**Problem:** `wiki_retro` tool existed but had no slash command prompt, while all other popular tools did.

**Fix:** Created `prompts/wiki-retro.md` following the established pattern (frontmatter + user-arg hints + steps).

### What I did NOT do (by design):
- Did NOT create a `/wiki-rebuild` prompt — it is a rare tool call, and the extension auto-rebuilds metadata anyway
- Issue #28 is a feature design proposal, not a documentation bug — left a CTO comment with architectural guidance instead

## Files changed

| File | Change |
|------|--------|
| `README.md` | Updated Slash Commands table (3→9) |
| `docs/commands.md` | Updated tool count (10→12), added wiki-retro to slash table |
| `skills/llm-wiki/SKILL.md` | "10 custom tools" → "12 custom tools" |
| `AGENTS.md` | "10 tools" → "12 tools" |
| `extensions/llm-wiki/index.ts` | "11 tools" → "12 tools" |
| `prompts/wiki-retro.md` | New file — /wiki-retro slash command