### PR TITLE
feat: add chunk-level indexing for precise section matching

### DIFF
--- a/extensions/llm-wiki/lib/recall.ts
+++ b/extensions/llm-wiki/lib/recall.ts
@@ -31,7 +31,13 @@ export interface RecallResult {
   score: number;
 }
 
-type Scored = { id: string; entry: Registry["pages"][string]; score: number; pagePath: string };
+type Scored = {
+  id: string;
+  entry: Registry["pages"][string];
+  score: number;
+  pagePath: string;
+  bestChunkPreview: string;
+};
 
 /**
  * Normalize text for recall matching.
@@ -118,9 +124,78 @@ function scoreField(value: unknown, terms: string[], weight: number): number {
   return score;
 }
 
+// ─── Chunk-Level Indexing ────────────────────────────
+
+interface PageChunk {
+  /** The heading line (e.g. "## Configuration") or empty for the intro section */
+  heading: string;
+  /** Content of this chunk */
+  content: string;
+  /** Heading level (0 for intro, 1 for #, 2 for ##, etc.) */
+  level: number;
+}
+
+/**
+ * Split a page's body into chunks by headings.
+ * Each heading and its following content become one chunk.
+ * Content before the first heading becomes the intro chunk.
+ */
+function chunkPage(body: string): PageChunk[] {
+  if (!body.trim()) return [];
+
+  const chunks: PageChunk[] = [];
+  const lines = body.split("\n");
+
+  let currentHeading = "";
+  let currentLevel = 0;
+  let currentContent: string[] = [];
+
+  for (const line of lines) {
+    const headingMatch = line.trim().match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      // Save previous chunk
+      if (currentContent.length > 0 || currentHeading) {
+        chunks.push({
+          heading: currentHeading,
+          content: currentContent.join("\n").trim(),
+          level: currentLevel,
+        });
+      }
+      currentHeading = headingMatch[2].trim();
+      currentLevel = headingMatch[1].length;
+      currentContent = [];
+    } else {
+      currentContent.push(line);
+    }
+  }
+
+  // Save last chunk
+  if (currentContent.length > 0 || currentHeading) {
+    chunks.push({
+      heading: currentHeading,
+      content: currentContent.join("\n").trim(),
+      level: currentLevel,
+    });
+  }
+
+  return chunks;
+}
+
 function pagePreview(content: string): string {
   const { body } = parseFrontmatter(content);
   return body.trim().slice(0, 200).replace(/\n/g, " ");
+}
+
+/**
+ * Get a preview of the best-matching chunk, or fall back to the page intro.
+ * Shows the heading (if any) and the first ~200 chars of content.
+ */
+function chunkPreview(heading: string, content: string): string {
+  const trimmed = content.slice(0, 180).replace(/\n/g, " ");
+  if (heading) {
+    return `#${heading} — ${trimmed}`;
+  }
+  return trimmed;
 }
 
 /**
@@ -177,26 +252,51 @@ export function searchWiki(
     score += scoreField(frontmatter.category, terms, 2);
     score += scoreField(frontmatter.domain, terms, 2);
 
-    // Body search makes the wiki useful even when registry metadata is sparse.
-    // Headings get a stronger boost because they are human-authored labels.
-    const headings = body
-      .split("\n")
-      .filter((line) => line.trim().startsWith("#"))
-      .join(" ");
-    score += scoreField(headings, terms, 4);
-    score += scoreField(body, terms, 1);
+    // Body search: use chunk-level indexing for more precise matching.
+    // Each section of the page is scored independently, so a query about
+    // "Postgres" matches only the Postgres section, not the whole page.
+    let bestChunkScore = 0;
+    let bestChunkHeading = "";
+    let bestChunkContent = "";
+
+    if (body.trim()) {
+      const chunks = chunkPage(body);
+      for (const chunk of chunks) {
+        let chunkScore = 0;
+        // Heading gets a strong boost
+        chunkScore += scoreField(chunk.heading, terms, 4);
+        // Chunk body content
+        chunkScore += scoreField(chunk.content, terms, 1);
+
+        if (chunkScore > bestChunkScore) {
+          bestChunkScore = chunkScore;
+          bestChunkHeading = chunk.heading;
+          bestChunkContent = chunk.content;
+        }
+      }
+    }
+
+    // Add best chunk score to total page score
+    score += bestChunkScore;
 
     if (score > 0) {
-      scored.push({ id, entry, score, pagePath });
+      scored.push({
+        id,
+        entry,
+        score,
+        pagePath,
+        bestChunkPreview: bestChunkContent ? chunkPreview(bestChunkHeading, bestChunkContent) : "",
+      });
     }
   }
 
   scored.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
   const top = scored.filter((s) => s.score >= minScore).slice(0, maxResults);
 
-  return top.map(({ id, entry, pagePath, score }) => {
-    let preview = "";
-    if (existsSync(pagePath)) {
+  return top.map(({ id, entry, pagePath, score, bestChunkPreview }) => {
+    let preview = bestChunkPreview;
+    if (!preview && existsSync(pagePath)) {
+      // Fallback: no chunk matched, show page intro
       preview = pagePreview(readFileSync(pagePath, "utf-8"));
     }
 

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -361,4 +361,110 @@ describe("wiki recall", () => {
       } catch {}
     });
   });
+
+  describe("chunk-level indexing", () => {
+    it("should match a query against a specific section, not the whole page", () => {
+      // Page with multiple sections - only one about the query topic
+      createRegistryPage(
+        "server-setup",
+        "concept",
+        "Server Setup",
+        [
+          "This page covers server setup basics.",
+          "",
+          "## Postgres",
+          "",
+          "PostgreSQL is configured with SSL and connection pooling via PgBouncer.",
+          "Connection string uses the DATABASE_URL env var.",
+          "",
+          "## Redis",
+          "",
+          "Redis is used for caching session data and rate limiting.",
+          "",
+          "## Nginx",
+          "",
+          "Nginx reverse proxies API requests and serves static assets.",
+        ].join("\n"),
+      );
+
+      const paths = getVaultPaths(wikiDir);
+      rebuildMetadataLight(paths);
+
+      // Query for Postgres - should match the Postgres section specifically
+      const results = searchWiki(paths, "PostgreSQL connection pooling");
+      expect(results.length).toBeGreaterThanOrEqual(1);
+
+      // The preview should show the Postgres section content, not the intro
+      const result = results[0];
+      expect(result.id).toBe("concepts/server-setup");
+      expect(result.preview).toContain("Postgres");
+      expect(result.preview).toContain("PgBouncer");
+      // Should not show the intro which mentions "server setup basics"
+      expect(result.preview).not.toContain("basics");
+    });
+
+    it("should match a query against the intro section", () => {
+      createRegistryPage(
+        "introduction",
+        "concept",
+        "Getting Started",
+        "Welcome to the framework. This is where you begin learning about routing and middleware.",
+      );
+
+      const paths = getVaultPaths(wikiDir);
+      rebuildMetadataLight(paths);
+
+      const results = searchWiki(paths, "Getting Started routing");
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results[0].preview).toContain("routing");
+    });
+
+    it("should match a deeply nested section heading", () => {
+      createRegistryPage(
+        "deep-page",
+        "synthesis",
+        "Deep Analysis",
+        [
+          "## Background",
+          "",
+          "General background.",
+          "",
+          "### Deep Dive",
+          "",
+          "The specific mechanism involves token-level processing.",
+          "",
+          "## Results",
+          "",
+          "All tests pass.",
+        ].join("\n"),
+      );
+
+      const paths = getVaultPaths(wikiDir);
+      rebuildMetadataLight(paths);
+
+      const results = searchWiki(paths, "token-level processing");
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      const result = results[0];
+      expect(result.preview).toContain("token-level");
+      expect(result.preview).toContain("Deep Dive");
+    });
+
+    it("should still find pages via metadata even when body has no match", () => {
+      createRegistryPage(
+        "api-reference",
+        "concept",
+        "API Reference",
+        "Detailed API documentation with examples.",
+        { aliases: "api-docs rest-api" },
+      );
+
+      const paths = getVaultPaths(wikiDir);
+      rebuildMetadataLight(paths);
+
+      // Match on alias, not body
+      const results = searchWiki(paths, "rest-api");
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results[0].id).toBe("concepts/api-reference");
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Wiki search matched against entire page bodies. A query about "Postgres" would match a "Server Setup" page equally well whether Postgres was a minor section or the main topic. The preview was always the first 200 chars of the page intro, even when the match was in a deep section.

## Solution

Replace whole-page body scoring with chunk-level scoring. Each page section (split by ## headings) is scored independently.

### How it works
1. chunkPage() splits a page body by headings into independent sections
2. Each section is scored separately for heading match (weight 4) and content match (weight 1)
3. The best-matching chunk's score is added to the page's metadata score
4. The preview now shows the best-matching chunk (heading + content) instead of the page intro

### Results
- Query "postgres connection pooling" against a "Server Setup" page shows the Postgres section, not the intro
- Nested sections (### level) are found correctly
- Metadata-only matches (via aliases, tags, titles) still work when no body chunk matches
- The old whole-page body scoring is removed (was double-counting body text)

### 4 new tests
- Section-specific matching (Postgres section on mixed page)
- Intro section matching when no headings exist
- Nested heading matching (### level)
- Metadata fallback when body has no matches
