### PR TITLE
feat: add async observation system with wiki_observe tool

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
+import { registerObservationReminder, registerWikiObserve } from "./lib/observation.js";
 import { formatRecallContext, registerWikiRecall, searchWikiLayered } from "./lib/recall.js";
 import { registerWikiRetro } from "./lib/retro.js";
 import {
@@ -55,6 +56,8 @@ export default function (pi: ExtensionAPI) {
   registerWikiWatch(pi);
   registerWikiRecall(pi);
   registerWikiRetro(pi);
+  registerWikiObserve(pi);
+  registerObservationReminder(pi);
 
   installGuardrails(pi);
 
@@ -97,7 +100,7 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (12 tools, layered recall active)");
+    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (13 tools, observe + recall active)");
   });
 
   // ─── Layered recall + topic inference hook ──────────
@@ -169,7 +172,7 @@ Then call wiki_bootstrap with the inferred topic and mode to finalize the setup.
     // Always inject a visible wiki status footer, even when empty
     // This ensures the model knows the wiki is active and can use it
     injectedContext +=
-      "\n\n<wiki_status>LLM Wiki active — use wiki_recall for deeper search, wiki_retro to save new knowledge.</wiki_status>";
+      "\n\n<wiki_status>LLM Wiki active — use wiki_recall for deeper search, wiki_observe to record observations, wiki_retro to save insights.</wiki_status>";
 
     if (injectedContext === event.systemPrompt) return;
     return { systemPrompt: injectedContext };

--- a/extensions/llm-wiki/lib/observation.ts
+++ b/extensions/llm-wiki/lib/observation.ts
@@ -1,0 +1,290 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+import { appendEvent, rebuildMetadataLight } from "./metadata.js";
+import { type VaultPaths, fmtDate, resolveVaultPaths } from "./utils.js";
+
+// ─── Types ─────────────────────────────────────────────
+
+export interface ObservationInput {
+  /** Short descriptive title (≤80 chars) */
+  title: string;
+  /** The observation content — what happened, was decided, or was learned */
+  content: string;
+  /** Relevance level for retention priority */
+  relevance: "low" | "medium" | "high" | "critical";
+  /** Optional space-separated tags for categorization */
+  tags?: string;
+  /** Context: what was being worked on when this was observed */
+  source_context?: string;
+}
+
+export interface ObservationResult {
+  slug: string;
+  pagePath: string;
+}
+
+// ─── Save Observation ──────────────────────────────────
+
+const RELEVANCE_EMOJIS: Record<string, string> = {
+  low: "📝",
+  medium: "🔍",
+  high: "⭐",
+  critical: "🔴",
+};
+
+/**
+ * Save an observation as a wiki source page.
+ *
+ * Unlike wiki_retro (which saves atomic insights at task end),
+ * wiki_observe records timestamped observations during a session
+ * that can later be distilled into durable wiki pages.
+ *
+ * Observations are stored in wiki/sources/ with type: source and
+ * status: observation. They are searchable via wiki_recail.
+ */
+export function saveObservation(paths: VaultPaths, input: ObservationInput): ObservationResult {
+  const today = fmtDate();
+  const timestamp = new Date().toISOString();
+
+  // Generate a slug from title
+  const slugBase = input.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60);
+  const slug = `obs-${today}-${slugBase}`;
+
+  // Write to wiki/sources/{slug}.md
+  const sourcePageDir = join(paths.wiki, "sources");
+  mkdirSync(sourcePageDir, { recursive: true });
+  const pagePath = join(sourcePageDir, `${slug}.md`);
+
+  const relevanceEmoji = RELEVANCE_EMOJIS[input.relevance] ?? "📝";
+  const tags = input.tags ?? "";
+  const sourceContext = input.source_context ?? "";
+
+  const pageContent = [
+    "---",
+    "type: source",
+    `title: "Observation: ${input.title}"`,
+    `slug: ${slug}`,
+    "status: observation",
+    `created: ${today}`,
+    `updated: ${today}`,
+    `relevance: ${input.relevance}`,
+    `observed_at: ${timestamp}`,
+    tags
+      ? `tags: [${tags
+          .split(/\s+/)
+          .filter(Boolean)
+          .map((t) => `"${t}"`)
+          .join(", ")}]`
+      : "",
+    sourceContext ? `source_context: "${sourceContext}"` : "",
+    "---",
+    "",
+    `# ${relevanceEmoji} Observation: ${input.title}`,
+    "",
+    input.content,
+    "",
+    `*Relevance: ${input.relevance}*`,
+    sourceContext ? `\n*Context: ${sourceContext}*` : "",
+    tags ? `\n*Tags: ${tags}*` : "",
+    "",
+    "---",
+    `*Observed: ${timestamp}*`,
+    "",
+  ]
+    .filter((l) => l !== "")
+    .join("\n");
+  writeFileSync(pagePath, pageContent, "utf-8");
+
+  // Log event
+  appendEvent(paths, {
+    kind: "observe",
+    slug,
+    title: input.title,
+    relevance: input.relevance,
+  });
+
+  // Rebuild metadata so the observation is immediately searchable
+  rebuildMetadataLight(paths);
+
+  return { slug, pagePath };
+}
+
+// ─── Tool Registration ─────────────────────────────────
+
+/**
+ * Register the `wiki_observe` tool.
+ * The model calls this to record observations during a session.
+ * Observations are saved to the wiki and become searchable.
+ */
+export function registerWikiObserve(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "wiki_observe",
+    label: "Wiki Observe",
+    description:
+      "Record an atomic observation from the current session into the wiki. " +
+      "Observations are timestamped, relevance-rated facts about decisions made, " +
+      "findings discovered, constraints established, or work completed. " +
+      "Saved observations are searchable via wiki_recall and can later be " +
+      "distilled into durable wiki pages via wiki_ensure_page. " +
+      "Call this proactively after non-trivial work — every observation " +
+      "compounds the wiki's knowledge across sessions.",
+    promptSnippet: "Record an observation about the current work",
+    promptGuidelines: [
+      "Call wiki_observe after non-trivial decisions, discoveries, or completions.",
+      "One observation per call. Use multiple calls for multiple observations.",
+      "Rate relevance honestly — most observations are medium or low, not critical.",
+      "Observations compound across sessions via wiki_recail.",
+    ],
+    parameters: Type.Object({
+      title: Type.String({
+        description:
+          "Short descriptive title (≤80 chars). Noun phrase, not a sentence. " +
+          "Example: 'JWT auth middleware added' or 'Postgres migration constraint discovered'",
+      }),
+      content: Type.String({
+        description:
+          "The observation in plain prose. What happened, was decided, or was learned. " +
+          "Preserve specific details: file paths, function names, error messages, " +
+          "quantitative results. Example: 'User decided to use JWT with refresh tokens. " +
+          "Implementation at src/auth/jwt.ts. Tests passing.'",
+      }),
+      relevance: Type.Union(
+        [
+          Type.Literal("low"),
+          Type.Literal("medium"),
+          Type.Literal("high"),
+          Type.Literal("critical"),
+        ],
+        {
+          description:
+            "Relevance level: low (routine), medium (task context), " +
+            "high (non-trivial decisions/constraints), critical (user identity, " +
+            "persistent preferences, completed work that must not be redone). " +
+            "Default: medium. Be honest — most observations are medium or low.",
+        },
+      ),
+      tags: Type.Optional(
+        Type.String({
+          description:
+            "Optional space-separated tags for categorization. " +
+            "Example: 'auth backend migration'",
+        }),
+      ),
+      source_context: Type.Optional(
+        Type.String({
+          description:
+            "What was being worked on. Example: 'Adding authentication module' or 'Debugging login timeout'",
+        }),
+      ),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const paths = resolveVaultPaths(ctx.cwd ?? process.cwd());
+
+      if (!existsSync(join(paths.dotWiki, "config.json"))) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "No wiki vault found at this location. Initialize one with wiki_bootstrap first.",
+            },
+          ],
+          details: { error: "no_vault" } as Record<string, unknown>,
+          isError: true,
+        };
+      }
+
+      const result = saveObservation(paths, {
+        title: params.title,
+        content: params.content,
+        relevance: params.relevance,
+        tags: params.tags,
+        source_context: params.source_context,
+      });
+
+      const relevanceEmoji = RELEVANCE_EMOJIS[params.relevance] ?? "📝";
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: [
+              `${relevanceEmoji} **Observation saved**: ${params.title}`,
+              "",
+              `- Page: \`${result.pagePath}\``,
+              `- Relevance: ${params.relevance}`,
+              params.tags ? `- Tags: ${params.tags}` : "",
+              "",
+              "This observation is now searchable via wiki_recall. " +
+                "It will compound with future observations across sessions.",
+            ]
+              .filter((l) => l !== "")
+              .join("\n"),
+          },
+        ],
+        details: {
+          slug: result.slug,
+          title: params.title,
+          relevance: params.relevance,
+          tags: params.tags || null,
+        } as Record<string, unknown>,
+      };
+    },
+  });
+}
+
+// ─── Turn-End Reminder ─────────────────────────────────
+
+/**
+ * Track observation cadence and send turn-end reminders.
+ * After every N significant turns, reminds the model to call wiki_observe
+ * for non-trivial findings (same pattern as memex-retro reminders).
+ */
+export function registerObservationReminder(
+  pi: ExtensionAPI,
+  options?: { turnsBetweenReminders?: number },
+): void {
+  const REMINDER_INTERVAL = options?.turnsBetweenReminders ?? 5;
+  let turnsSinceLastReminder = 0;
+  let observeDoneThisSession = false;
+
+  pi.on("session_start", async () => {
+    turnsSinceLastReminder = 0;
+    observeDoneThisSession = false;
+  });
+
+  // After compaction, reset the reminder state so reminders resume
+  pi.on("session_compact", async () => {
+    turnsSinceLastReminder = 0;
+    observeDoneThisSession = false;
+  });
+
+  pi.on("agent_end", async (_event, _ctx) => {
+    turnsSinceLastReminder++;
+    if (turnsSinceLastReminder < REMINDER_INTERVAL) return;
+    if (observeDoneThisSession) return;
+
+    pi.sendMessage(
+      {
+        customType: "wiki-observe-reminder",
+        content: [
+          "**Wiki observation reminder:** If the work in this session produced non-trivial ",
+          "decisions, findings, constraints, or completions worth preserving across sessions,",
+          "call `wiki_observe` to record them. Observations are searchable via `wiki_recall`",
+          "and compound your wiki's knowledge over time.",
+          "",
+          "One observation per call. Separate distinct findings into multiple calls.",
+        ].join(" "),
+        display: false,
+      },
+      {
+        deliverAs: "nextTurn",
+      },
+    );
+  });
+}

--- a/test/observation.test.ts
+++ b/test/observation.test.ts
@@ -1,0 +1,174 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rebuildMetadataLight } from "../extensions/llm-wiki/lib/metadata.js";
+import { saveObservation } from "../extensions/llm-wiki/lib/observation.js";
+import { searchWiki } from "../extensions/llm-wiki/lib/recall.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+
+describe("wiki observation", () => {
+  let tmpDir: string;
+  let vaultDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dirname, "..", "tmp", `observation-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    vaultDir = (() => {
+      const dir = join(tmpDir, `vault-${Math.random().toString(36).slice(2)}`);
+      mkdirSync(dir, { recursive: true });
+      const llmWiki = join(dir, ".llm-wiki");
+      const dirs = [
+        "raw/articles",
+        "raw/papers",
+        "raw/notes",
+        "wiki/entities",
+        "wiki/concepts",
+        "wiki/sources",
+        "wiki/syntheses",
+        "meta",
+        "outputs",
+        ".discoveries",
+      ];
+      for (const d of dirs) mkdirSync(join(llmWiki, d), { recursive: true });
+      return dir;
+    })();
+    ensureVaultStructure(getVaultPaths(vaultDir));
+
+    // Write config.json
+    const dotWiki = join(vaultDir, ".llm-wiki");
+    writeFileSync(
+      join(dotWiki, "config.json"),
+      JSON.stringify({
+        topic: "Test Vault",
+        mode: "personal",
+        created: "2026-05-27",
+        version: "1.0",
+      }),
+      "utf-8",
+    );
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("should save an observation and create a page file", () => {
+    const paths = getVaultPaths(vaultDir);
+    const result = saveObservation(paths, {
+      title: "JWT auth middleware added",
+      content:
+        "User decided to use JWT with refresh tokens. Implementation at src/auth/jwt.ts. Tests passing.",
+      relevance: "high",
+      tags: "auth jwt backend",
+      source_context: "Adding authentication module",
+    });
+
+    expect(result.slug).toContain("obs-");
+    expect(result.slug).toContain("jwt-auth-middleware-added");
+    expect(existsSync(result.pagePath)).toBe(true);
+
+    const content = readFileSync(result.pagePath, "utf-8");
+    expect(content).toContain("Observation: JWT auth middleware added");
+    expect(content).toContain("User decided to use JWT with refresh tokens");
+    expect(content).toContain("relevance: high");
+    expect(content).toContain('tags: ["auth", "jwt", "backend"]');
+    expect(content).toContain('source_context: "Adding authentication module"');
+  });
+
+  it("should save an observation with default optional fields", () => {
+    const paths = getVaultPaths(vaultDir);
+    const result = saveObservation(paths, {
+      title: "Quick fix applied",
+      content: "Fixed the login timeout bug by increasing TTL.",
+      relevance: "medium",
+    });
+
+    expect(existsSync(result.pagePath)).toBe(true);
+    const content = readFileSync(result.pagePath, "utf-8");
+    expect(content).toContain("relevance: medium");
+    expect(content).not.toContain("tags:");
+    expect(content).not.toContain("source_context:");
+  });
+
+  it("should save an observation with critical relevance", () => {
+    const paths = getVaultPaths(vaultDir);
+    const result = saveObservation(paths, {
+      title: "User is colorblind",
+      content: "User stated they are colorblind; red/green indicators do not work for them.",
+      relevance: "critical",
+    });
+
+    const content = readFileSync(result.pagePath, "utf-8");
+    expect(content).toContain("relevance: critical");
+  });
+
+  it("should make observations searchable via wiki_recall", () => {
+    const paths = getVaultPaths(vaultDir);
+    saveObservation(paths, {
+      title: "Postgres migration constraint",
+      content:
+        "Migration from MySQL to Postgres: discovered that JSONB queries use different syntax.",
+      relevance: "high",
+      tags: "migration postgres database",
+    });
+
+    rebuildMetadataLight(paths);
+    const results = searchWiki(paths, "postgres migration");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.title.includes("Postgres migration"))).toBe(true);
+  });
+
+  it("should search observation content in wiki_recall", () => {
+    const paths = getVaultPaths(vaultDir);
+    saveObservation(paths, {
+      title: "Auth decision",
+      content: "Team chose Lucia for session-based auth over NextAuth and Clerk.",
+      relevance: "high",
+      tags: "auth decision",
+    });
+
+    rebuildMetadataLight(paths);
+    // Search for content-specific terms
+    const results = searchWiki(paths, "Lucia session-based auth");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.title.includes("Auth decision"))).toBe(true);
+  });
+
+  it("should handle multiple observations independently", () => {
+    const paths = getVaultPaths(vaultDir);
+    const obs1 = saveObservation(paths, {
+      title: "First finding",
+      content: "Found bug in login flow.",
+      relevance: "high",
+    });
+    const obs2 = saveObservation(paths, {
+      title: "Second finding",
+      content: "Fixed the bug by adding validation.",
+      relevance: "medium",
+    });
+
+    expect(obs1.slug).not.toBe(obs2.slug);
+    expect(existsSync(obs1.pagePath)).toBe(true);
+    expect(existsSync(obs2.pagePath)).toBe(true);
+
+    const content1 = readFileSync(obs1.pagePath, "utf-8");
+    const content2 = readFileSync(obs2.pagePath, "utf-8");
+    expect(content1).toContain("First finding");
+    expect(content2).toContain("Second finding");
+  });
+
+  it("should slugify titles correctly", () => {
+    const paths = getVaultPaths(vaultDir);
+    const result = saveObservation(paths, {
+      title: "Complex/Edge Case: 100% Done!",
+      content: "Edge case handling completed.",
+      relevance: "low",
+    });
+
+    expect(result.slug).toContain("complex-edge-case-100-done");
+    expect(result.slug).not.toContain("//");
+    expect(result.slug).not.toContain("_");
+  });
+});


### PR DESCRIPTION
## Problem

The wiki was missing a mechanism for capturing session-level observations as durable knowledge. Users had to manually call wiki_retro at task end, and there was no structured way to record timestamped, relevance-rated observations that compound across sessions.

## Solution

Adds an observation system inspired by pi-observational-memory's pattern of capturing session-level facts.

### wiki_observe tool
- Model-callable tool for recording timestamped observations
- Fields: title, content, relevance (low/medium/high/critical), tags, source_context
- Saves to `wiki/sources/obs-{date}-{slug}.md` with structured frontmatter
- Immediately searchable via wiki_recail

### Turn-end reminder
- After every 5 significant turns, sends a nextTurn reminder (like memex does for retro)
- Reminds the model to call wiki_observe for non-trivial findings
- Resets after session start and compaction

### 7 new tests
- save observation creates correct page file with frontmatter
- default optional fields handled correctly
- critical relevance saved properly
- observations searchable via wiki_recail
- content-specific search works
- multiple observations are independent
- slugification handles special characters