### PR TITLE
feat: auto-bootstrap prompt + dormant status indicator

### DIFF
--- a/docs/plans/auto-bootstrap-plan.md
+++ b/docs/plans/auto-bootstrap-plan.md
@@ -1,0 +1,46 @@
+# Auto-Bootstrap Plan
+
+## Changes (3 files)
+
+### 1. `extensions/llm-wiki/index.ts`
+
+**session_start hook** — Show correct status based on vault existence:
+```typescript
+pi.on("session_start", async (_event, ctx) => {
+  const paths = resolveVaultPaths(process.cwd());
+  if (!existsSync(join(paths.dotWiki, "config.json"))) {
+    ctx.ui.setStatus("llm-wiki", "📝 No wiki — call wiki_bootstrap to enable");
+    return;
+  }
+  ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (12 tools, auto-recall active)");
+});
+```
+
+**before_agent_start hook** — When no wiki exists on first turn, inject a system prompt hint so the LLM knows to suggest bootstrapping:
+```typescript
+pi.on("before_agent_start", async (event, _ctx) => {
+  const paths = resolveVaultPaths(process.cwd());
+  if (!existsSync(join(paths.dotWiki, "config.json"))) {
+    return {
+      systemPrompt: `${event.systemPrompt}\n\n📝 No LLM Wiki found in this directory. On your first response, use ask_user to offer the user creating one via wiki_bootstrap. After suggesting once, do not repeat.`
+    };
+  }
+  // ... existing recall logic unchanged
+});
+```
+
+### 2. `extensions/llm-wiki/lib/recall.ts`
+
+**wiki_recall tool** — Improve error message when no vault exists to hint at bootstrap:
+```typescript
+// Current: "No wiki vault found at this location. Initialize one with wiki_bootstrap first."
+// Keep as-is but add isError flag for model to react
+```
+
+### 3. `skills/llm-wiki/SKILL.md`
+
+Add a section about what to do when no wiki exists — tell the model to proactively suggest bootstrapping using `ask_user`.
+
+## Not in scope (separate issue)
+
+- Migration script shipping — bcdiaconu's feedback from #22, needs its own focused PR

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -34,6 +34,9 @@ import { resolveVaultPaths } from "./lib/utils.js";
  * - wiki_recall tool available for explicit deep searches
  */
 
+// Track whether we already suggested bootstrapping this session
+let bootstrapSuggested = false;
+
 export default function (pi: ExtensionAPI) {
   registerWikiBootstrap(pi);
   registerWikiCaptureSource(pi);
@@ -51,6 +54,12 @@ export default function (pi: ExtensionAPI) {
   installGuardrails(pi);
 
   pi.on("session_start", async (_event, ctx) => {
+    bootstrapSuggested = false;
+    const paths = resolveVaultPaths(process.cwd());
+    if (!existsSync(join(paths.dotWiki, "config.json"))) {
+      ctx.ui.setStatus("llm-wiki", "📝 No wiki — call wiki_bootstrap to enable");
+      return;
+    }
     ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (12 tools, auto-recall active)");
   });
 
@@ -60,7 +69,14 @@ export default function (pi: ExtensionAPI) {
   pi.on("before_agent_start", async (event, _ctx) => {
     const paths = resolveVaultPaths(process.cwd());
     if (!existsSync(join(paths.dotWiki, "config.json"))) {
-      return; // No wiki vault — nothing to recall
+      // No wiki — suggest bootstrap on first turn only
+      if (!bootstrapSuggested) {
+        bootstrapSuggested = true;
+        return {
+          systemPrompt: `${event.systemPrompt}\n\n📝 No LLM Wiki found in this directory. On your first response, use ask_user to offer the user creating one via wiki_bootstrap. After suggesting once, do not repeat.`,
+        };
+      }
+      return;
     }
 
     const prompt = event.prompt || "";

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -81,6 +81,14 @@ wiki_recall(query="specific terms...", max_results=10)
 
 This gives you more control over the search terms and returns content previews.
 
+### No Wiki Yet
+
+If the extension injects a "No LLM Wiki found" hint, use `ask_user` to offer creating one:
+
+> "No LLM Wiki found in this directory. Would you like to create one? It gives you a linked knowledge base with automatic recall."
+
+If the user agrees, call `wiki_bootstrap(topic="...", mode="personal")`. Suggest only once per session.
+
 ## Available Tools
 
 Use these directly — they handle scaffolding, bookkeeping, recall, and capture:

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -206,4 +206,13 @@ describe("wiki recall", () => {
   it("should return empty string for empty results", () => {
     expect(formatRecallContext([])).toBe("");
   });
+
+  it("should return empty results when no vault exists", () => {
+    const emptyDir = join(tmpDir, "no-vault");
+    mkdirSync(emptyDir, { recursive: true });
+    const paths = getVaultPaths(emptyDir);
+    // No config.json means no vault — search should handle gracefully
+    const results = searchWiki(paths, "anything");
+    expect(results).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Problem

The extension registers 12 tools and installs hooks, but when no wiki vault exists it **silently does nothing** — the user has zero visibility that the feature is dormant. A user can install the extension, use pi for months, and never know wiki recall is off.

See [#33](https://github.com/zosmaai/pi-llm-wiki/issues/33) for full discussion.

## Changes

### `extensions/llm-wiki/index.ts`
- **session_start hook**: Shows "📝 No wiki — call wiki_bootstrap to enable" when no vault exists (instead of always showing "active")
- **before_agent_start hook**: On first turn without a wiki, injects a system prompt hint telling the model to use `ask_user` to offer creating one
- **Per-session tracking**: Suggests bootstrap only once per session via `bootstrapSuggested` flag

### `skills/llm-wiki/SKILL.md`
- Added "No Wiki Yet" section teaching the model to proactively suggest bootstrapping with `ask_user`

### `test/recall.test.ts`
- Added test: `searchWiki` returns empty results when no vault exists

## Behavior After This PR

| Before | After |
|--------|-------|
| Status always says "active" even with no wiki | Shows "📝 No wiki" when dormant |
| Auto-recall silently skips | Model is prompted to suggest bootstrap on first turn |
| User never knows feature exists | Clear status + proactive suggestion |

## How It Works

User opens pi from \`~/\` → sees "No wiki" status → model offers to create one → calls \`wiki_bootstrap\` → \`.llm-wiki/\` created in cwd → auto-recall activates.

No architectural change needed — the extension already uses \`process.cwd()\` as vault root.

Fixes #33