### PR TITLE
feat: magic bytes detection for unknown binary file captures

### DIFF
--- a/extensions/llm-wiki/lib/source-extractors.ts
+++ b/extensions/llm-wiki/lib/source-extractors.ts
@@ -1,3 +1,4 @@
+import { open } from "node:fs/promises";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { exec } from "./utils.js";
 
@@ -37,6 +38,67 @@ interface UrlExtractArgs {
   url: string;
   signal?: AbortSignal;
 }
+
+// ---------------------------------------------------------------------------
+// Binary magic byte detection
+// ---------------------------------------------------------------------------
+
+const BINARY_SIGNATURES: Array<{ bytes: number[]; format: string }> = [
+  // Archives & documents
+  { bytes: [0x50, 0x4b, 0x03, 0x04], format: "zip" }, // ZIP / DOCX / XLSX / PPTX / JAR
+  { bytes: [0x25, 0x50, 0x44, 0x46], format: "pdf" }, // %PDF
+  { bytes: [0x37, 0x7a, 0xbc, 0xaf], format: "7z" }, // 7-Zip
+  { bytes: [0x1f, 0x8b], format: "gzip" }, // gzip / .tar.gz
+  // Images
+  { bytes: [0x89, 0x50, 0x4e, 0x47], format: "png" }, // PNG
+  { bytes: [0xff, 0xd8, 0xff], format: "jpeg" }, // JPEG
+  { bytes: [0x47, 0x49, 0x46, 0x38], format: "gif" }, // GIF8
+  { bytes: [0x42, 0x4d], format: "bmp" }, // BMP
+  { bytes: [0x49, 0x49, 0x2a, 0x00], format: "tiff" }, // TIFF (little-endian)
+  { bytes: [0x4d, 0x4d, 0x00, 0x2a], format: "tiff" }, // TIFF (big-endian)
+  { bytes: [0x52, 0x49, 0x46, 0x46], format: "riff" }, // RIFF (WAV / AVI / WebP)
+  // Executables & binaries
+  { bytes: [0x4d, 0x5a], format: "exe" }, // Windows PE (EXE / DLL)
+  { bytes: [0xcf, 0xfa, 0xed, 0xfe], format: "macho" }, // Mach-O 64-bit LE
+  { bytes: [0xce, 0xfa, 0xed, 0xfe], format: "macho" }, // Mach-O 32-bit LE
+  { bytes: [0xfe, 0xed, 0xfa, 0xcf], format: "macho" }, // Mach-O 64-bit BE
+  { bytes: [0xfe, 0xed, 0xfa, 0xce], format: "macho" }, // Mach-O 32-bit BE
+  { bytes: [0xca, 0xfe, 0xba, 0xbe], format: "class" }, // Java .class / Mach-O FAT
+  { bytes: [0x7f, 0x45, 0x4c, 0x46], format: "elf" }, // ELF binary
+  { bytes: [0x00, 0x61, 0x73, 0x6d], format: "wasm" }, // WebAssembly
+  // Data & media
+  { bytes: [0x53, 0x51, 0x4c, 0x69], format: "sqlite" }, // SQLite
+  { bytes: [0x49, 0x44, 0x33], format: "mp3" }, // MP3 (ID3 tag)
+];
+
+/**
+ * Reads the first 8 bytes of `filePath` and checks them against known binary
+ * magic byte signatures. Returns the detected format name or `null` for text.
+ */
+export async function detectBinaryMagicBytes(filePath: string): Promise<string | null> {
+  let handle: import("node:fs/promises").FileHandle | undefined;
+  try {
+    handle = await open(filePath, "r");
+    const buf = Buffer.alloc(8);
+    const { bytesRead } = await handle.read(buf, 0, 8, 0);
+    const header = buf.subarray(0, bytesRead);
+
+    for (const { bytes, format } of BINARY_SIGNATURES) {
+      if (bytes.every((b, i) => header[i] === b)) return format;
+    }
+    return null;
+  } catch {
+    return null; // Unreadable file — let the extractor deal with it
+  } finally {
+    await handle?.close();
+  }
+}
+
+export function binaryExtractionFailureMessage(format: string): string {
+  return `_Binary file could not be converted to markdown (detected format: ${format}).\nCapture a text-based version or a URL pointing to readable content instead._\n`;
+}
+
+// ---------------------------------------------------------------------------
 
 const DEFAULT_MARKITDOWN_TIMEOUT_MS = 180_000;
 const DEFAULT_CURL_TIMEOUT_SECONDS = 30;

--- a/extensions/llm-wiki/lib/source-packet.ts
+++ b/extensions/llm-wiki/lib/source-packet.ts
@@ -2,7 +2,13 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { extname, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { appendEvent } from "./metadata.js";
-import { type ExtractedContent, extractUrlContent, fileExtractorFor } from "./source-extractors.js";
+import {
+  type ExtractedContent,
+  binaryExtractionFailureMessage,
+  detectBinaryMagicBytes,
+  extractUrlContent,
+  fileExtractorFor,
+} from "./source-extractors.js";
 import { type VaultPaths, exec, fmtDate, nextSourceId, readText, writeJson } from "./utils.js";
 
 /**
@@ -107,6 +113,18 @@ function fileCaptureSource(
     preserveOriginal: (packetPath) =>
       preserveFileOriginal(pi, packetPath, filePath, fileName, content, signal),
     extract: async () => {
+      // Guard: if we hit the generic catch-all extractor, check for binary magic bytes first
+      if (extractor.format === "file") {
+        const binaryFormat = await detectBinaryMagicBytes(filePath);
+        if (binaryFormat) {
+          return {
+            extracted: binaryExtractionFailureMessage(binaryFormat),
+            extractor: "magicBytes",
+            extraction_status: "unsupported" as const,
+          };
+        }
+      }
+
       const extractedStr = await extractor.extract({ pi, filePath, content, signal });
       const failed = extractedStr.includes("could not be converted");
       return {

--- a/test/e2e-binary-detection.test.ts
+++ b/test/e2e-binary-detection.test.ts
@@ -1,0 +1,320 @@
+/**
+ * E2E tests for magic bytes binary detection (Issue #56).
+ *
+ * Covers:
+ *   - Each of the 7 binary signatures bails out with a clear failure message
+ *     and sets extraction_status: "unsupported" in the manifest
+ *   - Plain text files with no extension are still captured correctly
+ *   - Plain text files with an unrecognised extension are still captured correctly
+ *   - Named extractors (.md, .pdf, .docx, .json, .xml) are NOT intercepted by the guard
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureFile } from "../extensions/llm-wiki/lib/source-packet.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+import { mockPi, readFile } from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMagicBytes(hex: number[]): Buffer {
+  // Pad to 64 bytes so the file is clearly "binary" in practice
+  const buf = Buffer.alloc(64, 0x00);
+  for (const [i, b] of hex.entries()) buf[i] = b;
+  return buf;
+}
+
+const SIGNATURES = [
+  // Archives & documents
+  { label: "ZIP (PK header)", format: "zip", bytes: [0x50, 0x4b, 0x03, 0x04] },
+  { label: "PDF (%PDF)", format: "pdf", bytes: [0x25, 0x50, 0x44, 0x46] },
+  { label: "7-Zip", format: "7z", bytes: [0x37, 0x7a, 0xbc, 0xaf] },
+  { label: "gzip", format: "gzip", bytes: [0x1f, 0x8b] },
+  // Images
+  { label: "PNG", format: "png", bytes: [0x89, 0x50, 0x4e, 0x47] },
+  { label: "JPEG", format: "jpeg", bytes: [0xff, 0xd8, 0xff] },
+  { label: "GIF", format: "gif", bytes: [0x47, 0x49, 0x46, 0x38] },
+  { label: "BMP", format: "bmp", bytes: [0x42, 0x4d] },
+  { label: "TIFF (little-endian)", format: "tiff", bytes: [0x49, 0x49, 0x2a, 0x00] },
+  { label: "TIFF (big-endian)", format: "tiff", bytes: [0x4d, 0x4d, 0x00, 0x2a] },
+  { label: "RIFF (WAV/AVI/WebP)", format: "riff", bytes: [0x52, 0x49, 0x46, 0x46] },
+  // Executables & binaries
+  { label: "Windows EXE/DLL (MZ)", format: "exe", bytes: [0x4d, 0x5a] },
+  { label: "Mach-O 64-bit LE", format: "macho", bytes: [0xcf, 0xfa, 0xed, 0xfe] },
+  { label: "Mach-O 32-bit LE", format: "macho", bytes: [0xce, 0xfa, 0xed, 0xfe] },
+  { label: "Mach-O 64-bit BE", format: "macho", bytes: [0xfe, 0xed, 0xfa, 0xcf] },
+  { label: "Mach-O 32-bit BE", format: "macho", bytes: [0xfe, 0xed, 0xfa, 0xce] },
+  { label: "Java .class / Mach-O FAT", format: "class", bytes: [0xca, 0xfe, 0xba, 0xbe] },
+  { label: "ELF binary", format: "elf", bytes: [0x7f, 0x45, 0x4c, 0x46] },
+  { label: "WebAssembly", format: "wasm", bytes: [0x00, 0x61, 0x73, 0x6d] },
+  // Data & media
+  { label: "SQLite", format: "sqlite", bytes: [0x53, 0x51, 0x4c, 0x69] },
+  { label: "MP3 (ID3)", format: "mp3", bytes: [0x49, 0x44, 0x33] },
+] as const;
+
+describe("binary magic bytes detection", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dirname, "..", "tmp", `binary-detection-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  function makePaths() {
+    const p = getVaultPaths(join(tmpDir, `wiki-${Math.random().toString(36).slice(2)}`));
+    ensureVaultStructure(p);
+    return p;
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. Binary signatures → clear failure message + unsupported status
+  // -------------------------------------------------------------------------
+
+  describe("binary files with no extension are rejected", () => {
+    for (const { label, format, bytes } of SIGNATURES) {
+      it(`should write a failure message for ${label} files (no extension)`, async () => {
+        const paths = makePaths();
+        const filePath = join(tmpDir, `binary-${format}`);
+        writeFileSync(filePath, makeMagicBytes([...bytes]));
+
+        const pi = mockPi();
+        const result = await captureFile(pi as never, paths, filePath);
+
+        const extracted = readFile(join(result.packetPath, "extracted.md"));
+        expect(extracted).toContain("Binary file could not be converted to markdown");
+        expect(extracted).toContain(`detected format: ${format}`);
+        expect(extracted).not.toContain("\u0000"); // no raw binary bytes
+
+        const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+        expect(manifest.extraction_status).toBe("unsupported");
+        expect(manifest.extractor).toBe("magicBytes");
+      });
+    }
+  });
+
+  describe("binary files with unrecognised extension are rejected", () => {
+    for (const { label, format, bytes } of SIGNATURES) {
+      it(`should write a failure message for ${label} with a .bin extension`, async () => {
+        const paths = makePaths();
+        const filePath = join(tmpDir, "data.bin");
+        writeFileSync(filePath, makeMagicBytes([...bytes]));
+
+        const pi = mockPi();
+        const result = await captureFile(pi as never, paths, filePath);
+
+        const extracted = readFile(join(result.packetPath, "extracted.md"));
+        expect(extracted).toContain("Binary file could not be converted to markdown");
+        expect(extracted).toContain(`detected format: ${format}`);
+
+        const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+        expect(manifest.extraction_status).toBe("unsupported");
+      });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Failure message format
+  // -------------------------------------------------------------------------
+
+  it("failure message should include a hint to use a text-based alternative", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "image");
+    writeFileSync(filePath, makeMagicBytes([0x89, 0x50, 0x4e, 0x47])); // PNG
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("Capture a text-based version");
+  });
+
+  it("manifest format should remain 'file' for unrecognised binary files", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "mystery");
+    writeFileSync(filePath, makeMagicBytes([0x7f, 0x45, 0x4c, 0x46])); // ELF
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.format).toBe("file");
+    expect(manifest.extraction_status).toBe("unsupported");
+    expect(manifest.extractor).toBe("magicBytes");
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Plain text files still work
+  // -------------------------------------------------------------------------
+
+  it("should capture a plain text file with no extension successfully", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "plaintext");
+    writeFileSync(filePath, "This is plain text content.\nSecond line.", "utf-8");
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("This is plain text content.");
+    expect(extracted).toContain("Second line.");
+    expect(extracted).not.toContain("Binary file could not be converted");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.extraction_status).toBe("success");
+    expect(manifest.extractor).toBe("passthrough");
+  });
+
+  it("should capture a plain text file with an unrecognised extension successfully", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "app.config");
+    writeFileSync(filePath, "key=value\ndebug=true\n", "utf-8");
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("key=value");
+    expect(extracted).toContain("debug=true");
+    expect(extracted).not.toContain("Binary file could not be converted");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.extraction_status).toBe("success");
+  });
+
+  it("should capture a YAML-like text file with an unrecognised extension successfully", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "setup.env");
+    writeFileSync(filePath, "NODE_ENV=production\nPORT=3000\n", "utf-8");
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("NODE_ENV=production");
+    expect(extracted).not.toContain("Binary file could not be converted");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.extraction_status).toBe("success");
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Named extractors are NOT intercepted by the binary guard
+  // -------------------------------------------------------------------------
+
+  it("should NOT intercept .md files — passthrough extractor runs as before", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "notes.md");
+    writeFileSync(filePath, "# Hello\n\nSome markdown.", "utf-8");
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("# Hello");
+    expect(extracted).not.toContain("Binary file could not be converted");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.format).toBe("markdown");
+    expect(manifest.extraction_status).toBe("success");
+    expect(manifest.extractor).toBe("passthrough");
+  });
+
+  it("should NOT intercept .json files — jsonToMarkdown extractor runs as before", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "data.json");
+    writeFileSync(filePath, JSON.stringify({ title: "Test", value: 42 }), "utf-8");
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("# Test");
+    expect(extracted).not.toContain("Binary file could not be converted");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.format).toBe("json");
+    expect(manifest.extractor).toBe("jsonToMarkdown");
+    expect(manifest.extraction_status).toBe("success");
+  });
+
+  it("should NOT intercept .xml files — xmlToMarkdown extractor runs as before", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "feed.xml");
+    writeFileSync(
+      filePath,
+      `<?xml version="1.0"?><root><title>XML Feed</title><body>Content</body></root>`,
+      "utf-8",
+    );
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("XML Feed");
+    expect(extracted).not.toContain("Binary file could not be converted");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.format).toBe("xml");
+    expect(manifest.extractor).toBe("xmlToMarkdown");
+  });
+
+  it("should NOT intercept .pdf files — markitdown extractor runs as before (failure path)", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "report.pdf");
+    // Real PDF magic bytes — but we want to confirm the .pdf extractor handles it, not magic bytes
+    writeFileSync(filePath, Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]));
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.format).toBe("pdf");
+    // Extractor should be "markitdown", not "magicBytes"
+    expect(manifest.extractor).toBe("markitdown");
+    expect(manifest.extraction_status).toBe("failed"); // MarkItDown unavailable in test env
+  });
+
+  it("should NOT intercept .docx files — markitdown extractor runs as before (failure path)", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "doc.docx");
+    // DOCX starts with PK (ZIP) magic bytes — guard must NOT fire for named extractors
+    writeFileSync(filePath, Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00]));
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.format).toBe("docx");
+    expect(manifest.extractor).toBe("markitdown");
+    // Must NOT be "unsupported" — failure is expected here, but from the docx extractor
+    expect(manifest.extraction_status).toBe("failed");
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Source page is still written even for unsupported binaries
+  // -------------------------------------------------------------------------
+
+  it("should still create a source page skeleton for unsupported binary files", async () => {
+    const paths = makePaths();
+    const filePath = join(tmpDir, "photo");
+    writeFileSync(filePath, makeMagicBytes([0x89, 0x50, 0x4e, 0x47])); // PNG
+
+    const pi = mockPi();
+    const result = await captureFile(pi as never, paths, filePath);
+
+    const sourcePage = readFile(result.sourcePagePath);
+    expect(sourcePage).toContain("type: source");
+    expect(sourcePage).toContain(result.sourceId);
+    expect(sourcePage).toContain("## Summary");
+    expect(sourcePage).toContain("## Key Takeaways");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #56. Deferred from #4.

When a user captured a file with an unrecognised or missing extension, the catch-all `textFileExtractor("file", [])` read raw bytes as UTF-8 and wrote garbage to `extracted.md`. This PR adds magic bytes detection to block binary files before they reach the extractor.

## Changes

### `extensions/llm-wiki/lib/source-extractors.ts`
- **`BINARY_SIGNATURES`** — 21 signatures across 4 categories (no new runtime deps, ≤8 bytes read per file)
- **`detectBinaryMagicBytes(filePath)`** — opens file, reads first 8 bytes, returns format name or `null` for text; safe fd cleanup via `finally`
- **`binaryExtractionFailureMessage(format)`** — clear user-facing message with actionable hint

### `extensions/llm-wiki/lib/source-packet.ts`
- Guard added in `fileCaptureSource` scoped to `extractor.format === "file"` only — named extractors (`.pdf`, `.docx`, `.md`, `.json`, `.xml`) are completely unaffected
- Binary files get `extraction_status: "unsupported"`, `extractor: "magicBytes"` in the manifest

## Covered formats

| Category | Formats |
|---|---|
| Archives | `zip`, `pdf`, `7z`, `gzip` |
| Images | `png`, `jpeg`, `gif`, `bmp`, `tiff` (×2 LE/BE), `riff` (WAV/AVI/WebP) |
| Executables | `exe`, `macho` (×4 variants), `class`, `elf`, `wasm` |
| Data/media | `sqlite`, `mp3` |

## Tests

53 new e2e tests in `test/e2e-binary-detection.test.ts` covering:
- All 21 signatures — no extension and unknown extension (`.bin`)
- Plain text files with no extension still captured correctly
- Named extractors not intercepted by the guard
- Failure message content and hint text
- Source page skeleton still written for unsupported files
- Manifest fields (`extraction_status`, `extractor`, `format`)

## Checklist

- [x] `detectBinaryMagicBytes` reads ≤ 8 bytes and returns format name or `null`
- [x] Capturing a PNG writes `_Binary file could not be converted…_` to `extracted.md`
- [x] Capturing a ZIP writes `_Binary file could not be converted…_` to `extracted.md`
- [x] `extraction_status` is `"unsupported"` in the manifest for all detected binary files
- [x] Plain text files with no extension still produce `extraction_status: "success"`
- [x] `.md`, `.pdf`, `.docx`, `.json`, `.xml` files are not affected
- [x] No new runtime dependencies
- [x] All 161 tests pass
- [x] TypeScript clean
- [x] Biome lint clean