### PR TITLE
fix: personal wiki created at doubled path ~/.llm-wiki/.llm-wiki/…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Personal wiki created at doubled path `~/.llm-wiki/.llm-wiki/…`**: `getPersonalWikiRoot()` returned the dot-dir itself (`~/.llm-wiki`) while `getVaultPaths()` then appended another `.llm-wiki/` segment, so the personal vault was written to `~/.llm-wiki/.llm-wiki/wiki/…`. Fixed by aligning `getPersonalWikiRoot()` with the same "root = parent of `.llm-wiki/`" contract used by project vaults. `WIKI_HOME` continues to override the parent.
+
+### Added
+- **`migrateDoubledPersonalVault()`** helper (`extensions/llm-wiki/lib/utils.ts`): Idempotent, in-place flatten of any vault that was already written to the broken doubled layout. Moves entries from `<root>/.llm-wiki/.llm-wiki/*` up to `<root>/.llm-wiki/*`, preserves outer entries on collision, removes the inner dir only when fully drained. Returns `null` when the layout is already correct, so it is safe to call on every session start.
+- **Auto-migration on `session_start`**: The extension now runs `migrateDoubledPersonalVault()` on the personal wiki at every session start. Existing broken vaults are flattened the next time the user opens or reloads pi — no manual step required. A one-line status message is shown when a flatten actually happens; otherwise the check is silent.
+- **`scripts/migrate-llm-wiki.js --fix-doubled`** flag: Manual recovery for arbitrary roots (`--fix-doubled ~/`, `--fix-doubled /some/project`). Supports `--dry-run` and `--force`.
+- **9 regression tests** (`test/personal-wiki-paths.test.ts`): pin `getPersonalWikiRoot()` to the parent-of-dotdir contract, exercise `WIKI_HOME`, and verify the migration helper across no-op, idempotent, and collision paths.
+
 ## [0.7.0] - 2026-05-13
 
 ### Added

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -25,6 +25,7 @@ import {
   ensureVaultStructure,
   fmtDate,
   getVaultPaths,
+  migrateDoubledPersonalVault,
   resolveVaultPaths,
   writeJson,
 } from "./lib/utils.js";
@@ -70,6 +71,22 @@ export default function (pi: ExtensionAPI) {
   let needsTopicInference = false;
 
   pi.on("session_start", async (_event, ctx) => {
+    // One-shot recovery for vaults created with the broken personal-root
+    // (~/.llm-wiki/.llm-wiki/… doubled layout). Runs on every session start
+    // because it is a cheap existence-check no-op when the layout is correct.
+    try {
+      const migration = migrateDoubledPersonalVault();
+      if (migration && migration.moved.length > 0) {
+        ctx.ui.setStatus(
+          "llm-wiki",
+          `🧠 Personal wiki layout fixed: flattened ${migration.moved.length} entries out of ${migration.from} (see CHANGELOG)`,
+        );
+      }
+    } catch (err) {
+      // Never let migration crash session start.
+      console.warn(`[llm-wiki] doubled-dotdir migration skipped: ${(err as Error).message}`);
+    }
+
     const paths = resolveVaultPaths(process.cwd());
     if (!existsSync(join(paths.dotWiki, "config.json"))) {
       // Silently create the wiki vault — no UI prompts

--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -1,4 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
@@ -33,16 +42,77 @@ export function detectVaultFormat(dir: string): VaultFormat {
   return "none";
 }
 
-/** Get the personal wiki root directory (~/.llm-wiki/). */
+/**
+ * Get the personal wiki root directory.
+ *
+ * The "root" follows the same contract as project wikis: it is the directory
+ * that *contains* the `.llm-wiki/` dot-dir, NOT the dot-dir itself.
+ * So the personal vault lives at `<root>/.llm-wiki/`.
+ *
+ * Default root: `homedir()` → personal vault at `~/.llm-wiki/`.
+ * Override:     `WIKI_HOME` env var → personal vault at `$WIKI_HOME/.llm-wiki/`.
+ *
+ * NOTE: Previously this returned `~/.llm-wiki` (the dot-dir itself), which
+ * caused `getVaultPaths()` to compose paths like `~/.llm-wiki/.llm-wiki/raw`.
+ * See `migrateDoubledPersonalVault()` for the one-shot recovery.
+ */
 export function getPersonalWikiRoot(): string {
   const envWiki = process.env.WIKI_HOME;
   if (envWiki) return envWiki;
-  return join(homedir(), ".llm-wiki");
+  return homedir();
 }
 
 /** Get VaultPaths for the personal wiki. */
 export function getPersonalWikiPaths(): VaultPaths {
   return getVaultPaths(getPersonalWikiRoot());
+}
+
+/**
+ * One-shot, idempotent migration for vaults that were created with the broken
+ * `getPersonalWikiRoot()` (returned the dot-dir itself, so `getVaultPaths()`
+ * composed `<root>/.llm-wiki/.llm-wiki/...`).
+ *
+ * Detects a doubled layout at `<root>/.llm-wiki/.llm-wiki/config.json` and
+ * flattens it up by one level. Safe to call on every session start: if the
+ * doubled sentinel is absent, this is a no-op.
+ *
+ * Returns a description of the action taken (or `null` if no migration was
+ * needed) so callers can surface a one-line status message.
+ */
+export function migrateDoubledPersonalVault(
+  parentRoot: string = getPersonalWikiRoot(),
+): { moved: string[]; from: string; to: string; skipped: string[] } | null {
+  const outerDotWiki = join(parentRoot, ".llm-wiki");
+  const innerDotWiki = join(outerDotWiki, ".llm-wiki");
+  const innerSentinel = join(innerDotWiki, "config.json");
+
+  if (!existsSync(innerSentinel)) return null;
+
+  const moved: string[] = [];
+  const skipped: string[] = [];
+
+  for (const entry of readdirSync(innerDotWiki)) {
+    const src = join(innerDotWiki, entry);
+    const dest = join(outerDotWiki, entry);
+    if (existsSync(dest)) {
+      // Collision — leave the inner copy in place rather than clobber.
+      skipped.push(entry);
+      continue;
+    }
+    renameSync(src, dest);
+    moved.push(entry);
+  }
+
+  // Only remove the inner dir if it is fully drained.
+  if (skipped.length === 0) {
+    try {
+      rmdirSync(innerDotWiki);
+    } catch {
+      // Leave behind if something raced us; harmless.
+    }
+  }
+
+  return { moved, from: innerDotWiki, to: outerDotWiki, skipped };
 }
 
 /**

--- a/scripts/migrate-llm-wiki.js
+++ b/scripts/migrate-llm-wiki.js
@@ -61,9 +61,7 @@ function moveDir(src, dest, name) {
 async function fixDoubled() {
   // Determine parent root: first positional arg if present, else homedir().
   // This is the directory that CONTAINS the outer .llm-wiki/.
-  const positional = process.argv.find(
-    (a, i) => i >= 2 && !a.startsWith("--"),
-  );
+  const positional = process.argv.find((a, i) => i >= 2 && !a.startsWith("--"));
   const parentRoot = positional
     ? positional.startsWith("/")
       ? positional
@@ -100,9 +98,7 @@ async function fixDoubled() {
   }
 
   if (plan.every((p) => p.collision)) {
-    console.log(
-      "\n❌ Every inner entry collides with the outer vault. Resolve manually.",
-    );
+    console.log("\n❌ Every inner entry collides with the outer vault. Resolve manually.");
     process.exit(1);
   }
 
@@ -147,9 +143,7 @@ async function fixDoubled() {
   } else {
     console.log(`✅ Flatten complete. Moved ${moved}, skipped ${skipped}.`);
     if (skipped > 0) {
-      console.log(
-        `   ${skipped} entry(ies) left in ${inner} due to collisions. Resolve manually.`,
-      );
+      console.log(`   ${skipped} entry(ies) left in ${inner} due to collisions. Resolve manually.`);
     }
   }
 }

--- a/scripts/migrate-llm-wiki.js
+++ b/scripts/migrate-llm-wiki.js
@@ -3,23 +3,37 @@
 /**
  * migrate-llm-wiki.js
  *
- * One-time migration script: moves an old-style wiki vault (.wiki/ sentinel)
- * to the new .llm-wiki/ layout.
+ * One-time migration script for wiki vault layouts.
+ *
+ * Two migrations are supported:
+ *
+ * 1. LEGACY → NEW (default): moves an old-style vault (`.wiki/` sentinel)
+ *    to the new `.llm-wiki/` layout.
+ *
+ * 2. DOUBLED → FLATTENED (`--fix-doubled`): flattens a vault that was
+ *    accidentally created at `<root>/.llm-wiki/.llm-wiki/…` due to a bug in
+ *    `getPersonalWikiRoot()` (fixed in 0.6.4). The extension auto-runs this
+ *    migration on `session_start`, but the script is provided for manual
+ *    recovery on arbitrary roots.
  *
  * Usage:
- *   node scripts/migrate-llm-wiki.js              # Run in wiki root directory
- *   node scripts/migrate-llm-wiki.js ~/my-wiki     # Run at specific path
+ *   node scripts/migrate-llm-wiki.js              # Legacy migration in cwd
+ *   node scripts/migrate-llm-wiki.js ~/my-wiki     # Legacy migration at path
  *   node scripts/migrate-llm-wiki.js --dry-run     # Preview without changes
- *   node scripts/migrate-llm-wiki.js --force        # Skip confirmation prompt
+ *   node scripts/migrate-llm-wiki.js --force       # Skip confirmation prompt
+ *   node scripts/migrate-llm-wiki.js --fix-doubled # Flatten doubled .llm-wiki/.llm-wiki
+ *   node scripts/migrate-llm-wiki.js --fix-doubled ~/  # …at a specific root
  */
 
-import { existsSync, mkdirSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, renameSync, rmdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 // ─── Helpers ────────────────────────────────────────────
 
 const DRY_RUN = process.argv.includes("--dry-run");
 const FORCE = process.argv.includes("--force");
+const FIX_DOUBLED = process.argv.includes("--fix-doubled");
 
 function log(action, ...args) {
   const prefix = DRY_RUN ? "[DRY-RUN]" : "[MIGRATE]";
@@ -44,7 +58,108 @@ function moveDir(src, dest, name) {
 
 // ─── Main ───────────────────────────────────────────────
 
+async function fixDoubled() {
+  // Determine parent root: first positional arg if present, else homedir().
+  // This is the directory that CONTAINS the outer .llm-wiki/.
+  const positional = process.argv.find(
+    (a, i) => i >= 2 && !a.startsWith("--"),
+  );
+  const parentRoot = positional
+    ? positional.startsWith("/")
+      ? positional
+      : join(process.cwd(), positional)
+    : homedir();
+
+  const outer = join(parentRoot, ".llm-wiki");
+  const inner = join(outer, ".llm-wiki");
+  const innerSentinel = join(inner, "config.json");
+
+  console.log(`\n🔍 Scanning for doubled vault at: ${inner}\n`);
+
+  if (!existsSync(innerSentinel)) {
+    console.log("✅ No doubled vault detected (no inner .llm-wiki/config.json).");
+    console.log(`   Outer: ${outer}`);
+    console.log(`   Inner: ${inner}`);
+    console.log("   Nothing to do.");
+    process.exit(0);
+  }
+
+  const entries = readdirSync(inner);
+  const plan = entries.map((entry) => {
+    const src = join(inner, entry);
+    const dest = join(outer, entry);
+    return { src, dest, entry, collision: existsSync(dest) };
+  });
+
+  console.log("📋 Flatten plan:");
+  console.log(`   ${inner}/  →  ${outer}/`);
+  console.log("   ─────────────────────────────");
+  for (const p of plan) {
+    const status = p.collision ? "⚠️  COLLISION (skip)" : "✓ move";
+    console.log(`   ${status}  ${p.entry}`);
+  }
+
+  if (plan.every((p) => p.collision)) {
+    console.log(
+      "\n❌ Every inner entry collides with the outer vault. Resolve manually.",
+    );
+    process.exit(1);
+  }
+
+  if (!FORCE && !DRY_RUN) {
+    console.log("\n❓ Proceed with flatten? (y/N)");
+    process.stdin.setRawMode?.(false);
+    const answer = await new Promise((resolve) => {
+      process.stdin.once("data", (data) => resolve(data.toString().trim().toLowerCase()));
+    });
+    if (answer !== "y" && answer !== "yes") {
+      console.log("Migration cancelled.");
+      process.exit(0);
+    }
+  }
+
+  console.log("");
+  let moved = 0;
+  let skipped = 0;
+  for (const p of plan) {
+    if (p.collision) {
+      log(`SKIP ${p.entry} — destination already exists`);
+      skipped++;
+      continue;
+    }
+    log(`MOVE ${p.entry}: ${p.src} → ${p.dest}`);
+    if (!DRY_RUN) renameSync(p.src, p.dest);
+    moved++;
+  }
+
+  if (skipped === 0 && !DRY_RUN) {
+    try {
+      rmdirSync(inner);
+      log(`RMDIR ${inner}`);
+    } catch (err) {
+      log(`RMDIR ${inner} failed: ${err.message} (left in place)`);
+    }
+  }
+
+  console.log("");
+  if (DRY_RUN) {
+    console.log(`✅ Dry-run complete. Would move ${moved}, skip ${skipped}.`);
+  } else {
+    console.log(`✅ Flatten complete. Moved ${moved}, skipped ${skipped}.`);
+    if (skipped > 0) {
+      console.log(
+        `   ${skipped} entry(ies) left in ${inner} due to collisions. Resolve manually.`,
+      );
+    }
+  }
+}
+
 async function main() {
+  if (FIX_DOUBLED) {
+    await fixDoubled();
+    return;
+  }
+
   // Determine root directory
   const root = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
 

--- a/test/personal-wiki-paths.test.ts
+++ b/test/personal-wiki-paths.test.ts
@@ -1,0 +1,171 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getPersonalWikiPaths,
+  getPersonalWikiRoot,
+  getVaultPaths,
+  migrateDoubledPersonalVault,
+} from "../extensions/llm-wiki/lib/utils.js";
+
+/**
+ * Regression suite for the doubled-dotdir personal-wiki bug.
+ *
+ * Before the fix, `getPersonalWikiRoot()` returned `~/.llm-wiki` (the
+ * dot-dir itself) while `getVaultPaths(root)` appended ANOTHER `.llm-wiki/`,
+ * producing paths like `~/.llm-wiki/.llm-wiki/raw`.
+ *
+ * After the fix:
+ *   - `getPersonalWikiRoot()` returns the PARENT of `.llm-wiki/`.
+ *   - `WIKI_HOME` overrides that parent.
+ *   - `migrateDoubledPersonalVault()` flattens a vault that was already
+ *     written in the broken layout, in-place and idempotently.
+ */
+
+describe("getPersonalWikiRoot / getPersonalWikiPaths", () => {
+  let savedWikiHome: string | undefined;
+
+  beforeEach(() => {
+    savedWikiHome = process.env.WIKI_HOME;
+    delete process.env.WIKI_HOME;
+  });
+
+  afterEach(() => {
+    if (savedWikiHome === undefined) delete process.env.WIKI_HOME;
+    else process.env.WIKI_HOME = savedWikiHome;
+  });
+
+  it("returns the parent of .llm-wiki, not the dot-dir itself", () => {
+    const root = getPersonalWikiRoot();
+    // Must not itself end in /.llm-wiki — that would re-create the doubled bug.
+    expect(root.endsWith("/.llm-wiki")).toBe(false);
+  });
+
+  it("composes vault paths under exactly ONE .llm-wiki segment", () => {
+    const paths = getPersonalWikiPaths();
+    // dotWiki should be <root>/.llm-wiki, never <root>/.llm-wiki/.llm-wiki.
+    expect(paths.dotWiki.endsWith("/.llm-wiki")).toBe(true);
+    expect(paths.dotWiki.endsWith("/.llm-wiki/.llm-wiki")).toBe(false);
+    expect(paths.raw.endsWith("/.llm-wiki/raw")).toBe(true);
+    expect(paths.wiki.endsWith("/.llm-wiki/wiki")).toBe(true);
+  });
+
+  it("honours WIKI_HOME as the parent of .llm-wiki", () => {
+    process.env.WIKI_HOME = "/tmp/custom-home";
+    expect(getPersonalWikiRoot()).toBe("/tmp/custom-home");
+    const paths = getPersonalWikiPaths();
+    expect(paths.dotWiki).toBe("/tmp/custom-home/.llm-wiki");
+    expect(paths.wiki).toBe("/tmp/custom-home/.llm-wiki/wiki");
+  });
+});
+
+describe("migrateDoubledPersonalVault", () => {
+  let scratch: string;
+
+  beforeEach(() => {
+    scratch = join(tmpdir(), `llm-wiki-mig-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(scratch, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  function seedDoubledLayout() {
+    // Reproduce the broken layout:
+    //   scratch/.llm-wiki/.llm-wiki/config.json
+    //   scratch/.llm-wiki/.llm-wiki/wiki/sources/note.md
+    //   scratch/.llm-wiki/.llm-wiki/meta/registry.json
+    const inner = join(scratch, ".llm-wiki", ".llm-wiki");
+    mkdirSync(join(inner, "wiki", "sources"), { recursive: true });
+    mkdirSync(join(inner, "meta"), { recursive: true });
+    writeFileSync(join(inner, "config.json"), JSON.stringify({ topic: "test" }));
+    writeFileSync(join(inner, "wiki", "sources", "note.md"), "# hello");
+    writeFileSync(join(inner, "meta", "registry.json"), "{}");
+  }
+
+  it("is a no-op when the layout is already correct", () => {
+    // Correct layout: scratch/.llm-wiki/config.json (single dot-dir level).
+    mkdirSync(join(scratch, ".llm-wiki"), { recursive: true });
+    writeFileSync(join(scratch, ".llm-wiki", "config.json"), "{}");
+
+    const result = migrateDoubledPersonalVault(scratch);
+    expect(result).toBeNull();
+    // Nothing was moved or destroyed.
+    expect(existsSync(join(scratch, ".llm-wiki", "config.json"))).toBe(true);
+  });
+
+  it("is a no-op when no vault exists at all", () => {
+    const result = migrateDoubledPersonalVault(scratch);
+    expect(result).toBeNull();
+  });
+
+  it("flattens a doubled layout in place", () => {
+    seedDoubledLayout();
+
+    const result = migrateDoubledPersonalVault(scratch);
+    expect(result).not.toBeNull();
+    expect(result?.moved.sort()).toEqual(["config.json", "meta", "wiki"]);
+    expect(result?.skipped).toEqual([]);
+
+    // After: only ONE level of .llm-wiki, with all original payload.
+    const outer = join(scratch, ".llm-wiki");
+    expect(existsSync(join(outer, "config.json"))).toBe(true);
+    expect(existsSync(join(outer, "wiki", "sources", "note.md"))).toBe(true);
+    expect(existsSync(join(outer, "meta", "registry.json"))).toBe(true);
+    // Inner dir is gone.
+    expect(existsSync(join(outer, ".llm-wiki"))).toBe(false);
+    // Payload is intact byte-for-byte.
+    expect(readFileSync(join(outer, "wiki", "sources", "note.md"), "utf-8")).toBe("# hello");
+  });
+
+  it("is idempotent — second call is a no-op", () => {
+    seedDoubledLayout();
+    const first = migrateDoubledPersonalVault(scratch);
+    expect(first?.moved.length).toBeGreaterThan(0);
+    const second = migrateDoubledPersonalVault(scratch);
+    expect(second).toBeNull();
+  });
+
+  it("preserves outer entries on collision and leaves inner copy behind", () => {
+    seedDoubledLayout();
+    // Pre-existing entry at the outer level that would collide.
+    writeFileSync(join(scratch, ".llm-wiki", "config.json"), '{"outer":true}');
+
+    const result = migrateDoubledPersonalVault(scratch);
+    expect(result?.skipped).toContain("config.json");
+    // Outer config preserved untouched.
+    expect(readFileSync(join(scratch, ".llm-wiki", "config.json"), "utf-8")).toBe(
+      '{"outer":true}',
+    );
+    // Inner dir kept because not fully drained.
+    expect(existsSync(join(scratch, ".llm-wiki", ".llm-wiki"))).toBe(true);
+    // Collided inner copy is preserved for the user to resolve.
+    expect(
+      existsSync(join(scratch, ".llm-wiki", ".llm-wiki", "config.json")),
+    ).toBe(true);
+    // Non-colliding entries still moved up.
+    expect(existsSync(join(scratch, ".llm-wiki", "wiki", "sources", "note.md"))).toBe(true);
+    expect(
+      existsSync(join(scratch, ".llm-wiki", ".llm-wiki", "wiki")),
+    ).toBe(false);
+  });
+
+  it("composes a path that getVaultPaths can consume without double-prefixing", () => {
+    // The bug surfaced because getVaultPaths appended .llm-wiki/ to a root
+    // that already ended in .llm-wiki/. After migration, the parent root
+    // composes cleanly: <root>/.llm-wiki/wiki, never <root>/.llm-wiki/.llm-wiki/wiki.
+    seedDoubledLayout();
+    migrateDoubledPersonalVault(scratch);
+
+    const paths = getVaultPaths(scratch);
+    expect(paths.dotWiki).toBe(join(scratch, ".llm-wiki"));
+    expect(paths.wiki).toBe(join(scratch, ".llm-wiki", "wiki"));
+    // Nothing should resolve under a doubled segment.
+    expect(paths.wiki.includes("/.llm-wiki/.llm-wiki/")).toBe(false);
+    // And the migrated content is reachable through the standard paths.
+    const sources = readdirSync(join(paths.wiki, "sources"));
+    expect(sources).toContain("note.md");
+  });
+});

--- a/test/personal-wiki-paths.test.ts
+++ b/test/personal-wiki-paths.test.ts
@@ -28,11 +28,15 @@ describe("getPersonalWikiRoot / getPersonalWikiPaths", () => {
 
   beforeEach(() => {
     savedWikiHome = process.env.WIKI_HOME;
-    delete process.env.WIKI_HOME;
+    // Use Reflect.deleteProperty rather than `delete` to satisfy biome's
+    // performance/noDelete rule. Plain assignment to undefined is wrong here:
+    // Node coerces it to the string "undefined" and treats the var as SET,
+    // which would defeat the "no env override" precondition this test needs.
+    Reflect.deleteProperty(process.env, "WIKI_HOME");
   });
 
   afterEach(() => {
-    if (savedWikiHome === undefined) delete process.env.WIKI_HOME;
+    if (savedWikiHome === undefined) Reflect.deleteProperty(process.env, "WIKI_HOME");
     else process.env.WIKI_HOME = savedWikiHome;
   });
 
@@ -136,20 +140,14 @@ describe("migrateDoubledPersonalVault", () => {
     const result = migrateDoubledPersonalVault(scratch);
     expect(result?.skipped).toContain("config.json");
     // Outer config preserved untouched.
-    expect(readFileSync(join(scratch, ".llm-wiki", "config.json"), "utf-8")).toBe(
-      '{"outer":true}',
-    );
+    expect(readFileSync(join(scratch, ".llm-wiki", "config.json"), "utf-8")).toBe('{"outer":true}');
     // Inner dir kept because not fully drained.
     expect(existsSync(join(scratch, ".llm-wiki", ".llm-wiki"))).toBe(true);
     // Collided inner copy is preserved for the user to resolve.
-    expect(
-      existsSync(join(scratch, ".llm-wiki", ".llm-wiki", "config.json")),
-    ).toBe(true);
+    expect(existsSync(join(scratch, ".llm-wiki", ".llm-wiki", "config.json"))).toBe(true);
     // Non-colliding entries still moved up.
     expect(existsSync(join(scratch, ".llm-wiki", "wiki", "sources", "note.md"))).toBe(true);
-    expect(
-      existsSync(join(scratch, ".llm-wiki", ".llm-wiki", "wiki")),
-    ).toBe(false);
+    expect(existsSync(join(scratch, ".llm-wiki", ".llm-wiki", "wiki"))).toBe(false);
   });
 
   it("composes a path that getVaultPaths can consume without double-prefixing", () => {


### PR DESCRIPTION
Fixes #50.

## Root cause

`getPersonalWikiRoot()` returned the dot-dir itself (`~/.llm-wiki`) while `getVaultPaths()` then appended another `.llm-wiki/` segment, so the personal vault was written to `~/.llm-wiki/.llm-wiki/wiki/`, `~/.llm-wiki/.llm-wiki/raw/`, etc. The two functions disagreed on the contract for `root`:

- `getVaultPaths()` expects the **parent** of `.llm-wiki/` (matching `detectVaultFormat(dir)` which checks `dir/.llm-wiki/config.json`).
- `getPersonalWikiRoot()` was returning the dot-dir itself — the legacy meaning that pre-dates the 0.7.0 dot-dir restructure.

`resolveVaultRoot()` then re-finds the doubled sentinel and the broken layout perpetuates.

## Fix

| Change | File |
|--------|------|
| `getPersonalWikiRoot()` returns `homedir()` (parent of `.llm-wiki/`). `WIKI_HOME` continues to override the parent. | `extensions/llm-wiki/lib/utils.ts` |
| New `migrateDoubledPersonalVault()` helper — idempotent, in-place flatten. Returns `null` when the layout is already correct. Preserves outer entries on collision and leaves the inner copy behind for manual resolution. | `extensions/llm-wiki/lib/utils.ts` |
| `session_start` hook auto-runs the migration on the personal wiki. Existing broken vaults are flattened the next time the user opens or reloads pi — no manual step. | `extensions/llm-wiki/index.ts` |
| `scripts/migrate-llm-wiki.js --fix-doubled` for manual recovery on arbitrary roots, with `--dry-run` and `--force`. | `scripts/migrate-llm-wiki.js` |
| 9 regression tests covering the contract, `WIKI_HOME`, no-op, idempotent, and collision paths. | `test/personal-wiki-paths.test.ts` |

## Auto-migration UX

On `session_start` the extension calls `migrateDoubledPersonalVault()` against the personal-wiki parent root:

- If `~/.llm-wiki/.llm-wiki/config.json` exists → flatten in place, surface a one-line status: `🧠 Personal wiki layout fixed: flattened N entries out of ~/.llm-wiki/.llm-wiki (see CHANGELOG)`.
- If absent (normal case) → silent no-op (single existence check).
- Errors are caught and logged via `console.warn`; they never crash session start.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 90/90 pass (9 new + 81 existing, including the personal-vault recall test that validates `getPersonalWikiPaths()` still works for layered recall).
- Live smoke: after the fix, `getPersonalWikiPaths()` returns `/home/arjun/.llm-wiki/{wiki,raw,meta,…}` with zero doubled segments.
- `node scripts/migrate-llm-wiki.js --fix-doubled --dry-run` correctly reports "no doubled vault" when the layout is already correct.

## Compat

- No API breakage: `getPersonalWikiRoot()` / `getPersonalWikiPaths()` keep the same signatures and the same semantic contract ("vault paths for the personal wiki"). Only the underlying return value changes to align with `getVaultPaths()`.
- Project vaults are completely unaffected — they were already correct.
- `WIKI_HOME` still works; users who set it to (e.g.) `/srv/notes` now get a vault at `/srv/notes/.llm-wiki/` instead of `/srv/notes/.llm-wiki/` (same outcome — they were almost certainly setting it to the parent already, given the legacy contract).