### PR TITLE
fix: wire observeDoneThisSession through shared state (CodeQL alert)

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -2,7 +2,11 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
-import { registerObservationReminder, registerWikiObserve } from "./lib/observation.js";
+import {
+  createReminderState,
+  registerObservationReminder,
+  registerWikiObserve,
+} from "./lib/observation.js";
 import { formatRecallContext, registerWikiRecall, searchWikiLayered } from "./lib/recall.js";
 import { registerWikiRetro } from "./lib/retro.js";
 import {
@@ -56,8 +60,9 @@ export default function (pi: ExtensionAPI) {
   registerWikiWatch(pi);
   registerWikiRecall(pi);
   registerWikiRetro(pi);
-  registerWikiObserve(pi);
-  registerObservationReminder(pi);
+  const reminderState = createReminderState();
+  registerWikiObserve(pi, reminderState);
+  registerObservationReminder(pi, reminderState);
 
   installGuardrails(pi);
 

--- a/extensions/llm-wiki/lib/observation.ts
+++ b/extensions/llm-wiki/lib/observation.ts
@@ -115,6 +115,21 @@ export function saveObservation(paths: VaultPaths, input: ObservationInput): Obs
   return { slug, pagePath };
 }
 
+// ─── Shared Reminder State ────────────────────────────
+
+/**
+ * Mutable state shared between wiki_observe tool and the turn-end reminder.
+ * When the model calls wiki_observe, the tool sets observeDoneThisSession
+ * so the reminder stops nagging.
+ */
+export interface ReminderState {
+  observeDoneThisSession: boolean;
+}
+
+export function createReminderState(): ReminderState {
+  return { observeDoneThisSession: false };
+}
+
 // ─── Tool Registration ─────────────────────────────────
 
 /**
@@ -122,7 +137,7 @@ export function saveObservation(paths: VaultPaths, input: ObservationInput): Obs
  * The model calls this to record observations during a session.
  * Observations are saved to the wiki and become searchable.
  */
-export function registerWikiObserve(pi: ExtensionAPI): void {
+export function registerWikiObserve(pi: ExtensionAPI, reminderState?: ReminderState): void {
   pi.registerTool({
     name: "wiki_observe",
     label: "Wiki Observe",
@@ -207,6 +222,11 @@ export function registerWikiObserve(pi: ExtensionAPI): void {
         source_context: params.source_context,
       });
 
+      // Signal the reminder to stop nagging this session
+      if (reminderState) {
+        reminderState.observeDoneThisSession = true;
+      }
+
       const relevanceEmoji = RELEVANCE_EMOJIS[params.relevance] ?? "📝";
 
       return {
@@ -247,27 +267,27 @@ export function registerWikiObserve(pi: ExtensionAPI): void {
  */
 export function registerObservationReminder(
   pi: ExtensionAPI,
+  reminderState: ReminderState,
   options?: { turnsBetweenReminders?: number },
 ): void {
   const REMINDER_INTERVAL = options?.turnsBetweenReminders ?? 5;
   let turnsSinceLastReminder = 0;
-  let observeDoneThisSession = false;
 
   pi.on("session_start", async () => {
     turnsSinceLastReminder = 0;
-    observeDoneThisSession = false;
+    reminderState.observeDoneThisSession = false;
   });
 
   // After compaction, reset the reminder state so reminders resume
   pi.on("session_compact", async () => {
     turnsSinceLastReminder = 0;
-    observeDoneThisSession = false;
+    reminderState.observeDoneThisSession = false;
   });
 
   pi.on("agent_end", async (_event, _ctx) => {
     turnsSinceLastReminder++;
     if (turnsSinceLastReminder < REMINDER_INTERVAL) return;
-    if (observeDoneThisSession) return;
+    if (reminderState.observeDoneThisSession) return;
 
     pi.sendMessage(
       {


### PR DESCRIPTION
## Problem

CodeQL alert #39 (`js/trivial-conditional`) flagged `observeDoneThisSession` in `observation.ts:270` as always evaluating to `false`.

Root cause: the variable was declared in the `registerObservationReminder` closure but the `wiki_observe` tool (registered in `registerWikiObserve`) is in a different closure — it could never set the flag to `true`.

## Fix

1. Extract `ReminderState` interface + `createReminderState()` factory
2. Share the state between `registerWikiObserve` and `registerObservationReminder`
3. The tool sets `observeDoneThisSession = true` when called
4. The reminder checks the shared flag instead of a local variable
5. `session_start` and `session_compact` reset the shared state

This is a one-line behavioral fix but required plumbing the shared state through both registration functions.
