### PR TITLE
feat: add wiki/requirements/ page type and /wiki-req slash command

### DIFF
--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -102,6 +102,7 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
         "- **concept** — ideas, patterns, frameworks",
         "- **synthesis** — cross-source theses and tensions",
         "- **analysis** — durable filed answers from queries",
+        "- **requirement** — atomic requirements with status, priority, and traceability",
         "",
         "## Linking Style",
         "",
@@ -368,7 +369,9 @@ export function registerWikiEnsurePage(pi: ExtensionAPI): void {
       "Search existing pages first with wiki_search.",
     ],
     parameters: Type.Object({
-      type: Type.String({ description: "Page type: entity | concept | synthesis | analysis" }),
+      type: Type.String({
+        description: "Page type: entity | concept | synthesis | analysis | requirement",
+      }),
       title: Type.String({ description: "Page title" }),
       content: Type.Optional(
         Type.String({ description: "Optional initial content (otherwise uses template)" }),
@@ -398,6 +401,7 @@ export function registerWikiEnsurePage(pi: ExtensionAPI): void {
         concept: "concepts",
         synthesis: "syntheses",
         analysis: "analyses",
+        requirement: "requirements",
       };
       const folder = folderMap[type] || "concepts";
       const pagePath = join(paths.wiki, folder, `${slug}.md`);
@@ -465,6 +469,43 @@ function buildPageTemplate(
       "[Description to be filled]",
       "Durable answer from a query.\n\n## Question\n\n[Original question]",
     );
+  }
+  if (type === "requirement") {
+    return [
+      "---",
+      "type: requirement",
+      `created: ${date}`,
+      `updated: ${date}`,
+      "status: draft",
+      "priority: p2",
+      "source_id: ",
+      "depends_on: []",
+      "---",
+      "",
+      `# ${title}`,
+      "",
+      "## Description",
+      "",
+      "[Clear description of what this requirement entails]",
+      "",
+      "## Acceptance Criteria",
+      "",
+      "- [ ] [Criterion 1]",
+      "- [ ] [Criterion 2]",
+      "",
+      "## Dependencies",
+      "",
+      "_Pages this requirement depends on._",
+      "",
+      "## Implementation Notes",
+      "",
+      "[Optional notes]",
+      "",
+      "## Sources",
+      "",
+      "- [[sources/SRC-...]] — original concept capture",
+      "",
+    ].join("\n");
   }
   return base;
 }

--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -97,6 +97,7 @@ export function ensureVaultStructure(paths: VaultPaths): void {
     join(paths.wiki, "concepts"),
     join(paths.wiki, "syntheses"),
     join(paths.wiki, "analyses"),
+    join(paths.wiki, "requirements"),
     paths.meta,
     paths.dotWiki,
     paths.outputs,

--- a/prompts/wiki-req.md
+++ b/prompts/wiki-req.md
@@ -1,0 +1,55 @@
+---
+description: Capture and decompose a concept into atomic, traceable wiki requirements. Clarifies ambiguous requirements, splits them into atomic pieces, and persists them as wiki/requirements/ pages with status tracking.
+argument-hint: "<concept description>"
+section: LLM Wiki
+topLevelCli: true
+---
+
+# /wiki-req
+
+Capture a concept and decompose it into atomic, traceable requirements in the wiki.
+
+Transforms natural language descriptions into structured `wiki/requirements/` pages, preserving the original clarified concept as an immutable source packet in `raw/sources/`.
+
+## User Arguments
+
+$ARGUMENTS
+
+Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand the wiki conventions, architecture, and page type rules.
+
+## Steps
+
+1. **Clarify the concept**
+   - Discuss with the user: unpack ambiguous terms, surfaces implicit assumptions, identify scope boundaries
+   - Ask targeted questions to resolve unknowns (e.g., "Which providers?", "What's the fallback behavior?", "Who are the actors?")
+   - Reach mutual clarity before proceeding
+
+2. **Capture the clarified concept**
+   - Call `wiki_capture_source(text=...)` with the clarified conversation as markdown
+   - This creates an immutable record in `raw/sources/SRC-YYYY-MM-DD-NNN/`
+   - The source captures the original intent verbatim — no interpretation, no decomposition
+
+3. **Decompose into atomic requirements**
+   - Break the clarified concept into the smallest meaningful units of functionality
+   - Each requirement should represent one independently verifiable behavior
+   - For each atomic requirement, call `wiki_ensure_page(type="requirement", title="...", content="...")` where content includes:
+     - `type: requirement` and `status: draft` in frontmatter
+     - A clear `## Description` section
+     - `## Acceptance Criteria` as a checkbox list (the threshold for "done")
+     - `source_id` linking back to the source capture
+     - `depends_on` linking to any prerequisite requirements
+     - `[[wikilinks]]` to relevant entities, concepts, and other wiki pages
+   - Set priority based on user input: `p0` (blocking), `p1` (critical), `p2` (important), `p3` (nice-to-have)
+
+4. **Cross-link and finalize**
+   - Ensure each requirement page has bidirectional wikilinks to related pages
+   - Update any existing entity or concept pages that these requirements reference
+   - Report the results: how many requirements created, their priorities, and the source capture ID
+
+**Rules:**
+- One atomic requirement per `wiki_ensure_page` call — each must be independently testable
+- Always capture the clarified concept first via `wiki_capture_source` before decomposing
+- Requirements live in `wiki/requirements/` — they are editable wiki pages, not immutable sources
+- Use status values: `draft` → `clarified` → `active` → `implemented` → `deferred` → `rejected`
+- Use priority values: `p0` (blocking), `p1` (critical), `p2` (important), `p3` (nice-to-have)
+- Do not create requirements in `raw/` — that layer is for external source artifacts only


### PR DESCRIPTION
## Summary

Implements a new `wiki/requirements/` page type and `/wiki-req` slash command for capturing, clarifying, and decomposing requirements as first-class wiki entities.

This is the implementation of the architecture discussed in [issue #28](https://github.com/zosmaai/pi-llm-wiki/issues/28) — requirements live in the editable `wiki/` layer (not `raw/`), following the same patterns as entities, concepts, syntheses, and analyses.

## Changes

### New page type: `requirement`
- **`extensions/llm-wiki/lib/utils.ts`** — `ensureVaultStructure()` now creates `wiki/requirements/` directory
- **`extensions/llm-wiki/lib/tools.ts`** — `buildPageTemplate()` supports `type: "requirement"` with frontmatter (status, priority, source_id, depends_on) and structured sections (Description, Acceptance Criteria, Dependencies, Implementation Notes, Sources)
- **`extensions/llm-wiki/lib/tools.ts`** — `folderMap` in `registerWikiEnsurePage()` maps `requirement → requirements/`
- **`extensions/llm-wiki/lib/tools.ts`** — Bootstrap schema lists requirement as a recognized page type

### New slash command: `/wiki-req`
- **`prompts/wiki-req.md`** — Guides the clarify → capture → decompose → persist workflow:
  1. Clarify the concept with the user (unpack ambiguities)
  2. Capture the clarified concept via `wiki_capture_source(text=...)` into `raw/sources/`
  3. Decompose into atomic requirements via `wiki_ensure_page(type="requirement", ...)`
  4. Cross-link requirements to sources, entities, and concepts

## Design Principles
- Requirements are **editable wiki pages** (in `wiki/`), not immutable raw artifacts
- They support a lifecycle: `draft → clarified → active → implemented → deferred → rejected`
- Priority: `p0` (blocking), `p1` (critical), `p2` (important), `p3` (nice-to-have)
- Each requirement links back to its source capture via `source_id`
- Dependency tracking via `depends_on` frontmatter
- Full wiki integration: auto-recall, backlinks, lint, and metadata rebuild all work out of the box

## Verification
- ✅ `npm run lint` — clean
- ✅ `npm run typecheck` — clean
- ✅ `npm test` — all 55 tests pass
- ✅ `git diff` — 3 files changed, 98 insertions, 1 deletion