### PR TITLE
Fix retro related-links placeholder

### DIFF
--- a/extensions/llm-wiki/lib/retro.ts
+++ b/extensions/llm-wiki/lib/retro.ts
@@ -58,7 +58,7 @@ export function saveInsight(
     "",
     "## Related",
     "",
-    "_(Add [[wikilinks]] to related pages)_",
+    "_Add links to related pages._",
     "",
   ]
     .filter((l) => l !== "")

--- a/test/retro.test.ts
+++ b/test/retro.test.ts
@@ -73,6 +73,9 @@ describe("wiki retro", () => {
     expect(sourcePage).toContain("status: insight");
     expect(sourcePage).toContain("This is a test insight.");
     expect(sourcePage).toContain("category: devops");
+    expect(sourcePage).toContain("## Related");
+    expect(sourcePage).toContain("_Add links to related pages._");
+    expect(sourcePage).not.toContain("[[wikilinks]]");
   });
 
   it("should save an insight without a category", async () => {


### PR DESCRIPTION
## Summary

- replace the generated `wiki_retro` related-pages placeholder so it no longer contains a literal `[[wikilinks]]` target
- keep the `## Related` section with a plain-text placeholder for humans/LLMs to fill in later
- add a regression assertion that generated retro source pages use the safe placeholder and do not include `[[wikilinks]]`

Closes #41.

## Validation

- `npm run test -- test/retro.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
