### PR TITLE
fix: add relevance threshold for auto-injection, exclude personal vault

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -147,9 +147,17 @@ ${projectHints}
 Then call wiki_bootstrap with the inferred topic and mode to finalize the setup. This is a one-time step.`;
     }
 
-    // Layered recall: search personal + project vaults for relevant pages
+    // Auto-injection recall: search ONLY the project vault with a relevance
+    // threshold. Low-confidence matches are discarded to avoid context pollution.
+    // Personal vault is excluded — it contains cross-project pages that
+    // produce noise in unrelated sessions. Users can call wiki_recall
+    // explicitly for personal-vault searches.
     if (prompt.trim()) {
-      const results = searchWikiLayered(paths, prompt);
+      // minScore=5: requires at least a title/heading/alias/trigger match,
+      // or multiple body matches. This eliminates accidental body-only
+      // substring matches (e.g. a Tally page matching on common words).
+      // includePersonal=false: personal vault is excluded from auto-injection.
+      const results = searchWikiLayered(paths, prompt, 3, 5, false);
       if (results.length > 0) {
         const recallContext = formatRecallContext(results);
         if (recallContext) {

--- a/extensions/llm-wiki/lib/recall.ts
+++ b/extensions/llm-wiki/lib/recall.ts
@@ -27,6 +27,8 @@ export interface RecallResult {
   path: string;
   /** Vault source label for dual-vault results */
   vaultLabel?: string;
+  /** Relevance score (higher = better match). Used for filtering auto-injected results. */
+  score: number;
 }
 
 type Scored = { id: string; entry: Registry["pages"][string]; score: number; pagePath: string };
@@ -124,8 +126,14 @@ function pagePreview(content: string): string {
 /**
  * Search a single vault's registry for pages matching a query.
  * Returns up to `maxResults` matches, each with a content preview.
+ * Results below `minScore` are excluded (default 0 = no filtering).
  */
-export function searchWiki(paths: VaultPaths, query: string, maxResults = 5): RecallResult[] {
+export function searchWiki(
+  paths: VaultPaths,
+  query: string,
+  maxResults = 5,
+  minScore = 0,
+): RecallResult[] {
   const registry = readJson<Registry>(join(paths.meta, "registry.json"), {
     version: "1.0",
     last_updated: "",
@@ -184,9 +192,9 @@ export function searchWiki(paths: VaultPaths, query: string, maxResults = 5): Re
   }
 
   scored.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
-  const top = scored.slice(0, maxResults);
+  const top = scored.filter((s) => s.score >= minScore).slice(0, maxResults);
 
-  return top.map(({ id, entry, pagePath }) => {
+  return top.map(({ id, entry, pagePath, score }) => {
     let preview = "";
     if (existsSync(pagePath)) {
       preview = pagePreview(readFileSync(pagePath, "utf-8"));
@@ -198,6 +206,7 @@ export function searchWiki(paths: VaultPaths, query: string, maxResults = 5): Re
       type: String(entry.type || "page"),
       preview,
       path: pagePath,
+      score,
     };
   });
 }
@@ -205,23 +214,32 @@ export function searchWiki(paths: VaultPaths, query: string, maxResults = 5): Re
 /**
  * Search both project/primary vault and personal vault, merging results.
  * Personal results are appended after primary results, deduplicated by page ID.
+ *
+ * @param minScore - Minimum relevance score (default 0 = no filter).
+ * @param includePersonal - Whether to search the personal vault (default true).
+ *   Auto-injection should pass false to avoid personal-vault contamination.
  */
 export function searchWikiLayered(
   primaryPaths: VaultPaths,
   query: string,
   maxResults = 5,
+  minScore = 0,
+  includePersonal = true,
 ): RecallResult[] {
   // Search primary vault
-  const primaryResults = searchWiki(primaryPaths, query, maxResults);
+  const primaryResults = searchWiki(primaryPaths, query, maxResults, minScore);
 
   // If primary is already the personal vault, no layered search needed
   if (isPersonalVault(primaryPaths)) return primaryResults;
 
-  // Search personal vault as secondary layer
-  const personalPaths = getPersonalWikiPaths();
-  if (!existsSync(join(personalPaths.dotWiki, "config.json"))) return primaryResults;
-
-  const personalResults = searchWiki(personalPaths, query, maxResults);
+  // Search personal vault as secondary layer (only when explicitly requested)
+  let personalResults: RecallResult[] = [];
+  if (includePersonal) {
+    const personalPaths = getPersonalWikiPaths();
+    if (existsSync(join(personalPaths.dotWiki, "config.json"))) {
+      personalResults = searchWiki(personalPaths, query, maxResults, minScore);
+    }
+  }
 
   // Merge: personal results first (they're the user's accumulated knowledge),
   // then primary results (project-specific). Deduplicate by page ID.

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -251,6 +251,7 @@ describe("wiki recall", () => {
         type: "concept",
         preview: "Retrieval augmented generation is a technique.",
         path: "/tmp/wiki/concepts/rag.md",
+        score: 5,
       },
       {
         id: "entities/openai",
@@ -258,6 +259,7 @@ describe("wiki recall", () => {
         type: "entity",
         preview: "OpenAI is an AI research organization.",
         path: "/tmp/wiki/entities/openai.md",
+        score: 3,
       },
     ];
     const context = formatRecallContext(results);


### PR DESCRIPTION
## Problem

The auto-injection in `before_agent_start` was returning low-confidence matches from the personal vault, causing irrelevant context (e.g. Tally .1800 file pages in a session about a different topic) to be injected into the agent's system prompt on every turn. This polluted the context window and eroded user trust.

## Changes

1. **Add `score` field to `RecallResult` interface** — every search result now carries its relevance score
2. **Add `minScore` parameter to `searchWiki()` and `searchWikiLayered()`** — results below the threshold are filtered out
3. **Auto-injection uses `minScore=5`** — requires at least one title/heading/alias/trigger match, or multiple body matches. This eliminates accidental body-only substring matches.
4. **Auto-injection sets `includePersonal=false`** — personal vault (`~/.llm-wiki/`) is excluded from auto-injection since it contains cross-project pages that produce noise in unrelated sessions
5. **`wiki_recall` tool (explicit calls) retains full behavior** — users can still search both vaults with no threshold by calling `wiki_recall` directly