### PR TITLE
feat: dynamic contributors list via scheduled workflow (closes #60)

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,45 @@
+name: Update Contributors
+
+# Materializes the contributor list directly into README.md so the displayed
+# avatars stay in sync with the actual contributors graph. Replaces the
+# contrib.rocks <img> approach, which only refreshed when external CDN +
+# GitHub camo caches rolled over (hours to weeks). See #60.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      # avoid loops: the action commits back to README.md
+      - "README.md"
+  schedule:
+    # weekly safety net in case a push run is skipped (e.g. paths-ignore filter)
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Refresh contributors block in README.md
+        # Pinned to v2.3.11 → 83ea0b4f1ac928fbfe88b9e8460a932a528eb79f
+        uses: akhilmhdh/contributors-readme-action@v2.3.11
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          image_size: 64
+          columns_per_row: 8
+          collaborators: direct
+          commit_message: "chore: update contributors list"
+          committer_username: "github-actions[bot]"
+          committer_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          auto_detect_branch_protection: true

--- a/README.md
+++ b/README.md
@@ -399,9 +399,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, test patterns, and
 
 ## Contributors
 
-<a href="https://github.com/zosmaai/pi-llm-wiki/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=zosmaai/pi-llm-wiki" alt="Contributors" />
-</a>
+Thanks to everyone who has contributed! This list is regenerated automatically by [`.github/workflows/contributors.yml`](.github/workflows/contributors.yml) — see [#60](https://github.com/zosmaai/pi-llm-wiki/issues/60) for the rationale.
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
+
+<sub>Full history: [contributors graph](https://github.com/zosmaai/pi-llm-wiki/graphs/contributors).</sub>
 
 ---
 


### PR DESCRIPTION
Closes #60.

## What

Replaces the `contrib.rocks` `<img>` in `README.md` with a marker block populated by [`akhilmhdh/contributors-readme-action`](https://github.com/akhilmhdh/contributors-readme-action), plus the workflow that drives it.

```diff
 ## Contributors

-<a href="https://github.com/zosmaai/pi-llm-wiki/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=zosmaai/pi-llm-wiki" alt="Contributors" />
-</a>
+Thanks to everyone who has contributed! This list is regenerated automatically by [`.github/workflows/contributors.yml`](.github/workflows/contributors.yml) — see [#60](https://github.com/zosmaai/pi-llm-wiki/issues/60) for the rationale.
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
+
+<sub>Full history: [contributors graph](https://github.com/zosmaai/pi-llm-wiki/graphs/contributors).</sub>
```

## Why

`contrib.rocks` is technically dynamic, but its rendered SVG is gated by **two cache layers** (the contrib.rocks CDN + GitHub's `camo` image proxy) that can leave the avatar grid stale for hours to weeks. At the time of writing, the live image still only shows `arjun-zosma` and `jfraser` — @Shanvit7 (5 commits via #58 + #59 merged today) is missing entirely.

Writing the contributor list directly into `README.md` as plain markdown eliminates both cache layers and produces a real HTML table of avatars with handle-linked profiles.

## Trigger model

The workflow runs:
- **on push to `main`** (excluding `README.md` itself, to avoid loops with its own commit-back)
- **on a weekly cron** (`Monday 06:00 UTC`) as a safety net in case a push run gets filtered
- **on `workflow_dispatch`** for manual refresh

`concurrency.group` keyed to the workflow name so overlapping runs serialize cleanly.

## Action pinning

`akhilmhdh/contributors-readme-action@v2.3.11` (commit `83ea0b4`), matching the repo's existing convention of version-tag pinning for third-party actions (`codecov/codecov-action@v5`, `softprops/action-gh-release@v2`). SHA noted in a comment for traceability if you later want to harden to pure SHA pins.

## Branch protection compatibility

`auto_detect_branch_protection: true` — if `main` ever becomes protected with required reviews, the action opens a PR instead of force-pushing. No-op today but future-proof.

## Scope notes

The 9 translated READMEs (`README.{zh,es,ja,de,fr,pt,ru,ko,hi}.md`) still use the contrib.rocks block. They're functionally static (last touched once, no translation automation in the repo), so leaving them out doesn't regress anything — they were already stale. Happy to do a follow-up PR that adds a matrix run across all README files once we confirm this primary workflow works end-to-end.

## Verification

- ✅ `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses
- ✅ Marker block placement preserves surrounding sections (Star History above, footer below)
- ✅ Action's `action.yml` confirms `readme_path`, `collaborators`, `auto_detect_branch_protection` inputs all exist on v2.3.11
- ✅ No new runtime dependencies; CI workflows untouched

## After merge

The workflow will fire on the merge commit's `push: main` trigger and produce a follow-up `chore: update contributors list` commit populating the marker block with the current 3-contributor grid (arjun-zosma, jfraser, Shanvit7). Subsequent contributions trigger the same flow automatically.
