### PR TITLE
feat: HTML normalization for web URL captures

### DIFF
--- a/extensions/llm-wiki/lib/source-extractors.ts
+++ b/extensions/llm-wiki/lib/source-extractors.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { NodeHtmlMarkdown } from "node-html-markdown";
 import { exec } from "./utils.js";
 
 export type ExtractionStatus = "success" | "failed" | "unsupported";
@@ -193,10 +194,11 @@ async function extractTextUrl(
       content_type: "application/pdf",
     };
   }
+  const normalized = htmlToMarkdown(curlExtracted);
   return {
-    extracted: curlExtracted,
-    title: titleFromHtml(curlExtracted),
-    extractor: "curl",
+    extracted: normalized,
+    title: titleFromMarkdown(normalized) ?? titleFromHtml(curlExtracted),
+    extractor: "htmlToMarkdown",
     extraction_status: "success",
   };
 }
@@ -279,6 +281,23 @@ function titleFromHtml(html: string): string | undefined {
   return html.match(/<title>([^<]*)<\/title>/i)?.[1]?.trim();
 }
 
+/** Decode common HTML/XML entities. Shared by xmlToMarkdown and htmlToMarkdown. */
+function decodeHtmlEntities(text: string): string {
+  return text.replace(/&(?:amp|lt|gt|quot|apos|#\d+);/gi, (entity) => {
+    const map: Record<string, string> = {
+      "&amp;": "&",
+      "&lt;": "<",
+      "&gt;": ">",
+      "&quot;": '"',
+      "&apos;": "'",
+    };
+    const lower = entity.toLowerCase();
+    if (map[lower]) return map[lower];
+    if (lower.startsWith("&#")) return String.fromCodePoint(Number.parseInt(entity.slice(2, -1)));
+    return entity;
+  });
+}
+
 /** Basic XML to markdown conversion: strip tags while preserving text structure. */
 function xmlToMarkdown(xml: string): string {
   let title = "";
@@ -297,14 +316,7 @@ function xmlToMarkdown(xml: string): string {
   }
   text = text.replace(/</g, "");
 
-  text = text.replace(/&(?:amp|lt|gt|quot|#\d+);/gi, (entity) => {
-    const map: Record<string, string> = { "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"' };
-    const lower = entity.toLowerCase();
-    if (map[lower]) return map[lower];
-    if (lower.startsWith("&#")) return String.fromCodePoint(Number.parseInt(entity.slice(2, -1)));
-    return entity;
-  });
-
+  text = decodeHtmlEntities(text);
   text = text.replace(/\n{3,}/g, "\n\n").trim();
   if (!text) return xml;
 
@@ -312,6 +324,37 @@ function xmlToMarkdown(xml: string): string {
   if (title) lines.push(`# ${title}\n`);
   lines.push(text);
   return lines.join("\n\n");
+}
+
+/**
+ * Lightweight HTML-to-markdown normalizer for the curl fallback path.
+ *
+ * Pre-strips page chrome (nav, header, footer, script, style) that
+ * node-html-markdown does not remove, then delegates full conversion —
+ * bold, italic, code blocks, tables, ordered lists, image alt text — to
+ * node-html-markdown. Prepends the <title> as a # heading when the body
+ * has no <h1> of its own.
+ *
+ * Falls back to the original HTML if conversion yields an empty string.
+ */
+export function htmlToMarkdown(input: string): string {
+  // 1. Extract <title> from original before stripping head
+  const title = input.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1]?.trim() ?? "";
+
+  // 2. Strip <head> and noise blocks that node-html-markdown won't remove
+  let html = input.replace(/<head[\s\S]*?<\/head>/gi, "");
+  html = html.replace(/<(script|style|nav|header|footer|noscript)[\s\S]*?<\/\1>/gi, "");
+
+  // 3. Delegate to node-html-markdown for full semantic conversion
+  const converted = NodeHtmlMarkdown.translate(html).trim();
+  if (!converted) return input;
+
+  // 4. Prepend <title> as # heading only if body has no <h1> of its own
+  const hasBodyH1 = /<h1[^>]*>[\s\S]*?<\/h1>/i.test(html);
+  const lines: string[] = [];
+  if (title && !hasBodyH1) lines.push(`# ${title}\n`);
+  lines.push(converted);
+  return lines.join("\n");
 }
 
 function jsonToMarkdown(json: string): string {

--- a/extensions/llm-wiki/lib/source-extractors.ts
+++ b/extensions/llm-wiki/lib/source-extractors.ts
@@ -343,7 +343,11 @@ export function htmlToMarkdown(input: string): string {
 
   // 2. Strip <head> and noise blocks that node-html-markdown won't remove
   let html = input.replace(/<head[\s\S]*?<\/head>/gi, "");
-  html = html.replace(/<(script|style|nav|header|footer|noscript)[\s\S]*?<\/\1>/gi, "");
+  let previousHtml = "";
+  while (previousHtml !== html) {
+    previousHtml = html;
+    html = html.replace(/<(script|style|nav|header|footer|noscript)[\s\S]*?<\/\1>/gi, "");
+  }
 
   // 3. Delegate to node-html-markdown for full semantic conversion
   const converted = NodeHtmlMarkdown.translate(html).trim();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/server": "^2.0.0-alpha.2"
+        "@modelcontextprotocol/server": "^2.0.0-alpha.2",
+        "node-html-markdown": "^2.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -4676,6 +4677,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -5124,6 +5131,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -5792,6 +5827,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
@@ -5800,6 +5876,20 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/eastasianwidth": {
@@ -5834,6 +5924,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -6498,6 +6600,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/highlight.js": {
@@ -7378,6 +7489,28 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-html-markdown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-2.0.0.tgz",
+      "integrity": "sha512-DqUC3GGP7pwSYxS93SwHoP+qCw78xcMP6C6H2DuC8rPD2AweJRjBzQb5SdXpKtDlqAQ7hVotJcfhgU7hU5Gthw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-html-parser": "^6.1.13"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -7386,6 +7519,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@modelcontextprotocol/server": "^2.0.0-alpha.2"
+    "@modelcontextprotocol/server": "^2.0.0-alpha.2",
+    "node-html-markdown": "^2.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/test/e2e-html-normalization.test.ts
+++ b/test/e2e-html-normalization.test.ts
@@ -1,0 +1,369 @@
+/**
+ * E2E tests for HTML normalization on the curl fallback path (Issue #55).
+ *
+ * All tests go through captureUrl with mockPi(html) — same pipeline pi uses
+ * when MarkItDown is unavailable and curl fetches the page.
+ *
+ * Also tests htmlToMarkdown directly for unit-level coverage of each rule.
+ */
+
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { htmlToMarkdown } from "../extensions/llm-wiki/lib/source-extractors.js";
+import { captureUrl } from "../extensions/llm-wiki/lib/source-packet.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+import { mockPi, mockPiWithMarkItDown, readFile } from "./helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function wrap(body: string, title = "Test Page") {
+  return `<!DOCTYPE html><html><head><title>${title}</title></head><body>${body}</body></html>`;
+}
+
+describe("HTML normalization (issue #55)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dirname, "..", "tmp", `html-norm-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  function makePaths() {
+    const p = getVaultPaths(join(tmpDir, `wiki-${Math.random().toString(36).slice(2)}`));
+    ensureVaultStructure(p);
+    return p;
+  }
+
+  // ── Unit tests for htmlToMarkdown ────────────────────────────────────────
+
+  describe("htmlToMarkdown unit", () => {
+    it("extracts <title> as # heading", () => {
+      const out = htmlToMarkdown(wrap("<p>Content</p>", "My Article"));
+      expect(out).toMatch(/^# My Article/);
+    });
+
+    it("removes <head> block entirely", () => {
+      const out = htmlToMarkdown(
+        `<html><head><title>T</title><meta charset="utf-8"><link rel="stylesheet" href="/s.css"></head><body>Body</body></html>`,
+      );
+      expect(out).not.toContain("<meta");
+      expect(out).not.toContain("<link");
+      expect(out).not.toContain("stylesheet");
+    });
+
+    it("strips <script> blocks and their content entirely", () => {
+      const out = htmlToMarkdown(
+        wrap('<script>alert("xss"); var secret = 42;</script><p>Real content</p>'),
+      );
+      expect(out).not.toContain("alert");
+      expect(out).not.toContain("secret");
+      expect(out).not.toContain("<script>");
+      expect(out).toContain("Real content");
+    });
+
+    it("strips <style> blocks and their content entirely", () => {
+      const out = htmlToMarkdown(wrap("<style>.nav { display:none }</style><p>Text</p>"));
+      expect(out).not.toContain(".nav");
+      expect(out).not.toContain("display:none");
+      expect(out).toContain("Text");
+    });
+
+    it("strips <nav> block and its content entirely", () => {
+      const out = htmlToMarkdown(
+        wrap("<nav><a href='/home'>Home</a><a href='/about'>About</a></nav><p>Article</p>"),
+      );
+      expect(out).not.toContain("Home");
+      expect(out).not.toContain("About");
+      expect(out).toContain("Article");
+    });
+
+    it("strips <header> block and its content entirely", () => {
+      const out = htmlToMarkdown(wrap("<header><h1>Site Name</h1></header><p>Article</p>"));
+      // header block removed — "Site Name" should not appear
+      expect(out).not.toContain("Site Name");
+      expect(out).toContain("Article");
+    });
+
+    it("strips <footer> block and its content entirely", () => {
+      const out = htmlToMarkdown(wrap("<p>Content</p><footer>Copyright 2025</footer>"));
+      expect(out).not.toContain("Copyright 2025");
+      expect(out).toContain("Content");
+    });
+
+    it("strips <noscript> block and its content entirely", () => {
+      const out = htmlToMarkdown(wrap("<noscript>Enable JavaScript</noscript><p>Content</p>"));
+      expect(out).not.toContain("Enable JavaScript");
+      expect(out).toContain("Content");
+    });
+
+    it("converts <h1>–<h6> to markdown # headings preserving level", () => {
+      const out = htmlToMarkdown(
+        wrap("<h1>One</h1><h2>Two</h2><h3>Three</h3><h4>Four</h4><h5>Five</h5><h6>Six</h6>"),
+      );
+      expect(out).toContain("# One");
+      expect(out).toContain("## Two");
+      expect(out).toContain("### Three");
+      expect(out).toContain("#### Four");
+      expect(out).toContain("##### Five");
+      expect(out).toContain("###### Six");
+    });
+
+    it("strips inner tags from heading content", () => {
+      const out = htmlToMarkdown(wrap("<h2><strong>Bold</strong> heading</h2>"));
+      // node-html-markdown preserves inline formatting inside headings
+      expect(out).toContain("## ");
+      expect(out).toContain("Bold");
+      expect(out).toContain("heading");
+      expect(out).not.toContain("<strong>");
+      expect(out).not.toContain("<h2>");
+    });
+
+    it("converts <a href> to [text](url)", () => {
+      const out = htmlToMarkdown(
+        wrap('<p>Read the <a href="https://example.com/docs">documentation</a> here.</p>'),
+      );
+      expect(out).toContain("[documentation](https://example.com/docs)");
+      expect(out).not.toContain("<a ");
+    });
+
+    it("converts <a href> with single-quoted attribute", () => {
+      const out = htmlToMarkdown(wrap("<p>Visit <a href='https://example.com'>Example</a>.</p>"));
+      expect(out).toContain("[Example](https://example.com)");
+    });
+
+    it("converts <li> items to markdown bullets", () => {
+      const out = htmlToMarkdown(
+        wrap("<ul><li>First item</li><li>Second item</li><li>Third item</li></ul>"),
+      );
+      // node-html-markdown uses * for unordered lists
+      expect(out).toContain("First item");
+      expect(out).toContain("Second item");
+      expect(out).toContain("Third item");
+      expect(out).toMatch(/[*-] First item/);
+      expect(out).not.toContain("<li>");
+    });
+
+    it("converts <blockquote> to > prefix", () => {
+      const out = htmlToMarkdown(wrap("<blockquote>Famous quote here</blockquote>"));
+      expect(out).toContain("> Famous quote here");
+      expect(out).not.toContain("<blockquote>");
+    });
+
+    it("decodes &amp; entity", () => {
+      const out = htmlToMarkdown(wrap("<p>Cats &amp; Dogs</p>"));
+      expect(out).toContain("Cats & Dogs");
+      expect(out).not.toContain("&amp;");
+    });
+
+    it("decodes &lt; and &gt; entities", () => {
+      const out = htmlToMarkdown(wrap("<p>x &lt; y &gt; z</p>"));
+      expect(out).toContain("x < y > z");
+    });
+
+    it("decodes &quot; entity", () => {
+      const out = htmlToMarkdown(wrap("<p>She said &quot;hello&quot;</p>"));
+      expect(out).toContain('She said "hello"');
+    });
+
+    it("decodes &apos; entity", () => {
+      const out = htmlToMarkdown(wrap("<p>It&apos;s fine</p>"));
+      expect(out).toContain("It's fine");
+    });
+
+    it("decodes numeric HTML entities", () => {
+      const out = htmlToMarkdown(wrap("<p>&#169; 2025</p>"));
+      // &#169; is the copyright symbol ©
+      expect(out).toContain("© 2025");
+    });
+
+    it("collapses 3+ consecutive newlines to 2", () => {
+      const out = htmlToMarkdown(wrap("<div>A</div><div>B</div><div>C</div><div>D</div>"));
+      expect(out).not.toMatch(/\n{3,}/);
+    });
+
+    it("produces no raw HTML tags in output for a full page", () => {
+      const page = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Full Page</title>
+  <style>body { font-size: 16px }</style>
+</head>
+<body>
+  <nav><a href="/">Home</a></nav>
+  <header><h1>Site Title</h1></header>
+  <main>
+    <h2>Article Title</h2>
+    <p>First paragraph with a <a href="https://example.com">link</a>.</p>
+    <ul><li>Item one</li><li>Item two</li></ul>
+  </main>
+  <footer>Footer content</footer>
+  <script>console.log("hi")</script>
+</body>
+</html>`;
+      const out = htmlToMarkdown(page);
+      expect(out).not.toMatch(/<[a-z]/i);
+      expect(out).toContain("## Article Title");
+      expect(out).toContain("First paragraph");
+      expect(out).toContain("[link](https://example.com)");
+      expect(out).toMatch(/[*-] Item one/);
+      expect(out).not.toContain("console.log");
+      expect(out).not.toContain("font-size");
+      expect(out).not.toContain("Footer content");
+    });
+
+    it("falls back to original HTML if result would be empty", () => {
+      const garbage = "<html><head></head><body></body></html>";
+      const out = htmlToMarkdown(garbage);
+      // stripping produces empty string → return original
+      expect(out).toBe(garbage);
+    });
+  });
+
+  // ── Improvements over custom implementation ──────────────────────────────
+
+  describe("node-html-markdown improvements", () => {
+    it("preserves <strong> as **bold**", () => {
+      const out = htmlToMarkdown(wrap("<p>Use <strong>self-attention</strong> layers.</p>"));
+      expect(out).toContain("**self-attention**");
+    });
+
+    it("preserves <em> as _italic_", () => {
+      const out = htmlToMarkdown(wrap("<p>Process <em>in parallel</em>.</p>"));
+      expect(out).toMatch(/_in parallel_|\*in parallel\*/);
+    });
+
+    it("preserves <ol><li> as numbered list", () => {
+      const out = htmlToMarkdown(
+        wrap("<ol><li>First step</li><li>Second step</li><li>Third step</li></ol>"),
+      );
+      expect(out).toContain("1. First step");
+      expect(out).toContain("2. Second step");
+      expect(out).toContain("3. Third step");
+    });
+
+    it("preserves inline <code> as backtick", () => {
+      const out = htmlToMarkdown(wrap("<p>Run <code>npm install</code> first.</p>"));
+      expect(out).toContain("`npm install`");
+    });
+
+    it("preserves <pre><code> as fenced code block", () => {
+      const out = htmlToMarkdown(wrap("<pre><code>const x = 1;\nconst y = 2;</code></pre>"));
+      expect(out).toContain("```");
+      expect(out).toContain("const x = 1;");
+    });
+
+    it("preserves <table> as GFM markdown table", () => {
+      const out = htmlToMarkdown(
+        wrap(
+          "<table><tr><th>Model</th><th>Params</th></tr>" +
+            "<tr><td>BERT</td><td>110M</td></tr></table>",
+        ),
+      );
+      expect(out).toContain("Model");
+      expect(out).toContain("Params");
+      expect(out).toContain("BERT");
+      expect(out).toContain("110M");
+      // Values should NOT be merged on one line (old custom impl bug)
+      expect(out).not.toMatch(/BERT.*110M.*BERT|Model.*Params.*Model/);
+    });
+
+    it("preserves <img> alt text as ![alt](src)", () => {
+      const out = htmlToMarkdown(wrap('<img src="/diagram.png" alt="Architecture diagram">'));
+      expect(out).toContain("Architecture diagram");
+      expect(out).toContain("/diagram.png");
+    });
+  });
+
+  // ── Integration tests via captureUrl ─────────────────────────────────────
+
+  describe("captureUrl curl fallback integration", () => {
+    it("extracted.md contains normalized markdown, not raw HTML tags", async () => {
+      const html = wrap("<h2>Main Heading</h2><p>Some article content.</p>", "Article Title");
+      const paths = makePaths();
+      const result = await captureUrl(mockPi(html) as never, paths, "https://example.com/article");
+
+      const extracted = readFile(join(result.packetPath, "extracted.md"));
+      expect(extracted).not.toMatch(/<[a-z]/i);
+      expect(extracted).toContain("Article Title");
+      expect(extracted).toContain("## Main Heading");
+      expect(extracted).toContain("Some article content.");
+    });
+
+    it("manifest extractor is htmlToMarkdown on curl path", async () => {
+      const paths = makePaths();
+      const result = await captureUrl(
+        mockPi(wrap("<p>Content</p>")) as never,
+        paths,
+        "https://example.com",
+      );
+      const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+      expect(manifest.extractor).toBe("htmlToMarkdown");
+      expect(manifest.extraction_status).toBe("success");
+    });
+
+    it("original artifact is preserved as raw HTML, extracted.md is clean", async () => {
+      const html = wrap("<p>Clean content</p>", "My Page");
+      const paths = makePaths();
+      const result = await captureUrl(mockPi(html) as never, paths, "https://example.com/page");
+
+      // original untouched
+      expect(readFile(join(result.packetPath, "original", "source.html"))).toBe(html);
+      // extracted clean
+      const extracted = readFile(join(result.packetPath, "extracted.md"));
+      expect(extracted).not.toContain("<p>");
+      expect(extracted).toContain("Clean content");
+    });
+
+    it("script and style content does not appear in extracted.md", async () => {
+      const html = wrap(
+        `<script>var password = "secret123"</script>
+         <style>.hidden { display:none }</style>
+         <p>Visible content</p>`,
+        "Page",
+      );
+      const paths = makePaths();
+      const result = await captureUrl(mockPi(html) as never, paths, "https://example.com");
+
+      const extracted = readFile(join(result.packetPath, "extracted.md"));
+      expect(extracted).not.toContain("secret123");
+      expect(extracted).not.toContain("display:none");
+      expect(extracted).toContain("Visible content");
+    });
+
+    it("MarkItDown path is completely unchanged — extractor stays markitdown", async () => {
+      const markdownContent = "# From MarkItDown\n\nExtracted via markitdown tool.";
+      const paths = makePaths();
+      const result = await captureUrl(
+        mockPiWithMarkItDown(markdownContent) as never,
+        paths,
+        "https://example.com",
+      );
+
+      const extracted = readFile(join(result.packetPath, "extracted.md"));
+      expect(extracted).toContain("# From MarkItDown");
+
+      const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+      expect(manifest.extractor).toBe("markitdown");
+      // Must NOT be htmlToMarkdown
+      expect(manifest.extractor).not.toBe("htmlToMarkdown");
+    });
+
+    it("page title extracted from <title> tag appears as # heading in extracted.md", async () => {
+      const html = wrap("<p>Body text</p>", "Extracted Title");
+      const paths = makePaths();
+      const result = await captureUrl(mockPi(html) as never, paths, "https://example.com");
+
+      const extracted = readFile(join(result.packetPath, "extracted.md"));
+      expect(extracted).toMatch(/^# Extracted Title/);
+    });
+  });
+});

--- a/test/source-capture.test.ts
+++ b/test/source-capture.test.ts
@@ -35,8 +35,17 @@ describe("source packet capture", () => {
     const result = await captureUrl(pi as never, paths, url);
 
     expect(existsSync(join(result.packetPath, "original", "source.html"))).toBe(true);
+    // original artifact is preserved as-is
     expect(readFile(join(result.packetPath, "original", "source.html"))).toBe(html);
-    expect(readFile(join(result.packetPath, "extracted.md"))).toBe(html);
+    // extracted.md is normalized markdown, not raw HTML
+    const extracted = readFile(join(result.packetPath, "extracted.md"));
+    expect(extracted).toContain("Example Page");
+    expect(extracted).toContain("Hello");
+    expect(extracted).not.toContain("<html>");
+    expect(extracted).not.toContain("<body>");
+
+    const manifest = JSON.parse(readFile(join(result.packetPath, "manifest.json")));
+    expect(manifest.extractor).toBe("htmlToMarkdown");
 
     const sourcePage = readFile(result.sourcePagePath);
     expect(sourcePage).toContain(`> _Original: [${url}](${url})_`);


### PR DESCRIPTION
## Summary

Closes #55. Deferred from #4. Companion to #56 (magic bytes).

When MarkItDown is unavailable, `extractTextUrl` was dumping raw HTML from `curl` directly into `extracted.md` — violating the packet contract and producing noisy, LLM-unfriendly output.

## Changes

### `extensions/llm-wiki/lib/source-extractors.ts`
- **`htmlToMarkdown(input)`** — exported normalizer: pre-strips page chrome, delegates to `node-html-markdown`, prepends `<title>` as `#` heading when body has no `<h1>`
- **`decodeHtmlEntities()`** — extracted as shared helper (used by both `xmlToMarkdown` and now available for reuse)
- **`extractTextUrl`** — curl fallback now calls `htmlToMarkdown`; sets `extractor: "htmlToMarkdown"` in manifest. MarkItDown path is untouched.

### `package.json` / `package-lock.json`
- `node-html-markdown` added as runtime dependency

### `test/source-capture.test.ts`
- Updated one assertion that checked `extracted.md === raw HTML`; now asserts clean markdown + correct `extractor` field

### `test/e2e-html-normalization.test.ts` *(new — 35 tests)*

## Why `node-html-markdown` over a custom regex pipeline

A custom step-by-step pipeline (the original approach) had meaningful gaps for a knowledge base:

| Element | Custom regex | `node-html-markdown` |
|---|---|---|
| `<strong>` / `<em>` | stripped to plain text | `**bold**` / `_italic_` |
| `<ol>` | became `- bullets` | `1. 2. 3.` numbered |
| Inline `<code>` | lost | ``backticks`` |
| `<pre><code>` | raw indented text | fenced ```block``` |
| `<table>` | columns merged: `BERT110M` | proper GFM table |
| `<img>` alt text | lost entirely | `![alt](src)` |

`node-html-markdown` has one runtime dep (`node-html-parser`). Both are zero-native-binding, TypeScript-native packages.

## Noise still stripped (our pre-processing)

`node-html-markdown` doesn't remove `<nav>`, `<footer>`, `<script>` etc. We pre-strip those before handing off, so page chrome never leaks through.

## Test coverage (35 new tests)

| Group | Count |
|---|---|
| Noise stripping (script/style/nav/header/footer/noscript/head) | 8 |
| Semantic conversion (headings, links, bullets, blockquotes, entities ×5) | 12 |
| Improvements: bold/italic/code/tables/img/ordered lists | 7 |
| Integration via `captureUrl` (curl + MarkItDown paths) | 6 |
| Edge cases (whitespace collapse, empty fallback) | 2 |

## Checklist

- [x] `curl`-path URL captures produce clean readable markdown
- [x] `<script>`, `<style>`, `<nav>`, `<header>`, `<footer>` removed entirely
- [x] `<h1>`–`<h6>` → markdown headings
- [x] `<a href>` → `[text](url)`
- [x] `<li>` → markdown bullets (ordered + unordered)
- [x] HTML entities decoded
- [x] Page title extracted from `<title>`
- [x] MarkItDown path completely unchanged
- [x] `extractor: "htmlToMarkdown"` in manifest on curl path
- [x] `decodeHtmlEntities` shared helper (no duplication)
- [x] All 143 tests pass
- [x] TypeScript clean
- [x] Biome lint clean