### PR TITLE
fix: DOCX extraction and manifest metadata — closes #4

### DIFF
--- a/extensions/llm-wiki/lib/source-extractors.ts
+++ b/extensions/llm-wiki/lib/source-extractors.ts
@@ -1,14 +1,21 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { exec } from "./utils.js";
 
+export type ExtractionStatus = "success" | "failed" | "unsupported";
+
 export interface ExtractedContent {
   extracted: string;
   title?: string;
+  extractor?: string;
+  extraction_status?: ExtractionStatus;
+  content_type?: string;
 }
 
 export interface FileExtractor {
   format: string;
   shouldReadText: boolean;
+  extractorName?: string;
+  content_type?: string;
   matches(filePath: string): boolean;
   extract(args: FileExtractArgs): Promise<string> | string;
 }
@@ -38,25 +45,38 @@ const FILE_EXTRACTORS: FileExtractor[] = [
   {
     format: "pdf",
     shouldReadText: false,
+    extractorName: "markitdown",
+    content_type: "application/pdf",
     matches: hasExtension(".pdf"),
     extract: ({ pi, filePath, signal }) => extractPdf(pi, filePath, signal),
   },
-  textFileExtractor("markdown", [".md"]),
-  textFileExtractor("text", [".txt"]),
-  textFileExtractor("html", [".html", ".htm"]),
+  textFileExtractor("markdown", [".md"], "text/markdown"),
+  textFileExtractor("text", [".txt"], "text/plain"),
+  textFileExtractor("html", [".html", ".htm"], "text/html"),
   {
     format: "xml",
     shouldReadText: true,
+    extractorName: "xmlToMarkdown",
+    content_type: "application/xml",
     matches: hasExtension(".xml"),
     extract: ({ content }) => xmlToMarkdown(content),
   },
   {
     format: "json",
     shouldReadText: true,
+    extractorName: "jsonToMarkdown",
+    content_type: "application/json",
     matches: hasExtension(".json"),
     extract: ({ content }) => jsonToMarkdown(content),
   },
-  textFileExtractor("docx", [".docx"]),
+  {
+    format: "docx",
+    shouldReadText: false,
+    extractorName: "markitdown",
+    content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    matches: hasExtension(".docx"),
+    extract: ({ pi, filePath, signal }) => extractDocx(pi, filePath, signal),
+  },
   textFileExtractor("file", []),
 ];
 
@@ -91,10 +111,12 @@ export function pdfExtractionFailureMessage(source: string): string {
   return `_PDF content could not be converted to markdown from ${source}. Try increasing WIKI_MARKITDOWN_TIMEOUT_MS._\n`;
 }
 
-function textFileExtractor(format: string, extensions: string[]): FileExtractor {
+function textFileExtractor(format: string, extensions: string[], contentType?: string): FileExtractor {
   return {
     format,
     shouldReadText: true,
+    extractorName: "passthrough",
+    content_type: contentType,
     matches: extensions.length ? hasAnyExtension(extensions) : () => true,
     extract: ({ content }) => content,
   };
@@ -113,13 +135,29 @@ async function extractPdf(pi: ExtensionAPI, source: string, signal?: AbortSignal
   return extracted || pdfExtractionFailureMessage(source);
 }
 
+export function docxExtractionFailureMessage(source: string): string {
+  return `_DOCX content could not be converted to markdown from ${source}. Ensure uvx and markitdown are installed._\n`;
+}
+
+async function extractDocx(pi: ExtensionAPI, source: string, signal?: AbortSignal): Promise<string> {
+  const extracted = await extractWithMarkItDown(pi, source, signal);
+  return extracted || docxExtractionFailureMessage(source);
+}
+
 async function extractPdfUrl(
   pi: ExtensionAPI,
   url: string,
   signal?: AbortSignal,
 ): Promise<ExtractedContent> {
   const extracted = await extractPdf(pi, url, signal);
-  return { extracted, title: titleFromMarkdown(extracted) };
+  const failed = extracted.includes("could not be converted");
+  return {
+    extracted,
+    title: titleFromMarkdown(extracted),
+    extractor: "markitdown",
+    extraction_status: failed ? "failed" : "success",
+    content_type: "application/pdf",
+  };
 }
 
 async function extractTextUrl(
@@ -129,13 +167,30 @@ async function extractTextUrl(
 ): Promise<ExtractedContent> {
   const markitdownExtracted = await extractWithMarkItDown(pi, url, signal);
   if (markitdownExtracted) {
-    return { extracted: markitdownExtracted, title: titleFromMarkdown(markitdownExtracted) };
+    return {
+      extracted: markitdownExtracted,
+      title: titleFromMarkdown(markitdownExtracted),
+      extractor: "markitdown",
+      extraction_status: "success",
+    };
   }
 
   const curlExtracted = await fetchTextUrl(pi, url, signal);
-  if (!curlExtracted) return { extracted: "" };
-  if (looksLikePdf(curlExtracted)) return { extracted: pdfExtractionFailureMessage(url) };
-  return { extracted: curlExtracted, title: titleFromHtml(curlExtracted) };
+  if (!curlExtracted) return { extracted: "", extractor: "none", extraction_status: "failed" };
+  if (looksLikePdf(curlExtracted)) {
+    return {
+      extracted: pdfExtractionFailureMessage(url),
+      extractor: "curl",
+      extraction_status: "failed",
+      content_type: "application/pdf",
+    };
+  }
+  return {
+    extracted: curlExtracted,
+    title: titleFromHtml(curlExtracted),
+    extractor: "curl",
+    extraction_status: "success",
+  };
 }
 
 async function extractWithMarkItDown(

--- a/extensions/llm-wiki/lib/source-extractors.ts
+++ b/extensions/llm-wiki/lib/source-extractors.ts
@@ -111,7 +111,11 @@ export function pdfExtractionFailureMessage(source: string): string {
   return `_PDF content could not be converted to markdown from ${source}. Try increasing WIKI_MARKITDOWN_TIMEOUT_MS._\n`;
 }
 
-function textFileExtractor(format: string, extensions: string[], contentType?: string): FileExtractor {
+function textFileExtractor(
+  format: string,
+  extensions: string[],
+  contentType?: string,
+): FileExtractor {
   return {
     format,
     shouldReadText: true,
@@ -139,7 +143,11 @@ export function docxExtractionFailureMessage(source: string): string {
   return `_DOCX content could not be converted to markdown from ${source}. Ensure uvx and markitdown are installed._\n`;
 }
 
-async function extractDocx(pi: ExtensionAPI, source: string, signal?: AbortSignal): Promise<string> {
+async function extractDocx(
+  pi: ExtensionAPI,
+  source: string,
+  signal?: AbortSignal,
+): Promise<string> {
   const extracted = await extractWithMarkItDown(pi, source, signal);
   return extracted || docxExtractionFailureMessage(source);
 }

--- a/extensions/llm-wiki/lib/source-packet.ts
+++ b/extensions/llm-wiki/lib/source-packet.ts
@@ -106,9 +106,16 @@ function fileCaptureSource(
     fallbackText: "",
     preserveOriginal: (packetPath) =>
       preserveFileOriginal(pi, packetPath, filePath, fileName, content, signal),
-    extract: async () => ({
-      extracted: await extractor.extract({ pi, filePath, content, signal }),
-    }),
+    extract: async () => {
+      const extractedStr = await extractor.extract({ pi, filePath, content, signal });
+      const failed = extractedStr.includes("could not be converted");
+      return {
+        extracted: extractedStr,
+        extractor: extractor.extractorName ?? "passthrough",
+        extraction_status: (failed ? "failed" : "success") as "failed" | "success",
+        ...(extractor.content_type ? { content_type: extractor.content_type } : {}),
+      };
+    },
     manifest: () => ({
       title: fileName,
       file_path: filePath,
@@ -152,6 +159,9 @@ function finalizeCapture(
     captured: fmtDate(),
     packet_version: "1.0",
     ...source.manifest({ ...content, extracted }),
+    extractor: content.extractor ?? "passthrough",
+    extraction_status: content.extraction_status ?? "success",
+    ...(content.content_type ? { content_type: content.content_type } : {}),
   };
 
   writeFileSync(join(packet.packetPath, "extracted.md"), extracted, "utf-8");

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -66,6 +66,20 @@ export function createWikiPage(dir: string, subdir: string | "", name: string, c
   writeFileSync(target, content);
 }
 
+export function mockPiWithMarkItDown(markdownOutput: string) {
+  return {
+    exec: async (command: string, args: string[]) => {
+      if (command === "sh") {
+        const cmd = args[1] ?? "";
+        if (cmd.includes("which uvx")) return { stdout: "yes\n", stderr: "", code: 0 };
+        if (cmd.includes("markitdown")) return { stdout: markdownOutput, stderr: "", code: 0 };
+      }
+      if (command === "cp") return { stdout: "", stderr: "", code: 0 };
+      throw new Error(`Unexpected command: ${command}`);
+    },
+  };
+}
+
 export function mockPi(stdout?: string, writeOriginal = true) {
   const html = "<html><head><title>Example Page</title></head><body>Hello</body></html>";
   return {

--- a/test/source-capture.test.ts
+++ b/test/source-capture.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureFile, captureText, captureUrl } from "../extensions/llm-wiki/lib/source-packet.js";
 import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
-import { mockPi, readFile } from "./helpers.js";
+import { mockPi, mockPiWithMarkItDown, readFile } from "./helpers.js";
 
 describe("source packet capture", () => {
   const html = "<html><head><title>Example Page</title></head><body>Hello</body></html>";
@@ -236,5 +236,70 @@ describe("source packet capture", () => {
 
     const extracted = readFile(join(result.packetPath, "extracted.md"));
     expect(extracted).toBe(jsonContent);
+  });
+
+  it("should write a failure message for .docx files when MarkItDown is unavailable", async () => {
+    const paths = makePaths();
+    const docxPath = join(tmpDir, "report.docx");
+    writeFileSync(docxPath, Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00]));
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, docxPath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).not.toContain("PK");
+    expect(extracted).toContain("DOCX content could not be converted");
+    expect(extracted).toContain("report.docx");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.format).toBe("docx");
+    expect(manifest.extraction_status).toBe("failed");
+    expect(manifest.extractor).toBe("markitdown");
+  });
+
+  it("should convert .docx content to markdown via MarkItDown when available", async () => {
+    const paths = makePaths();
+    const docxPath = join(tmpDir, "proposal.docx");
+    writeFileSync(docxPath, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+
+    const pi = mockPiWithMarkItDown("# Proposal\n\nThis is the extracted content.");
+    const result = await captureFile(pi as never, paths, docxPath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("# Proposal");
+    expect(extracted).toContain("extracted content");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.format).toBe("docx");
+    expect(manifest.extraction_status).toBe("success");
+    expect(manifest.extractor).toBe("markitdown");
+  });
+
+  it("should record extractor and extraction_status in manifest for XML captures", async () => {
+    const paths = makePaths();
+    const xmlPath = join(tmpDir, "data.xml");
+    writeFileSync(xmlPath, "<root><title>Test</title><body>Content here.</body></root>", "utf-8");
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, xmlPath);
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.extractor).toBe("xmlToMarkdown");
+    expect(manifest.extraction_status).toBe("success");
+    expect(manifest.content_type).toBe("application/xml");
+  });
+
+  it("should record extractor and extraction_status in manifest for JSON captures", async () => {
+    const paths = makePaths();
+    const jsonPath = join(tmpDir, "data.json");
+    writeFileSync(jsonPath, JSON.stringify({ title: "Test", value: 42 }), "utf-8");
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, jsonPath);
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.extractor).toBe("jsonToMarkdown");
+    expect(manifest.extraction_status).toBe("success");
+    expect(manifest.content_type).toBe("application/json");
   });
 });


### PR DESCRIPTION
## Summary

Closes #4 — reported by @jfraser.

Two concrete gaps remained from the source-type aware extraction pipeline requested in #4. This PR addresses both.

---

## Problem

### 1. Word documents produced binary garbage

Capturing a `.docx` file wrote raw binary bytes into `extracted.md`. DOCX files are ZIP archives — reading them as plain text produces unreadable noise like `PK♦♦☺☺`. The LLM cannot use this content for anything.

### 2. Manifests had no record of how extraction went

Every captured source creates a `manifest.json` receipt. That file recorded the source title, URL or path, format, and timestamp — but nothing about the extraction itself. If a capture failed or produced bad output, there was no way to tell from the manifest what happened or which tool was used.

The packet contract says `extracted.md` should always be normalized markdown. Manifests should record how that extraction was performed.

---

## What changed

### DOCX now routes through MarkItDown

`.docx` files are now handled the same way as PDFs — sent through MarkItDown (`uvx markitdown`), which supports Word documents natively. If MarkItDown is not installed, the user gets a clear human-readable message instead of binary content:

```
_DOCX content could not be converted to markdown from report.docx.
Ensure uvx and markitdown are installed._
```

### Every manifest now records extraction metadata

Three new fields are written to `manifest.json` for every capture:

```json
{
  "extractor": "markitdown",
  "extraction_status": "success",
  "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
}
```

- `extractor` — which tool ran (e.g. `markitdown`, `xmlToMarkdown`, `jsonToMarkdown`, `curl`, `passthrough`)
- `extraction_status` — `success` or `failed`
- `content_type` — MIME type where known

This applies to all file types: PDF, XML, JSON, DOCX, markdown, text, and web URLs.

---

## Status against #4's checklist

| Item | Status |
|------|--------|
| PDF — no raw bytes | ✅ Already fixed (PR #5) |
| XML — readable markdown | ✅ Already fixed (PR #14) |
| JSON — readable markdown | ✅ Already fixed (PR #15) |
| DOCX — readable markdown | ✅ **This PR** |
| `extractor`, `extraction_status`, `content_type` in manifest | ✅ **This PR** |
| HTML normalization | ⏳ Deferred — separate issue |
| Magic bytes for unknown binary | ⏳ Deferred — separate issue |

---

## Changes

**`source-extractors.ts`**
- Add `ExtractionStatus` type and extend `ExtractedContent` with `extractor`, `extraction_status`, `content_type`
- Add `extractorName` and `content_type` to `FileExtractor` interface
- Annotate all `FILE_EXTRACTORS` entries with metadata
- Replace `textFileExtractor("docx", ...)` with a proper MarkItDown-backed entry
- Add `extractDocx()` and `docxExtractionFailureMessage()`
- Return extraction metadata from `extractPdfUrl` and `extractTextUrl`

**`source-packet.ts`**
- `fileCaptureSource.extract` builds full `ExtractedContent` including metadata from the extractor
- `finalizeCapture` merges `extractor`, `extraction_status`, `content_type` into every manifest

**`test/helpers.ts`**
- Add `mockPiWithMarkItDown(markdownOutput)` test helper

**`test/source-capture.test.ts`**
- 4 new tests: DOCX failure path, DOCX success path, XML manifest fields, JSON manifest fields

## Validation

- `npm test` — 94 tests pass (was 90)