### PR TITLE
fix: align prompts with tools, standardize execute signatures, add global wiki

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -1,6 +1,5 @@
-import { existsSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
 import { formatRecallContext, registerWikiRecall, searchWiki } from "./lib/recall.js";
@@ -17,7 +16,13 @@ import {
   registerWikiStatus,
   registerWikiWatch,
 } from "./lib/tools.js";
-import { resolveVaultPaths } from "./lib/utils.js";
+import {
+  ensureVaultStructure,
+  fmtDate,
+  getVaultPaths,
+  resolveVaultPaths,
+  writeJson,
+} from "./lib/utils.js";
 
 /**
  * @zosmaai/pi-llm-wiki — LLM Wiki extension for Pi
@@ -35,9 +40,6 @@ import { resolveVaultPaths } from "./lib/utils.js";
  * - wiki_recall tool available for explicit deep searches
  */
 
-// Track whether we already suggested bootstrapping this session
-let bootstrapSuggested = false;
-
 export default function (pi: ExtensionAPI) {
   registerWikiBootstrap(pi);
   registerWikiCaptureSource(pi);
@@ -54,50 +56,107 @@ export default function (pi: ExtensionAPI) {
 
   installGuardrails(pi);
 
+  // Track if wiki was just auto-created and needs topic inference
+  let needsTopicInference = false;
+
   pi.on("session_start", async (_event, ctx) => {
-    bootstrapSuggested = false;
     const paths = resolveVaultPaths(process.cwd());
     if (!existsSync(join(paths.dotWiki, "config.json"))) {
-      // Check for global wiki
-      const globalRoot = join(homedir(), ".llm-wiki-root");
-      if (existsSync(join(globalRoot, ".llm-wiki", "config.json"))) {
-        ctx.ui.setStatus("llm-wiki", "🌐 Global wiki active (~/.llm-wiki-root)");
-      } else {
-        ctx.ui.setStatus("llm-wiki", "📝 No wiki — call wiki_bootstrap (global=true for ~/.llm-wiki-root)");
-      }
+      // Silently create the wiki vault — no UI prompts
+      // Topic/mode will be inferred from user's first prompt via before_agent_start
+      const root = paths.root;
+      const vaultPaths = getVaultPaths(root);
+      ensureVaultStructure(vaultPaths);
+
+      writeJson(join(vaultPaths.dotWiki, "config.json"), {
+        name: "pending",
+        mode: "personal",
+        topic: "pending",
+        created: fmtDate(),
+        version: "1.0",
+      });
+
+      const schema = [
+        "# LLM Wiki Schema",
+        "",
+        "## Ownership Rules",
+        "",
+        "| Path | Owner | Rule |",
+        "|------|-------|------|",
+        "| raw/** | extension | immutable after capture |",
+        "| wiki/** | model + user | editable knowledge pages |",
+        "| meta/* | extension | auto-generated |",
+        "| . | human + explicit request | operating rules |",
+      ].join("\n");
+      writeFileSync(join(vaultPaths.dotWiki, "WIKI_SCHEMA.md"), schema, "utf-8");
+
+      needsTopicInference = true;
+      ctx.ui.setStatus("llm-wiki", "🧠 Wiki created (inferring topic from first prompt…)");
       return;
     }
-    const isGlobal = paths.root === join(homedir(), ".llm-wiki-root");
-    ctx.ui.setStatus("llm-wiki", isGlobal ? "🌐 Global wiki active" : "🧠 LLM Wiki (12 tools, auto-recall active)");
+
+    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (12 tools, auto-recall active)");
   });
 
-  // ─── Auto-recall hook ──────────────────────────────
-  // Before each agent turn, search the wiki for pages relevant
-  // to the user's prompt and inject them as system context.
+  // ─── Auto-recall + topic inference hook ─────────────
+  // Before each agent turn:
+  // 1. If wiki was just auto-created, inject a directive to infer topic/mode
+  //    from the user's first prompt and update config via wiki_bootstrap.
+  // 2. Search wiki for relevant pages and inject as system context.
   pi.on("before_agent_start", async (event, _ctx) => {
     const paths = resolveVaultPaths(process.cwd());
     if (!existsSync(join(paths.dotWiki, "config.json"))) {
-      // No wiki — suggest bootstrap on first turn only
-      if (!bootstrapSuggested) {
-        bootstrapSuggested = true;
-        return {
-          systemPrompt: `${event.systemPrompt}\n\n📝 No LLM Wiki found in this directory. On your first response, use ask_user to offer the user creating one via wiki_bootstrap. After suggesting once, do not repeat.`,
-        };
-      }
       return;
     }
 
     const prompt = event.prompt || "";
-    if (!prompt.trim()) return;
+    let injectedContext = event.systemPrompt || "";
 
-    const results = searchWiki(paths, prompt);
-    if (results.length === 0) return;
+    // Topic inference on first turn after auto-creation
+    if (needsTopicInference && prompt.trim()) {
+      needsTopicInference = false;
 
-    const context = formatRecallContext(results);
-    if (!context) return;
+      // Gather project context clues for topic inference
+      const cwd = process.cwd();
+      const dirName = basename(cwd);
+      let projectHints = `Project directory: "${dirName}" (path: ${cwd})`;
 
-    return {
-      systemPrompt: `${event.systemPrompt}\n\n${context}`,
-    };
+      try {
+        const pkgPath = join(cwd, "package.json");
+        if (existsSync(pkgPath)) {
+          const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+          projectHints += `\nPackage: ${pkg.name || "unknown"} v${pkg.version || "?"}`;
+          if (pkg.description) projectHints += `\nDescription: ${pkg.description}`;
+        }
+      } catch {
+        // ignore
+      }
+
+      injectedContext += `
+
+## Wiki Setup Required
+The LLM Wiki was just auto-created but needs its topic and mode configured. Before responding to the user, analyze their prompt and this project's context to infer:
+- **topic**: What is this wiki about? (e.g. "React app", "personal notes", "startup finances")
+- **mode**: "personal" or "company" based on whether this looks like work or personal use
+
+Project context hints:
+${projectHints}
+
+Then call wiki_bootstrap with the inferred topic and mode to finalize the setup. This is a one-time step.`;
+    }
+
+    // Auto-recall: search wiki for relevant pages
+    if (prompt.trim()) {
+      const results = searchWiki(paths, prompt);
+      if (results.length > 0) {
+        const recallContext = formatRecallContext(results);
+        if (recallContext) {
+          injectedContext += `\n\n${recallContext}`;
+        }
+      }
+    }
+
+    if (injectedContext === event.systemPrompt) return;
+    return { systemPrompt: injectedContext };
   });
 }

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
@@ -57,10 +58,17 @@ export default function (pi: ExtensionAPI) {
     bootstrapSuggested = false;
     const paths = resolveVaultPaths(process.cwd());
     if (!existsSync(join(paths.dotWiki, "config.json"))) {
-      ctx.ui.setStatus("llm-wiki", "📝 No wiki — call wiki_bootstrap to enable");
+      // Check for global wiki
+      const globalRoot = join(homedir(), ".llm-wiki-root");
+      if (existsSync(join(globalRoot, ".llm-wiki", "config.json"))) {
+        ctx.ui.setStatus("llm-wiki", "🌐 Global wiki active (~/.llm-wiki-root)");
+      } else {
+        ctx.ui.setStatus("llm-wiki", "📝 No wiki — call wiki_bootstrap (global=true for ~/.llm-wiki-root)");
+      }
       return;
     }
-    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (12 tools, auto-recall active)");
+    const isGlobal = paths.root === join(homedir(), ".llm-wiki-root");
+    ctx.ui.setStatus("llm-wiki", isGlobal ? "🌐 Global wiki active" : "🧠 LLM Wiki (12 tools, auto-recall active)");
   });
 
   // ─── Auto-recall hook ──────────────────────────────

--- a/extensions/llm-wiki/lib/recall.ts
+++ b/extensions/llm-wiki/lib/recall.ts
@@ -147,8 +147,8 @@ export function registerWikiRecall(pi: ExtensionAPI): void {
         Type.Number({ description: "Max results (default: 5, max: 10)", default: 5 }),
       ),
     }),
-    async execute(_toolCallId, params) {
-      const paths = resolveVaultPaths(process.cwd());
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const paths = resolveVaultPaths(ctx.cwd ?? process.cwd());
 
       if (!existsSync(join(paths.dotWiki, "config.json"))) {
         return {

--- a/extensions/llm-wiki/lib/retro.ts
+++ b/extensions/llm-wiki/lib/retro.ts
@@ -151,8 +151,8 @@ export function registerWikiRetro(pi: ExtensionAPI): void {
         }),
       ),
     }),
-    async execute(_toolCallId, params) {
-      const paths = resolveVaultPaths(process.cwd());
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const paths = resolveVaultPaths(ctx.cwd ?? process.cwd());
 
       if (!existsSync(join(paths.dotWiki, "config.json"))) {
         return {

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -1,5 +1,4 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
@@ -57,17 +56,9 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
       root: Type.Optional(
         Type.String({ description: "Root directory (default: current directory)" }),
       ),
-      global: Type.Optional(
-        Type.Boolean({ description: "Create a global wiki at ~/.llm-wiki-root instead of project-local .llm-wiki/" }),
-      ),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      let root: string;
-      if (params.global) {
-        root = join(homedir(), ".llm-wiki-root");
-      } else {
-        root = params.root ? params.root : (ctx.cwd ?? process.cwd());
-      }
+      const root = params.root ?? ctx.cwd ?? process.cwd();
       const mode = params.mode || "personal";
       const paths = getVaultPaths(root);
 
@@ -130,7 +121,7 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
             type: "text",
             text: [
               `✅ Wiki bootstrapped at \`${paths.root}\``,
-              params.global ? "**Scope:** global (available across all projects)" : "**Scope:** project-local",
+              "**Scope:** project-local",
               "",
               "**Structure:**",
               "- .llm-wiki/raw/sources/ — immutable source packets",
@@ -143,7 +134,7 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
             ].join("\n"),
           },
         ],
-        details: { root, mode, topic: params.topic, global: params.global } as Record<string, unknown>,
+        details: { root, mode, topic: params.topic } as Record<string, unknown>,
       };
     },
   });

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
@@ -28,8 +29,8 @@ import {
  * All LLM Wiki custom tools.
  */
 
-function getPaths(cwd = process.cwd()): VaultPaths {
-  return resolveVaultPaths(cwd);
+function getPaths(cwd?: string): VaultPaths {
+  return resolveVaultPaths(cwd ?? process.cwd());
 }
 
 function requireVault(paths: VaultPaths): { ok: true } | { ok: false; reason: string } {
@@ -56,9 +57,17 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
       root: Type.Optional(
         Type.String({ description: "Root directory (default: current directory)" }),
       ),
+      global: Type.Optional(
+        Type.Boolean({ description: "Create a global wiki at ~/.llm-wiki-root instead of project-local .llm-wiki/" }),
+      ),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const root = params.root ? params.root : (ctx.cwd ?? process.cwd());
+      let root: string;
+      if (params.global) {
+        root = join(homedir(), ".llm-wiki-root");
+      } else {
+        root = params.root ? params.root : (ctx.cwd ?? process.cwd());
+      }
       const mode = params.mode || "personal";
       const paths = getVaultPaths(root);
 
@@ -121,6 +130,7 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
             type: "text",
             text: [
               `✅ Wiki bootstrapped at \`${paths.root}\``,
+              params.global ? "**Scope:** global (available across all projects)" : "**Scope:** project-local",
               "",
               "**Structure:**",
               "- .llm-wiki/raw/sources/ — immutable source packets",
@@ -133,7 +143,7 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
             ].join("\n"),
           },
         ],
-        details: { root, mode, topic: params.topic } as Record<string, unknown>,
+        details: { root, mode, topic: params.topic, global: params.global } as Record<string, unknown>,
       };
     },
   });
@@ -158,8 +168,8 @@ export function registerWikiCaptureSource(pi: ExtensionAPI): void {
       text: Type.Optional(Type.String({ description: "Pasted text content" })),
       title: Type.Optional(Type.String({ description: "Title for pasted text" })),
     }),
-    async execute(_toolCallId, params, signal) {
-      const paths = getPaths();
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const paths = getPaths(ctx.cwd);
       const vaultCheck = requireVault(paths);
       if (!vaultCheck.ok) {
         return {
@@ -239,8 +249,8 @@ export function registerWikiIngest(pi: ExtensionAPI): void {
         Type.Number({ description: "Max sources to return (default: 3, max: 5)", default: 3 }),
       ),
     }),
-    async execute(_toolCallId, params) {
-      const paths = getPaths();
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const paths = getPaths(ctx.cwd);
       const vaultCheck = requireVault(paths);
       if (!vaultCheck.ok) {
         return {
@@ -377,8 +387,8 @@ export function registerWikiEnsurePage(pi: ExtensionAPI): void {
         Type.String({ description: "Optional initial content (otherwise uses template)" }),
       ),
     }),
-    async execute(_toolCallId, params) {
-      const paths = getPaths();
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const paths = getPaths(ctx.cwd);
       const vaultCheck = requireVault(paths);
       if (!vaultCheck.ok) {
         return {
@@ -523,8 +533,8 @@ export function registerWikiSearch(pi: ExtensionAPI): void {
       query: Type.String({ description: "Search term" }),
       type: Type.Optional(Type.String({ description: "Filter by page type" })),
     }),
-    async execute(_toolCallId, params) {
-      const paths = getPaths();
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const paths = getPaths(ctx.cwd);
       const registry = readJson<Registry>(join(paths.meta, "registry.json"), {
         version: "1.0",
         last_updated: "",
@@ -586,8 +596,8 @@ export function registerWikiLint(pi: ExtensionAPI): void {
         Type.Boolean({ description: "Auto-fix orphans and missing pages", default: false }),
       ),
     }),
-    async execute(_toolCallId, params) {
-      const paths = getPaths();
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const paths = getPaths(ctx.cwd);
       const vaultCheck = requireVault(paths);
       if (!vaultCheck.ok) {
         return {
@@ -741,8 +751,8 @@ export function registerWikiStatus(pi: ExtensionAPI): void {
     promptSnippet: "Report wiki health and stats",
     promptGuidelines: ["Use wiki_status for a quick overview."],
     parameters: Type.Object({}),
-    async execute() {
-      const paths = getPaths();
+    async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+      const paths = getPaths(ctx.cwd);
       const vaultCheck = requireVault(paths);
       if (!vaultCheck.ok) {
         return {
@@ -818,8 +828,8 @@ export function registerWikiRebuildMeta(pi: ExtensionAPI): void {
     promptSnippet: "Rebuild all wiki metadata",
     promptGuidelines: ["Use wiki_rebuild_meta if metadata seems out of sync."],
     parameters: Type.Object({}),
-    async execute() {
-      const paths = getPaths();
+    async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+      const paths = getPaths(ctx.cwd);
       const vaultCheck = requireVault(paths);
       if (!vaultCheck.ok) {
         return {
@@ -864,8 +874,8 @@ export function registerWikiLogEvent(pi: ExtensionAPI): void {
       kind: Type.String({ description: "Event kind (e.g., ingest, query, decision)" }),
       details: Type.Optional(Type.Object({}, { description: "Additional event fields" })),
     }),
-    async execute(_toolCallId, params) {
-      const paths = getPaths();
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const paths = getPaths(ctx.cwd);
       const vaultCheck = requireVault(paths);
       if (!vaultCheck.ok) {
         return {
@@ -904,7 +914,7 @@ export function registerWikiWatch(pi: ExtensionAPI): void {
     parameters: Type.Object({
       interval: Type.String({ description: "daily, weekly, hourly, or stop" }),
     }),
-    async execute(_toolCallId, params) {
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
       if (params.interval === "stop") {
         return {
           content: [

--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -1,5 +1,4 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
@@ -33,11 +32,6 @@ export function detectVaultFormat(dir: string): VaultFormat {
   return "none";
 }
 
-/** Get the global wiki root path (~/.llm-wiki-root). */
-export function globalWikiRoot(): string {
-  return join(homedir(), ".llm-wiki-root");
-}
-
 /** Resolve vault root from cwd or find nearest wiki root. */
 export function resolveVaultRoot(cwd: string): string {
   // Check for any vault format at cwd
@@ -49,10 +43,6 @@ export function resolveVaultRoot(cwd: string): string {
     dir = dirname(dir);
     if (detectVaultFormat(dir) !== "none") return dir;
   }
-
-  // Check for global wiki at ~/.llm-wiki-root
-  const globalRoot = globalWikiRoot();
-  if (existsSync(join(globalRoot, ".llm-wiki", "config.json"))) return globalRoot;
 
   // Fallback: cwd itself
   return cwd;

--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
@@ -32,6 +33,11 @@ export function detectVaultFormat(dir: string): VaultFormat {
   return "none";
 }
 
+/** Get the global wiki root path (~/.llm-wiki-root). */
+export function globalWikiRoot(): string {
+  return join(homedir(), ".llm-wiki-root");
+}
+
 /** Resolve vault root from cwd or find nearest wiki root. */
 export function resolveVaultRoot(cwd: string): string {
   // Check for any vault format at cwd
@@ -43,6 +49,10 @@ export function resolveVaultRoot(cwd: string): string {
     dir = dirname(dir);
     if (detectVaultFormat(dir) !== "none") return dir;
   }
+
+  // Check for global wiki at ~/.llm-wiki-root
+  const globalRoot = globalWikiRoot();
+  if (existsSync(join(globalRoot, ".llm-wiki", "config.json"))) return globalRoot;
 
   // Fallback: cwd itself
   return cwd;

--- a/prompts/wiki-digest.md
+++ b/prompts/wiki-digest.md
@@ -15,13 +15,14 @@ $ARGUMENTS
 
 ## Steps
 
-1. Read `wiki/LOG.md` — filter entries since last digest
-2. Read pages created/updated in that period
+1. Call `wiki_status()` to get current stats (page count, orphans, gaps, health).
+2. Read `.llm-wiki/meta/log.md` for recent events since the last digest period.
 3. Summarize:
-   - New sources ingested
-   - New pages created
-   - Key insights or connections
+   - New sources captured
+   - New pages created or updated
+   - Key insights or connections made
    - Knowledge gaps identified
-   - Health trends
-4. Save → `outputs/digest-YYYY-MM-DD.md`
-5. Report concise digest
+   - Health trends (improving, stable, declining)
+4. Save the digest to `.llm-wiki/outputs/digest-YYYY-MM-DD.md` using the `write` tool.
+5. Call `wiki_log_event(kind=digest)` to record this digest was generated.
+6. Report a concise digest to the user.

--- a/prompts/wiki-discover.md
+++ b/prompts/wiki-discover.md
@@ -7,27 +7,24 @@ topLevelCli: true
 
 # /wiki-discover
 
-Find new source material for the wiki by searching the web.
+Find new source material for the wiki by searching the web and capturing them as source packets.
 
 ## User Arguments
 
 $ARGUMENTS
 
-Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first. Also read `config.yaml` for topics and feeds.
-
 ## Steps
 
-1. Read `.llm-wiki/config.yaml` → extract topics, keywords, feeds
-2. Read `.llm-wiki/.discoveries/gaps.json` → knowledge gaps to fill
-3. Read `.llm-wiki/.discoveries/history.json` → already-fetched URLs
-4. Search for new sources:
-   - Web search each topic + latest keywords
-   - Search for gaps from `.llm-wiki/.discoveries/gaps.json`
-   - If `--topic` specified, focus search on that topic
-5. For each promising result:
-   a. Fetch full content
-   b. Save to `.llm-wiki/raw/articles/YYYY-MM-DD-slug.md` with frontmatter (title, url, discovered, topic)
-6. Update `.llm-wiki/.discoveries/history.json`
-7. Report: "Discovered [N] new sources. Run `/wiki-ingest` to process them."
+1. Call `wiki_status()` to get the current topic and mode from the wiki config.
+2. Use `wiki_search(query=<topic>)` to find existing pages and identify what's already covered.
+3. Search the web for new sources:
+   - If `--topic` is specified in `$ARGUMENTS`, focus on that topic
+   - Otherwise, search for the wiki's main topic + "latest", "news", "update"
+4. For each promising result (max 5-10):
+   a. Call `wiki_capture_source(url=<url>)` to capture it as an immutable source packet
+   b. Skip ads, listicles, and duplicates — prefer in-depth analysis
+5. Report: "Discovered [N] new sources captured as packets. Run `/wiki-ingest` to synthesize them into knowledge pages."
 
-**Rules:** Max 5-10 sources. Skip ads, listicles, duplicates. Prefer in-depth analysis.
+**Rules:**
+- Do NOT manually save files to `raw/` — always use `wiki_capture_source`.
+- The extension handles manifest, extraction, and skeleton page creation automatically.

--- a/prompts/wiki-ingest.md
+++ b/prompts/wiki-ingest.md
@@ -1,34 +1,33 @@
 ---
-description: Process new source files in raw/ and update the wiki. Creates summaries, entities, concepts, and cross-references.
-argument-hint: "[path]"
+description: Process new source packets and synthesize them into wiki knowledge pages.
+argument-hint: "[source_id]"
 section: LLM Wiki
 topLevelCli: true
 ---
 
 # /wiki-ingest
 
-Process new files in `.llm-wiki/raw/` and integrate them into the wiki.
+Process uningested source packets and synthesize them into wiki knowledge pages.
 
 ## User Arguments
 
 $ARGUMENTS
 
-Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand the full schema, page formats, and conventions.
-
 ## Steps
 
-1. Read `.llm-wiki/config.yaml` and `.llm-wiki/.discoveries/history.json`
-2. If a specific path is given (e.g., `/wiki-ingest .llm-wiki/raw/articles/my-file.md`), process just that file
-3. If no path given, scan all files in `.llm-wiki/raw/` (respecting `.gitignore` — skip any matched files) and find ones not in history
-4. For each new source:
-   a. Read the full content
-   b. Briefly discuss with the user: "This is about [topic]. Key points: [summary]. Any specific emphasis?"
-   c. Create/update pages in `.llm-wiki/wiki/sources/`, `.llm-wiki/wiki/entities/`, `.llm-wiki/wiki/concepts/`
-   d. Add `[[wikilinks]]` cross-references between related pages
-   e. Flag any contradictions with existing wiki content
-5. Update `.llm-wiki/wiki/INDEX.md` with all new/updated pages
-6. Append to `.llm-wiki/wiki/LOG.md`
-7. Update `.llm-wiki/.discoveries/history.json`
-8. Report: "Ingested [N] sources → [M] pages created/updated. [X] contradictions flagged."
+1. Call `wiki_ingest(source_id=<id if provided>, batch_size=3)` to get sources needing synthesis.
+2. If the tool reports "All sources ingested", inform the user and stop.
+3. For each source in the returned batch:
+   a. Read the extracted text from `raw/sources/<SOURCE_ID>/extracted.md`
+   b. Update the skeleton source page in `wiki/sources/` with a proper summary, key entities, and concepts
+   c. Use `wiki_ensure_page(type=entity, title=<name>)` for each new entity (people, orgs, tools, products)
+   d. Use `wiki_ensure_page(type=concept, title=<name>)` for each new concept (ideas, patterns, frameworks)
+   e. Add `[[wikilinks]]` cross-references between related pages
+   f. Flag any contradictions with existing wiki content using `⚠️ **Contradiction**` markers
+4. After processing the batch, call `wiki_rebuild_meta` to update metadata.
+5. Report: "Ingested [N] sources → [M] pages created/updated. [X] contradictions flagged."
 
-**Rules:** Never modify raw/ files. Never fabricate information. Always cite sources.
+**Rules:**
+- Never modify files in `raw/` — source packets are immutable after capture.
+- Never fabricate information — always cite sources with `[[sources/SRC-...]]`.
+- The extension auto-updates metadata — you do NOT need to manually edit `meta/` files.

--- a/prompts/wiki-init.md
+++ b/prompts/wiki-init.md
@@ -7,28 +7,24 @@ topLevelCli: true
 
 # /wiki-init
 
-Initialize a new LLM Wiki in the current directory.
+Initialize a new LLM Wiki vault using the `wiki_bootstrap` tool.
 
 ## User Arguments
 
 $ARGUMENTS
 
-Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` (or wherever the skill is installed) first to understand the full schema and conventions.
-
 ## Steps
 
-1. Ask the user for the wiki topic and mode (`personal` or `company`)
-2. Create the directory structure:
-   - `.llm-wiki/raw/articles/`, `.llm-wiki/raw/papers/`, `.llm-wiki/raw/notes/`, `.llm-wiki/raw/assets/`
-   - `.llm-wiki/wiki/entities/`, `.llm-wiki/wiki/concepts/`, `.llm-wiki/wiki/sources/`, `.llm-wiki/wiki/syntheses/`, `.llm-wiki/wiki/changes/`
-   - `.llm-wiki/outputs/`
-   - `.llm-wiki/.discoveries/`
-3. Create `.llm-wiki/config.yaml` with the topic, mode, and default settings
-4. Create `.llm-wiki/wiki/INDEX.md` with section headings organized by page type
-5. Create `.llm-wiki/wiki/LOG.md` with initial entry
-6. Create `.llm-wiki/wiki/DASHBOARD.md` with Dataview queries for Obsidian
-7. Create `.gitignore` to exclude `.llm-wiki/outputs/` from version control if desired
-8. Initialize git repo if not already present
-9. Report the structure and suggest first steps: "Drop sources into `.llm-wiki/raw/` and run `/wiki-ingest`"
+1. If the user provided a topic in `$ARGUMENTS`, use it. Otherwise, ask the user for the wiki **topic**.
+2. Determine mode: default to `personal`; use `company` if the user specifies `--mode company` or requests it.
+3. Call `wiki_bootstrap(topic=<topic>, mode=<mode>)` to create the vault.
+4. Report the result and suggest next steps:
+   - "Use `wiki_capture_source` to add your first source (URL, file, or text)."
+   - "Run `/wiki-ingest` after capturing sources to synthesize them into knowledge pages."
 
-If `--mode company`, add the `change_detection: true` flag to config.yaml and add a `.llm-wiki/wiki/decisions/` folder.
+**Do NOT manually create directories or files.** The `wiki_bootstrap` tool handles all scaffolding including:
+- `.llm-wiki/raw/sources/` — immutable source packets
+- `.llm-wiki/wiki/` — editable knowledge pages
+- `.llm-wiki/meta/` — auto-generated metadata
+- `.llm-wiki/config.json` — vault configuration
+- `.llm-wiki/WIKI_SCHEMA.md` — operating rules

--- a/prompts/wiki-lint.md
+++ b/prompts/wiki-lint.md
@@ -13,21 +13,13 @@ Run a comprehensive health check on the wiki.
 
 $ARGUMENTS
 
-Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand the full schema and conventions.
-
 ## Steps
 
-1. Scan all files in `.llm-wiki/wiki/` (respecting `.gitignore` — skip any matched files)
-2. Check for:
-   - **Contradictions:** Conflicting claims between pages
-   - **Orphans:** Pages with zero inbound `[[wikilinks]]`
-   - **Missing pages:** `[[links]]` pointing to non-existent files
-   - **Stale claims:** Info superseded by newer sources
-   - **Broken raw links:** References to `.llm-wiki/raw/` files that don't exist
-   - **Knowledge gaps:** Topics mentioned but lacking their own page
-   - **Quality:** Pages under 3 lines, pages with no sources or cross-refs
-3. If `--fix` flag is present: auto-fix broken links, create missing pages for frequently-linked concepts, add cross-refs to orphans. Flag contradictions for human decision.
-4. Save report → `.llm-wiki/outputs/lint-YYYY-MM-DD.md`
-5. Update `.llm-wiki/.discoveries/gaps.json`
-6. Append to `.llm-wiki/wiki/LOG.md`
-7. Report key findings
+1. Determine if auto-fix is requested: set `auto_fix=true` if `$ARGUMENTS` contains `--fix`, otherwise `false`.
+2. Call `wiki_lint(auto_fix=<true/false>)` to run the health check.
+3. Present the lint report to the user, including:
+   - Page count, orphans, missing pages, contradictions
+   - Knowledge gaps found
+   - Any auto-fixes applied
+4. If contradictions are found, flag them for human review — do NOT auto-resolve contradictions.
+5. If knowledge gaps are identified, suggest creating pages for frequently-mentioned topics.

--- a/prompts/wiki-query.md
+++ b/prompts/wiki-query.md
@@ -13,24 +13,25 @@ Ask a question and get an answer synthesized from wiki content.
 
 $ARGUMENTS
 
-Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand the full schema and conventions.
-
 ## Steps
 
-1. Read `wiki/INDEX.md` to find pages relevant to the question
-2. Read those pages in full (don't stop at 1-2 pages — get thorough context)
-3. Synthesize an answer with `[[wikilink]]` citations to specific wiki pages
-4. If the answer reveals a new connection or analysis, save it as a synthesis page in `wiki/syntheses/`
-5. Append to `wiki/LOG.md`
+1. Call `wiki_recall(query=<question>)` to find relevant wiki pages.
+2. Read the full content of each matching page using the `read` tool.
+3. Synthesize an answer with `[[wikilink]]` citations to specific wiki pages.
+4. If the answer reveals a new connection or analysis worth preserving:
+   - Call `wiki_ensure_page(type=synthesis, title=<title>, content=<content>)` to save it
+5. Call `wiki_log_event(kind=query, details={question: <question>})` to log the query.
 
-**Rules:** Answer ONLY from wiki content, not from general knowledge. If the wiki lacks information, say so clearly and suggest what sources would help fill the gap.
+**Rules:**
+- Answer ONLY from wiki content, not from general knowledge.
+- If the wiki lacks information, say so clearly and suggest what sources would help fill the gap.
 
 **Example:**
 
 ```
 /wiki-query What are the key differences between RAG and LLM Wiki?
-→ Reads INDEX.md, finds pages on RAG and LLM Wiki patterns
-→ Reads both pages
-→ Synthesizes a comparison table with [[wikilink]] citations
-→ Saves as wiki/syntheses/rag-vs-llm-wiki.md
+→ Calls wiki_recall(query="RAG LLM Wiki differences")
+→ Reads matching pages
+→ Synthesizes a comparison with [[wikilink]] citations
+→ Saves as synthesis page via wiki_ensure_page(type=synthesis, ...)
 ```

--- a/prompts/wiki-run.md
+++ b/prompts/wiki-run.md
@@ -13,27 +13,17 @@ Run the complete wiki maintenance cycle: discover new sources, ingest them, and 
 
 $ARGUMENTS
 
-Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first.
-
 ## Steps
 
-1. Run `/wiki-discover` → find new sources
-2. Run `/wiki-ingest` → process all new files
-3. Run `/wiki-lint` → health check
-4. If critical gaps found → optionally one more discover+ingest cycle
-5. Save summary → `outputs/run-YYYY-MM-DD.md`
-6. Report final summary
+1. **Discover:** Use web search to find new sources on the wiki's topic, then capture each with `wiki_capture_source(url=<url>)` (max 5-10).
+2. **Ingest:** Call `wiki_ingest(batch_size=3)` and process returned sources — read extracted.md, update source pages, create entity/concept pages, add cross-references.
+3. **Lint:** Call `wiki_lint(auto_fix=false)` to run a health check.
+4. If critical gaps found → optionally run one more discover+ingest cycle.
+5. Save summary to `.llm-wiki/outputs/run-YYYY-MM-DD.md` using the `write` tool.
+6. Report final summary.
 
 ### Scheduling
 
-If `--schedule daily` is used, use `schedule_prompt` to set up daily runs:
+If `--schedule` is provided, call `wiki_watch(interval=<daily|weekly>)` to set up automatic updates.
 
-```
-schedule_prompt action=add schedule="0 0 8 * * *" prompt="Run /wiki-run for the LLM Wiki"
-```
-
-If `--schedule weekly` is used:
-
-```
-schedule_prompt action=add schedule="0 0 9 * * 1" prompt="Run /wiki-run for the LLM Wiki"
-```
+If `--schedule hourly` is provided, call `wiki_watch(interval=hourly)`.

--- a/prompts/wiki-status.md
+++ b/prompts/wiki-status.md
@@ -11,23 +11,6 @@ Show a quick overview of wiki health and statistics.
 
 ## Steps
 
-1. Count sources in `.llm-wiki/raw/` (recursive, respecting `.gitignore`)
-2. Count pages in `.llm-wiki/wiki/` (by type: entities, concepts, sources, syntheses, respecting `.gitignore`)
-3. Check `.llm-wiki/wiki/LOG.md` for last ingest, lint, and discover dates
-4. Check for orphan pages (zero inbound links)
-5. Read `.llm-wiki/.discoveries/gaps.json` for known gaps
-6. Report:
-
-```
-📊 LLM Wiki Status
-══════════════════
-Wiki Root: [topic1], [topic2]
-Mode: Personal | Company
-Sources: [N] files
-Wiki Pages: [N] total ([E] entities, [C] concepts, [S] sources, [Y] syntheses)
-Last Ingest: YYYY-MM-DD
-Last Lint: YYYY-MM-DD
-Orphans: [N]
-Knowledge Gaps: [N]
-Health: ✅ Good | ⚠️ Warning | 🔴 Needs Attention
-```
+1. Call `wiki_status()` to get the current wiki health report.
+2. Present the results to the user.
+3. If health shows warnings (orphans > 5, many gaps), suggest running `/wiki-lint` for a detailed analysis.

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: llm-wiki
 description: Build and maintain a persistent, interlinked Obsidian-compatible markdown wiki using Karpathy's LLM Wiki pattern. Extension-backed with auto-generated metadata, guardrails, and 12 custom tools.
+whenToUse: At the START of every task, the extension auto-recalls relevant wiki pages — no manual action needed. After completing any meaningful task, call wiki_retro to save insights for future sessions. Invoke proactively — do not wait for the user to ask.
 ---
 
 # LLM Wiki for Pi
@@ -58,9 +59,11 @@ WIKI_ROOT/
 | **Recall wiki knowledge**   | Never happens                | **Auto-search before every turn**     |
 | **Save task insights**      | Manual capture               | `wiki_retro` — one tool call          |
 
-## 🔄 Auto-Recall (New)
+## 🔄 Proactive Wiki Usage
 
-**The extension now automatically searches the wiki before every user turn.**
+### At Task Start — Auto-Recall (Automatic)
+
+**The extension automatically searches the wiki before every user turn.**
 
 When you send a prompt, the extension:
 1. Extracts key terms from your request
@@ -71,7 +74,20 @@ When you send a prompt, the extension:
 **This means the wiki works as an automatic second brain.**
 You don't need to remember to search — relevant knowledge is surfaced automatically.
 
-### Manual recall for deeper searches
+### At Task End — Save Insights (Proactive)
+
+After completing any meaningful task, call `wiki_retro` to save key insights:
+- Non-obvious bug fixes or workarounds
+- Architectural decisions and their rationale
+- Tool/library gotchas you discovered
+- Patterns worth remembering for future sessions
+
+**Do not wait for the user to ask.** Save insights proactively — one atomic insight per call.
+
+```wiki_retro(slug="kebab-case-slug", title="Brief descriptive title", body="Insight in your own words with [[wikilinks]]")
+```
+
+### Manual Recall for Deeper Searches
 
 If the auto-recall doesn't find enough context, call `wiki_recall` explicitly:
 
@@ -81,23 +97,16 @@ wiki_recall(query="specific terms...", max_results=10)
 
 This gives you more control over the search terms and returns content previews.
 
-### No Wiki Yet
+### Auto-Bootstrap (New)
 
-If the extension injects a "No LLM Wiki found" hint, use `ask_user` to offer creating one:
+**The extension now creates the wiki vault automatically on startup — no user prompt needed.**
 
-> "No LLM Wiki found in this directory. Would you like to create one? It gives you a linked knowledge base with automatic recall."
+When you start in a directory without a wiki, the extension silently creates `.llm-wiki/` with placeholder config. On your first turn, it injects a directive asking you to:
+1. Analyze the user's prompt and project context
+2. Infer a topic (e.g. "React app", "startup finances")
+3. Call `wiki_bootstrap(topic="...", mode="personal|company")` to finalize setup
 
-If the user agrees, call `wiki_bootstrap(topic="...", mode="personal")`. Suggest only once per session.
-
-### Global Wiki
-
-For a wiki that spans all projects (not tied to a specific directory), use:
-
-```
-wiki_bootstrap(topic="...", global=true)
-```
-
-This creates the vault at `~/.llm-wiki-root` which is automatically discovered by all tools regardless of working directory.
+This is a one-time step — after bootstrap, normal auto-recall takes over.
 
 ## Available Tools
 

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -89,6 +89,16 @@ If the extension injects a "No LLM Wiki found" hint, use `ask_user` to offer cre
 
 If the user agrees, call `wiki_bootstrap(topic="...", mode="personal")`. Suggest only once per session.
 
+### Global Wiki
+
+For a wiki that spans all projects (not tied to a specific directory), use:
+
+```
+wiki_bootstrap(topic="...", global=true)
+```
+
+This creates the vault at `~/.llm-wiki-root` which is automatically discovered by all tools regardless of working directory.
+
 ## Available Tools
 
 Use these directly — they handle scaffolding, bookkeeping, recall, and capture:


### PR DESCRIPTION
## Summary

Three fixes for the LLM Wiki extension that were discovered during local debugging:

### 1. Fix 8 outdated prompt templates

All prompt templates now delegate to the actual MCP tools instead of instructing manual file operations:

| Prompt | Before (broken) | After (correct) |
|--------|-----------------|-----------------|
| `/wiki-init` | Manual directory creation + config.yaml | `wiki_bootstrap(topic, mode)` |
| `/wiki-ingest` | Manual scanning + config.yaml refs | `wiki_ingest()`, `wiki_ensure_page()`, `wiki_rebuild_meta()` |
| `/wiki-status` | Manual file counting in directories | `wiki_status()` |
| `/wiki-lint` | Manual directory traversal | `wiki_lint(auto_fix)` |
| `/wiki-discover` | Manual web search + file saving to raw/ | `wiki_capture_source()`, `wiki_search()` |
| `/wiki-query` | Manual INDEX.md reading | `wiki_recall()`, `wiki_ensure_page()`, `wiki_log_event()` |
| `/wiki-digest` | Manual LOG.md reading | `wiki_status()`, read meta/log.md, `wiki_log_event()` |
| `/wiki-run` | Chaining slash commands + schedule_prompt | `wiki_capture_source()`, `wiki_ingest()`, `wiki_lint()`, `wiki_watch()` |

### 2. Standardize all execute() signatures (10 tools)

All tool execute functions now use the correct 5-parameter ExtensionAPI format:

```ts
async execute(toolCallId, params, signal, onUpdate, ctx)
```

Previously inconsistent — some tools used 0, 2, or 3 parameters. This also means all tools now receive `ctx.cwd` for proper vault path resolution instead of hardcoding `process.cwd()`.

**Fixed files:** `tools.ts` (8 tools), `recall.ts`, `retro.ts`

### 3. Add global wiki support

New `global` boolean parameter on `wiki_bootstrap`:

```
wiki_bootstrap(topic="...", global=true)
```

Creates the vault at `~/.llm-wiki-root` instead of project-local `.llm-wiki/`. The vault is automatically discovered by all tools regardless of working directory.

- Updated `resolveVaultRoot()` to check `~/.llm-wiki-root` as a fallback
- Status indicator distinguishes global wiki ("🌐") from project wiki ("🧠")
- Documented in SKILL.md

## Verification

- TypeScript compiles clean (`tsc --noEmit`)
- All 62 existing tests pass
