### PR TITLE
feat(indexing): non-blocking, coalescing vault reindex

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -67,7 +67,7 @@ export default function (pi: ExtensionAPI) {
   const runtime = registerBackgroundRuntime(pi);
 
   registerWikiBootstrap(pi);
-  registerWikiCaptureSource(pi);
+  registerWikiCaptureSource(pi, runtime);
   registerWikiIngest(pi, runtime);
   registerWikiEnsurePage(pi, runtime);
   registerWikiSearch(pi);
@@ -78,13 +78,13 @@ export default function (pi: ExtensionAPI) {
   registerWikiLogEvent(pi);
   registerWikiWatch(pi);
   registerWikiRecall(pi, runtime);
-  registerWikiRetro(pi);
+  registerWikiRetro(pi, runtime);
   // Model selection surface (issue #69): /wiki-model command to view/set the
   // background task model. The taskModel config field + resolveModel already
   // exist; this exposes them to the user (default stays the session model).
   registerWikiModelCommand(pi, runtime);
   const reminderState = createReminderState();
-  registerWikiObserve(pi, reminderState);
+  registerWikiObserve(pi, runtime, reminderState);
   registerObservationReminder(pi, reminderState);
 
   installGuardrails(pi, runtime);

--- a/extensions/llm-wiki/lib/guardrails.ts
+++ b/extensions/llm-wiki/lib/guardrails.ts
@@ -1,6 +1,6 @@
 import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { launchReindex } from "./embeddings.js";
+import { scheduleReindex } from "./indexing.js";
 import { rebuildMetadataLight } from "./metadata.js";
 import type { Runtime } from "./runtime.js";
 import { isProtectedPath, resolveVaultPaths } from "./utils.js";
@@ -54,10 +54,13 @@ export function installGuardrails(pi: ExtensionAPI, runtime?: Runtime): void {
       pendingRebuild = false;
       try {
         const paths = resolveVaultPaths(process.cwd());
-        rebuildMetadataLight(paths);
+        // Manual page edits also rebuild off the critical path. Without a
+        // runtime (shouldn't happen in normal wiring) fall back to inline.
         if (runtime) {
           const launchCtx = ctx ? { hasUI: ctx.hasUI, ui: ctx.ui } : { hasUI: false as const };
-          launchReindex(runtime, launchCtx, paths);
+          scheduleReindex(runtime, launchCtx, paths);
+        } else {
+          rebuildMetadataLight(paths);
         }
       } catch {
         // Silently fail — metadata rebuild is best-effort

--- a/extensions/llm-wiki/lib/indexing.ts
+++ b/extensions/llm-wiki/lib/indexing.ts
@@ -1,0 +1,88 @@
+/**
+ * Non-blocking vault (re)indexing.
+ *
+ * Writing a wiki page (observe / retro / capture / ensure_page) and editing one
+ * by hand both require the derived metadata — `meta/registry.json`,
+ * `backlinks.json`, `index.md`, `log.md` — to be rebuilt, plus (optionally) the
+ * semantic embedding store to be refreshed. That rebuild is O(pages): it
+ * rescans every page in the vault. Doing it inline on the tool's / turn's
+ * critical path makes every write get slower as the vault grows.
+ *
+ * `scheduleReindex` moves that work off the caller's stack onto the shared
+ * background Runtime (#64) and coalesces a burst of writes into a single pass:
+ *
+ *   - A leading micro-yield guarantees the caller (a tool's `execute`, or the
+ *     turn_end handler) returns BEFORE the heavy rebuild runs.
+ *   - A per-vault `dirty` flag + drain loop means writes that land while a pass
+ *     is in flight are folded into a trailing rebuild instead of being lost —
+ *     this also covers the async window of the embeddings refresh.
+ *   - A per-vault `inflight` guard collapses concurrent schedule calls onto the
+ *     same promise (single-flight), so N writes in a turn cost one rebuild.
+ *
+ * Errors are isolated by `Runtime.launchTask`; the promise never rejects. The
+ * embeddings step is a no-op unless an embedder is configured (#66/#67).
+ */
+
+import { reindexEmbeddings, resolveEmbedder } from "./embeddings.js";
+import { rebuildMetadataLight } from "./metadata.js";
+import type { LaunchCtx, Runtime } from "./runtime.js";
+import type { VaultPaths } from "./utils.js";
+
+/** Promise of the current background pass, keyed by vault root. */
+const inflight = new Map<string, Promise<void>>();
+/** Vault roots with writes awaiting a (re)build. */
+const dirty = new Set<string>();
+
+/** Stable single-flight label for a vault's background index pass. */
+export function indexLabel(root: string): string {
+  return `index:${root}`;
+}
+
+/**
+ * Schedule a non-blocking metadata rebuild (+ embeddings refresh) for a vault.
+ * Returns the promise of the in-flight pass so callers/tests can await drainage
+ * (the agent loop itself never awaits it). Safe to call on every write.
+ */
+export function scheduleReindex(
+  runtime: Runtime,
+  ctx: LaunchCtx,
+  paths: VaultPaths,
+): Promise<void> {
+  const root = paths.root;
+  dirty.add(root);
+
+  const active = inflight.get(root);
+  if (active) return active;
+
+  const pass = runtime.launchTask(ctx, indexLabel(root), async () => {
+    // Yield once so the caller returns before the O(pages) rebuild runs. This
+    // is what makes the surrounding write non-blocking.
+    await Promise.resolve();
+    try {
+      // Drain: keep rebuilding until no new write arrived during the previous
+      // pass. The loop re-checks AFTER the awaited embeddings step, so writes
+      // that land during embedding are not lost.
+      while (dirty.has(root)) {
+        dirty.delete(root);
+        rebuildMetadataLight(paths);
+
+        // Refresh embeddings only after metadata is consistent. Stale-aware and
+        // a no-op unless an embedder is configured.
+        runtime.ensureConfig(root);
+        const embedder = resolveEmbedder(runtime.config);
+        if (embedder) await reindexEmbeddings(paths, embedder);
+      }
+    } finally {
+      inflight.delete(root);
+    }
+  });
+
+  inflight.set(root, pass);
+  return pass;
+}
+
+/** Test-only: clear coalescing state between cases. */
+export function __resetIndexingState(): void {
+  inflight.clear();
+  dirty.clear();
+}

--- a/extensions/llm-wiki/lib/observation.ts
+++ b/extensions/llm-wiki/lib/observation.ts
@@ -2,7 +2,9 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
+import { scheduleReindex } from "./indexing.js";
 import { appendEvent, rebuildMetadataLight } from "./metadata.js";
+import type { Runtime } from "./runtime.js";
 import { type VaultPaths, fmtDate, resolveVaultPaths } from "./utils.js";
 
 // ─── Types ─────────────────────────────────────────────
@@ -44,7 +46,11 @@ const RELEVANCE_EMOJIS: Record<string, string> = {
  * Observations are stored in wiki/sources/ with type: source and
  * status: observation. They are searchable via wiki_recail.
  */
-export function saveObservation(paths: VaultPaths, input: ObservationInput): ObservationResult {
+export function saveObservation(
+  paths: VaultPaths,
+  input: ObservationInput,
+  opts?: { rebuild?: boolean },
+): ObservationResult {
   const today = fmtDate();
   const timestamp = new Date().toISOString();
 
@@ -109,8 +115,10 @@ export function saveObservation(paths: VaultPaths, input: ObservationInput): Obs
     relevance: input.relevance,
   });
 
-  // Rebuild metadata so the observation is immediately searchable
-  rebuildMetadataLight(paths);
+  // Rebuild metadata so the observation is immediately searchable. Callers that
+  // background this (the wiki_observe tool) pass { rebuild: false } and schedule
+  // a non-blocking reindex instead.
+  if (opts?.rebuild !== false) rebuildMetadataLight(paths);
 
   return { slug, pagePath };
 }
@@ -137,7 +145,11 @@ export function createReminderState(): ReminderState {
  * The model calls this to record observations during a session.
  * Observations are saved to the wiki and become searchable.
  */
-export function registerWikiObserve(pi: ExtensionAPI, reminderState?: ReminderState): void {
+export function registerWikiObserve(
+  pi: ExtensionAPI,
+  runtime?: Runtime,
+  reminderState?: ReminderState,
+): void {
   pi.registerTool({
     name: "wiki_observe",
     label: "Wiki Observe",
@@ -214,13 +226,24 @@ export function registerWikiObserve(pi: ExtensionAPI, reminderState?: ReminderSt
         };
       }
 
-      const result = saveObservation(paths, {
-        title: params.title,
-        content: params.content,
-        relevance: params.relevance,
-        tags: params.tags,
-        source_context: params.source_context,
-      });
+      const result = saveObservation(
+        paths,
+        {
+          title: params.title,
+          content: params.content,
+          relevance: params.relevance,
+          tags: params.tags,
+          source_context: params.source_context,
+        },
+        // When a background runtime is available, write the page synchronously
+        // but defer the O(pages) metadata rebuild + embeddings off the tool's
+        // critical path. Without a runtime, fall back to the inline rebuild.
+        { rebuild: !runtime },
+      );
+      if (runtime) {
+        const launchCtx = { hasUI: ctx.hasUI, ui: ctx.ui };
+        scheduleReindex(runtime, launchCtx, paths);
+      }
 
       // Signal the reminder to stop nagging this session
       if (reminderState) {

--- a/extensions/llm-wiki/lib/retro.ts
+++ b/extensions/llm-wiki/lib/retro.ts
@@ -2,7 +2,9 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
+import { scheduleReindex } from "./indexing.js";
 import { appendEvent, rebuildMetadataLight } from "./metadata.js";
+import type { Runtime } from "./runtime.js";
 import { type VaultPaths, fmtDate, resolveVaultPaths } from "./utils.js";
 
 // ─── Public API ────────────────────────────────────────
@@ -28,6 +30,7 @@ export function saveInsight(
   title: string,
   body: string,
   category?: string,
+  opts?: { rebuild?: boolean },
 ): RetroResult {
   const today = fmtDate();
 
@@ -73,8 +76,9 @@ export function saveInsight(
     category: category || "uncategorized",
   });
 
-  // Rebuild metadata so the insight is immediately searchable
-  rebuildMetadataLight(paths);
+  // Rebuild metadata so the insight is immediately searchable. The wiki_retro
+  // tool passes { rebuild: false } and schedules a non-blocking reindex instead.
+  if (opts?.rebuild !== false) rebuildMetadataLight(paths);
 
   return { slug, sourcePagePath };
 }
@@ -86,7 +90,7 @@ export function saveInsight(
  * The model calls this to save an atomic insight from a completed task.
  * Inspired by the memex_retro pattern.
  */
-export function registerWikiRetro(pi: ExtensionAPI): void {
+export function registerWikiRetro(pi: ExtensionAPI, runtime?: Runtime): void {
   pi.registerTool({
     name: "wiki_retro",
     label: "Wiki Retro",
@@ -134,7 +138,12 @@ export function registerWikiRetro(pi: ExtensionAPI): void {
         };
       }
 
-      const result = saveInsight(paths, params.slug, params.title, params.body, params.category);
+      const result = saveInsight(paths, params.slug, params.title, params.body, params.category, {
+        rebuild: !runtime,
+      });
+      if (runtime) {
+        scheduleReindex(runtime, { hasUI: ctx.hasUI, ui: ctx.ui }, paths);
+      }
 
       return {
         content: [

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import { launchEmbedPages, reindexEmbeddings, resolveEmbedder } from "./embeddings.js";
+import { scheduleReindex } from "./indexing.js";
 import { runIngestSynthesis } from "./ingest-worker.js";
 import {
   type Registry,
@@ -146,7 +147,7 @@ export function registerWikiBootstrap(pi: ExtensionAPI): void {
 
 // ─── 2. wiki_capture_source ─────────────────────────────
 
-export function registerWikiCaptureSource(pi: ExtensionAPI): void {
+export function registerWikiCaptureSource(pi: ExtensionAPI, runtime?: Runtime): void {
   pi.registerTool({
     name: "wiki_capture_source",
     label: "Wiki Capture Source",
@@ -195,7 +196,11 @@ export function registerWikiCaptureSource(pi: ExtensionAPI): void {
         };
       }
 
-      rebuildMetadataLight(paths);
+      if (runtime) {
+        scheduleReindex(runtime, { hasUI: ctx.hasUI, ui: ctx.ui }, paths);
+      } else {
+        rebuildMetadataLight(paths);
+      }
 
       return {
         content: [
@@ -513,17 +518,13 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
         path: `${folder}/${slug}`,
       });
 
-      // Register the new page so retrieval + embeddings can see it, then embed
-      // it in the background (#66). Both are no-ops when unconfigured.
-      rebuildMetadataLight(paths);
+      // Register the new page so retrieval + embeddings can see it. When a
+      // background runtime is available, the rebuild + embeddings run off the
+      // tool's critical path; otherwise fall back to a synchronous rebuild.
       if (runtime) {
-        launchEmbedPages(
-          runtime,
-          { hasUI: ctx.hasUI, ui: ctx.ui },
-          paths,
-          [`${folder}/${slug}`],
-          `embed:page:${folder}/${slug}`,
-        );
+        scheduleReindex(runtime, { hasUI: ctx.hasUI, ui: ctx.ui }, paths);
+      } else {
+        rebuildMetadataLight(paths);
       }
 
       return {

--- a/test/indexing.test.ts
+++ b/test/indexing.test.ts
@@ -1,0 +1,283 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetIndexingState,
+  indexLabel,
+  scheduleReindex,
+} from "../extensions/llm-wiki/lib/indexing.js";
+import { saveObservation } from "../extensions/llm-wiki/lib/observation.js";
+import { Runtime } from "../extensions/llm-wiki/lib/runtime.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+
+// ── vault scaffolding ─────────────────────────────────────
+function makeVault(tmpDir: string): string {
+  const dir = join(tmpDir, `vault-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  const llmWiki = join(dir, ".llm-wiki");
+  const dirs = [
+    "raw/articles",
+    "wiki/entities",
+    "wiki/concepts",
+    "wiki/sources",
+    "wiki/syntheses",
+    "meta",
+    "outputs",
+    ".discoveries",
+  ];
+  for (const d of dirs) mkdirSync(join(llmWiki, d), { recursive: true });
+  ensureVaultStructure(getVaultPaths(dir));
+  writeFileSync(
+    join(llmWiki, "config.json"),
+    JSON.stringify({ topic: "Test", mode: "personal", created: "2026-06-06", version: "1.0" }),
+    "utf-8",
+  );
+  return dir;
+}
+
+function writePage(vaultDir: string, slug: string): void {
+  const p = join(vaultDir, ".llm-wiki", "wiki", "concepts", `${slug}.md`);
+  writeFileSync(
+    p,
+    `---\ntype: concept\ntitle: "${slug}"\ncreated: 2026-06-06\nupdated: 2026-06-06\n---\n\n# ${slug}\n\nBody.\n`,
+    "utf-8",
+  );
+}
+
+function readRegistry(vaultDir: string): { pages: Record<string, unknown> } {
+  const p = join(vaultDir, ".llm-wiki", "meta", "registry.json");
+  if (!existsSync(p)) return { pages: {} };
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+// A fake runtime that counts launchTask invocations but reproduces its
+// single-flight-per-label + error-isolation contract.
+function fakeRuntime() {
+  let launches = 0;
+  const inFlight = new Map<string, Promise<void>>();
+  const rt = {
+    config: {} as Record<string, unknown>,
+    configLoaded: true,
+    ensureConfig() {},
+    launchCount: () => launches,
+    launchTask(_ctx: unknown, label: string, work: () => Promise<void>) {
+      const existing = inFlight.get(label);
+      if (existing) return existing;
+      launches++;
+      // biome-ignore lint/style/useConst: referenced in its own finally
+      let promise!: Promise<void>;
+      promise = (async () => {
+        try {
+          await work();
+        } finally {
+          if (inFlight.get(label) === promise) inFlight.delete(label);
+        }
+      })();
+      inFlight.set(label, promise);
+      return promise;
+    },
+    async awaitAll() {
+      while (inFlight.size > 0) await Promise.allSettled([...inFlight.values()]);
+    },
+  };
+  return rt;
+}
+
+const CTX = { hasUI: false as const };
+
+describe("scheduleReindex", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    __resetIndexingState();
+    tmpDir = join(
+      import.meta.dirname,
+      "..",
+      "tmp",
+      `indexing-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+  });
+  afterEach(() => {
+    __resetIndexingState();
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("is non-blocking: the metadata rebuild does not run on the caller's stack", async () => {
+    const vaultDir = makeVault(tmpDir);
+    const paths = getVaultPaths(vaultDir);
+    const rt = new Runtime();
+    writePage(vaultDir, "alpha");
+
+    scheduleReindex(rt, CTX, paths);
+
+    // Synchronously after scheduling, the rebuild must NOT have run yet.
+    expect(readRegistry(vaultDir).pages["concepts/alpha"]).toBeUndefined();
+
+    await rt.awaitAll();
+
+    // After draining background work, the page is registered.
+    expect(readRegistry(vaultDir).pages["concepts/alpha"]).toBeDefined();
+  });
+
+  it("coalesces a burst of schedule calls into a single background pass", async () => {
+    const vaultDir = makeVault(tmpDir);
+    const paths = getVaultPaths(vaultDir);
+    const rt = fakeRuntime();
+
+    writePage(vaultDir, "a");
+    scheduleReindex(rt as unknown as Runtime, CTX, paths);
+    writePage(vaultDir, "b");
+    scheduleReindex(rt as unknown as Runtime, CTX, paths);
+    writePage(vaultDir, "c");
+    scheduleReindex(rt as unknown as Runtime, CTX, paths);
+
+    expect(rt.launchCount()).toBe(1);
+
+    await rt.awaitAll();
+
+    const pages = readRegistry(vaultDir).pages;
+    expect(pages["concepts/a"]).toBeDefined();
+    expect(pages["concepts/b"]).toBeDefined();
+    expect(pages["concepts/c"]).toBeDefined();
+  });
+
+  it("does not lose a write scheduled after the in-flight pass started", async () => {
+    const vaultDir = makeVault(tmpDir);
+    const paths = getVaultPaths(vaultDir);
+    const rt = new Runtime();
+
+    writePage(vaultDir, "first");
+    const p1 = scheduleReindex(rt, CTX, paths);
+    writePage(vaultDir, "second");
+    scheduleReindex(rt, CTX, paths);
+    expect(scheduleReindex(rt, CTX, paths)).toBe(p1); // coalesced into the same pass
+
+    await rt.awaitAll();
+
+    const pages = readRegistry(vaultDir).pages;
+    expect(pages["concepts/first"]).toBeDefined();
+    expect(pages["concepts/second"]).toBeDefined();
+  });
+
+  it("uses a stable per-vault label", () => {
+    const paths = getVaultPaths("/some/vault/root");
+    expect(indexLabel(paths.root)).toBe("index:/some/vault/root");
+  });
+
+  it("is a no-op embedder path that does not throw when none is configured", async () => {
+    const vaultDir = makeVault(tmpDir);
+    const paths = getVaultPaths(vaultDir);
+    const rt = new Runtime();
+    writePage(vaultDir, "solo");
+    await expect(scheduleReindex(rt, CTX, paths)).resolves.toBeUndefined();
+    expect(readRegistry(vaultDir).pages["concepts/solo"]).toBeDefined();
+  });
+});
+
+describe("saveObservation rebuild opt-out", () => {
+  let tmpDir: string;
+  let vaultDir: string;
+
+  beforeEach(() => {
+    __resetIndexingState();
+    tmpDir = join(
+      import.meta.dirname,
+      "..",
+      "tmp",
+      `obsopt-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    vaultDir = makeVault(tmpDir);
+  });
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("rebuilds synchronously by default (backward compatible)", () => {
+    const paths = getVaultPaths(vaultDir);
+    const r = saveObservation(paths, { title: "Sync One", content: "x", relevance: "low" });
+    expect(existsSync(r.pagePath)).toBe(true);
+    // registry reflects the page immediately
+    const key = `sources/${r.slug}`;
+    expect(readRegistry(vaultDir).pages[key]).toBeDefined();
+  });
+
+  it("skips the inline rebuild when { rebuild: false }", () => {
+    const paths = getVaultPaths(vaultDir);
+    const r = saveObservation(
+      paths,
+      { title: "Async One", content: "x", relevance: "low" },
+      { rebuild: false },
+    );
+    // the page file is written synchronously...
+    expect(existsSync(r.pagePath)).toBe(true);
+    // ...but the registry was NOT rebuilt inline
+    const key = `sources/${r.slug}`;
+    expect(readRegistry(vaultDir).pages[key]).toBeUndefined();
+  });
+});
+
+describe("wiki_observe tool backgrounds its rebuild", () => {
+  let tmpDir: string;
+  let vaultDir: string;
+
+  beforeEach(() => {
+    __resetIndexingState();
+    tmpDir = join(
+      import.meta.dirname,
+      "..",
+      "tmp",
+      `obstool-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    vaultDir = makeVault(tmpDir);
+  });
+  afterEach(() => {
+    __resetIndexingState();
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("writes the page synchronously but defers the rebuild to the runtime", async () => {
+    const { registerWikiObserve } = await import("../extensions/llm-wiki/lib/observation.js");
+    let captured: { execute: (...a: unknown[]) => Promise<unknown> } | undefined;
+    const pi = {
+      registerTool: (def: unknown) => {
+        captured = def as { execute: (...a: unknown[]) => Promise<unknown> };
+      },
+    } as unknown as ExtensionAPI;
+    const rt = new Runtime();
+
+    registerWikiObserve(pi, rt);
+    expect(captured).toBeDefined();
+
+    const ctx = { cwd: vaultDir, hasUI: false };
+    // Kick off the tool but do NOT await it yet: the execute body runs to
+    // completion synchronously (no awaits), so the heavy rebuild must still be
+    // pending in the background at this point.
+    const pending = captured?.execute(
+      "id",
+      { title: "Tool Obs", content: "y", relevance: "high" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    // The registry is not rebuilt on the tool's synchronous stack.
+    const beforeKey = Object.keys(readRegistry(vaultDir).pages).find((k) => k.includes("tool-obs"));
+    expect(beforeKey).toBeUndefined();
+
+    await pending;
+    await rt.awaitAll();
+
+    const afterKey = Object.keys(readRegistry(vaultDir).pages).find((k) => k.includes("tool-obs"));
+    expect(afterKey).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Problem

Every wiki write — `wiki_observe`, `wiki_retro`, `wiki_capture_source`, `wiki_ensure_page` — and every manual page edit triggers a **synchronous** metadata rebuild (`rebuildMetadataLight`: registry + backlinks + index.md + log.md), which rescans **every page in the vault**. It ran inline on the tool's / turn's critical path, so writes get linearly slower as the vault grows. Embeddings refresh for observe/retro was also missing.

## Change

New `lib/indexing.ts` → `scheduleReindex(runtime, ctx, paths)`: moves the rebuild **and** the (opt-in) embeddings refresh onto the shared background `Runtime` (#64) and coalesces a burst of writes into a single pass.

- **Leading micro-yield** so the caller (`execute` / `turn_end`) returns before the O(pages) rebuild runs — genuinely off the synchronous critical path.
- **Per-vault `dirty` flag + drain loop**: writes that land while a pass is in flight (including during the embeddings `await`) fold into a trailing rebuild instead of being lost.
- **Per-vault `inflight` guard**: concurrent schedules collapse onto one promise (single-flight) — N writes in a turn cost one rebuild.
- Errors isolated by `Runtime.launchTask`; drained at compaction/shutdown via the existing `awaitAll`.
- Embeddings step is a no-op unless an embedder is configured.

### Wiring

- `wiki_observe` / `wiki_retro`: `saveObservation` / `saveInsight` gain an opt-out `{ rebuild: false }` — the tools write the page **synchronously** (honest result) but defer the rebuild. Direct callers and all existing tests keep the synchronous default (fully backward compatible).
- `wiki_capture_source` / `wiki_ensure_page`: inline rebuild (and ensure's one-off `launchEmbedPages`) replaced by `scheduleReindex`.
- `turn_end` manual-edit handler: inline `rebuildMetadataLight` + `launchReindex` replaced by `scheduleReindex` — also acts as a backstop that re-schedules any missed rebuild.
- Each site falls back to a synchronous rebuild when no `runtime` is present.

## Tests

8 new cases in `test/indexing.test.ts`: non-blocking (no rebuild on the caller's sync stack), burst coalescing → single pass, no-lost-writes after an in-flight pass starts, stable per-vault label, no-embedder no-throw, `saveObservation` rebuild opt-out (default vs `{ rebuild: false }`), and tool-level deferral.

**Full suite: 282 passing. `tsc` clean, `biome` clean.**