### PR TITLE
feat: agent trajectory working-memory (capture → distill → recall)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
+| 🧭 **Agent working-memory** | `wiki_capture_trajectory` records *how* a task was solved (tool-call trajectory) → distill into reusable `skill`/`case` pages → `wiki_recall_skill` surfaces them next time |
 | 🌐 **MCP Server** | Use with Claude Code, Cursor, Windsurf via stdio MCP transport |
 | 📝 **Obsidian-friendly** | Folder-qualified wikilinks, stable source-ID citations, compatible vault |
 | 🛡️ **Guardrails** | Blocks direct edits to raw sources and generated metadata |
@@ -106,6 +107,9 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_capture_trajectory` | Capture the completed task's tool-call trajectory (agent working-memory) |
+| `wiki_distill_skills` | Batch undistilled trajectories for synthesis into reusable skill pages |
+| `wiki_recall_skill` | Recall distilled skills + similar past cases — "have I done this before?" |
 
 ### Slash Commands
 
@@ -121,6 +125,8 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
+| `/wiki-record <title>` | Capture the completed task's trajectory (agent working-memory) |
+| `/wiki-skills [query]` | Search distilled skills + past cases relevant to the task |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
-| 🧭 **Agent working-memory** | `wiki_capture_trajectory` records *how* a task was solved (tool-call trajectory) → distill into reusable `skill`/`case` pages → `wiki_recall_skill` surfaces them next time |
+| 🧭 **Agent working-memory** _(opt-in)_ | `wiki_capture_trajectory` records *how* a task was solved (tool-call trajectory) → distill into reusable `skill`/`case` pages → `wiki_recall_skill` surfaces them next time. Off by default; enable with `/wiki-trajectories on` |
 | 🌐 **MCP Server** | Use with Claude Code, Cursor, Windsurf via stdio MCP transport |
 | 📝 **Obsidian-friendly** | Folder-qualified wikilinks, stable source-ID citations, compatible vault |
 | 🛡️ **Guardrails** | Blocks direct edits to raw sources and generated metadata |
@@ -107,9 +107,11 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
-| `wiki_capture_trajectory` | Capture the completed task's tool-call trajectory (agent working-memory) |
-| `wiki_distill_skills` | Batch undistilled trajectories for synthesis into reusable skill pages |
-| `wiki_recall_skill` | Recall distilled skills + similar past cases — "have I done this before?" |
+| `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
+| `wiki_distill_skills` _(opt-in)_ | Batch undistilled trajectories for synthesis into reusable skill pages |
+| `wiki_recall_skill` _(opt-in)_ | Recall distilled skills + similar past cases — "have I done this before?" |
+
+> The three agent-trajectory tools are **off by default** (issue #80). Enable them with `/wiki-trajectories on` (sets `llm-wiki.trajectories`); when off they are not registered at all.
 
 ### Slash Commands
 
@@ -125,8 +127,9 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
-| `/wiki-record <title>` | Capture the completed task's trajectory (agent working-memory) |
-| `/wiki-skills [query]` | Search distilled skills + past cases relevant to the task |
+| `/wiki-trajectories <on\|off>` | Enable/disable agent working-memory (opt-in, off by default) |
+| `/wiki-record <title>` | Capture the completed task's trajectory (requires trajectories enabled) |
+| `/wiki-skills [query]` | Search distilled skills + past cases (requires trajectories enabled) |
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-All 13 tools registered by the extension. Parameters marked `?` are optional.
+All 16 tools registered by the extension. Parameters marked `?` are optional.
 
 ---
 
@@ -92,7 +92,7 @@ Resolve or safely create a canonical wiki page. Returns immediately if the page 
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `type` | `string` | ✅ | Page type: `"entity"`, `"concept"`, `"synthesis"`, `"analysis"`, or `"requirement"` |
+| `type` | `string` | ✅ | Page type: `"entity"`, `"concept"`, `"synthesis"`, `"analysis"`, `"requirement"`, `"skill"`, or `"case"` |
 | `title` | `string` | ✅ | Human-readable page title; auto-slugified to a kebab-case filename |
 | `content` | `string` | — | Full markdown content for the page; if omitted, the type-appropriate template is used |
 
@@ -331,6 +331,104 @@ details: {
 
 When `interval` is `"stop"`, returns `details: { action: "stop_instructions" }` with instructions
 for removing existing jobs via `schedule_prompt action=remove`.
+
+---
+
+## wiki_capture_trajectory
+
+Capture the just-completed task's tool-call trajectory into an immutable packet
+(`raw/trajectories/TRJ-*`) plus a skeleton `case` page (`wiki/cases/`). The working-memory
+counterpart to `wiki_capture_source`. By default the trajectory is auto-extracted from the live
+session; pass `steps` to override.
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `title` | `string` | — | Short descriptive title for the task (≤60 chars). Inferred from the prompt if omitted. |
+| `task` | `string` | — | The task/prompt that started the work. Inferred from the session if omitted. |
+| `outcome` | `string` | — | `"success"` (default), `"failure"`, or `"partial"` — recorded on the case skeleton |
+| `steps` | `array` | — | Explicit trajectory steps (tool-call history). Omit to auto-extract from the live session. |
+| `model` | `string` | — | Model that ran the task. Inferred from the session if omitted. |
+
+**Returns**
+
+```
+details: {
+  trajectoryId: string,    // e.g. "TRJ-2026-06-07-001"
+  casePagePath: string,    // path to wiki/cases/....md (skeleton)
+  stepCount: number
+}
+```
+
+Errors with `isError: true` if no vault exists, or with `error: "empty_trajectory"` when no
+trajectory can be extracted and no `steps` are provided.
+
+---
+
+## wiki_distill_skills
+
+Return a batch of captured trajectories that have not yet been distilled into `skill` pages. Does
+not write anything itself — the model reads each packet and synthesizes reusable skill pages (via
+`wiki_ensure_page(type="skill")`) that cite the trajectory IDs. A trajectory counts as "distilled"
+once a `skills/` page links to it.
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `trajectory_id` | `string` | — | Distill a specific trajectory only; omit for all undistilled |
+| `batch_size` | `number` | — | Max trajectories to return (default: `3`, max: `5`) |
+
+**Returns**
+
+```
+details: {
+  batch: string[],    // trajectory IDs in this batch, e.g. ["TRJ-2026-06-07-001"]
+  remaining: number   // undistilled trajectories still waiting after this batch
+}
+```
+
+Each batch entry includes the title, step/tool-call counts, and paths to read
+(`raw/trajectories/{id}/packet.json` and `extracted.md`). Returns an "all trajectories distilled"
+message with `{ distilled, total }` when nothing is pending.
+
+---
+
+## wiki_recall_skill
+
+Search distilled `skill` pages and past `case` pages for patterns relevant to the current task —
+answers "have I done something like this before?". Filters layered recall (`searchWikiLayered`) to
+skill/case pages. Call at the START of a task.
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | `string` | ✅ | Search query — use the task description or key terms |
+| `kind` | `string` | — | `"skill"`, `"case"`, or `"any"` (default) |
+| `max_results` | `number` | — | Maximum pages to return (default: `5`, max: `10`) |
+
+**Returns**
+
+```
+details: {
+  query: string,
+  kind: string,
+  matches: Array<{
+    id: string,           // folder-qualified page ID, e.g. "skills/jwt-revocation"
+    title: string,
+    type: string,         // "skill" | "case"
+    preview: string,
+    path: string,
+    score: number,
+    vaultLabel?: string   // "📓 personal" when result is from the personal vault
+  }>
+}
+```
+
+Returns empty `matches: []` with a hint to capture work via `wiki_capture_trajectory` /
+`wiki_distill_skills` when nothing matches.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,11 @@
 # API Reference
 
-All 16 tools registered by the extension. Parameters marked `?` are optional.
+All tools registered by the extension. Parameters marked `?` are optional.
+
+13 tools are always registered. The 3 agent-trajectory tools
+(`wiki_capture_trajectory`, `wiki_distill_skills`, `wiki_recall_skill`) are **opt-in,
+off by default** (issue #80) — they are only registered when `llm-wiki.trajectories`
+is `true`; enable with `/wiki-trajectories on`.
 
 ---
 
@@ -337,9 +342,10 @@ for removing existing jobs via `schedule_prompt action=remove`.
 ## wiki_capture_trajectory
 
 Capture the just-completed task's tool-call trajectory into an immutable packet
-(`raw/trajectories/TRJ-*`) plus a skeleton `case` page (`wiki/cases/`). The working-memory
+(`raw/trajectories/TRJ-*`) with a self-contained summary (`extracted.md`). The working-memory
 counterpart to `wiki_capture_source`. By default the trajectory is auto-extracted from the live
-session; pass `steps` to override.
+session; pass `steps` to override. **Opt-in** (issue #80): only available when
+`llm-wiki.trajectories` is enabled (`/wiki-trajectories on`).
 
 **Parameters**
 
@@ -347,7 +353,7 @@ session; pass `steps` to override.
 |------|------|----------|-------------|
 | `title` | `string` | — | Short descriptive title for the task (≤60 chars). Inferred from the prompt if omitted. |
 | `task` | `string` | — | The task/prompt that started the work. Inferred from the session if omitted. |
-| `outcome` | `string` | — | `"success"` (default), `"failure"`, or `"partial"` — recorded on the case skeleton |
+| `outcome` | `string` | — | `"success"` (default), `"failure"`, or `"partial"` — recorded in the packet manifest |
 | `steps` | `array` | — | Explicit trajectory steps (tool-call history). Omit to auto-extract from the live session. |
 | `model` | `string` | — | Model that ran the task. Inferred from the session if omitted. |
 
@@ -356,7 +362,7 @@ session; pass `steps` to override.
 ```
 details: {
   trajectoryId: string,    // e.g. "TRJ-2026-06-07-001"
-  casePagePath: string,    // path to wiki/cases/....md (skeleton)
+  packetPath: string,      // path to raw/trajectories/TRJ-*/ (packet.json + extracted.md)
   stepCount: number
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,11 +107,17 @@ The wiki captures not only what the agent *reads* (sources) but what it *does*
 through the same pipeline:
 
 ```
-raw/trajectories/TRJ-*  →  wiki/cases/*  →  wiki/skills/*  →  meta/*
+raw/trajectories/TRJ-*  →  wiki/skills/*  (+ optional wiki/cases/*)  →  meta/*
 ```
 
-- `wiki_capture_trajectory` writes the immutable packet + a skeleton `case` page
-  (auto-extracting the tool-call sequence from the live session).
+This is **opt-in, off by default** (issue #80): the three tools below are only
+registered when `llm-wiki.trajectories` is enabled (`/wiki-trajectories on`), and
+the `raw/trajectories`, `wiki/skills`, `wiki/cases` directories are created lazily
+on first use — so a vault with the feature off carries no trace of it.
+
+- `wiki_capture_trajectory` writes the immutable packet + a self-contained summary
+  (`extracted.md`), auto-extracting the tool-call sequence from the live session.
+  It does not emit a to-be-fleshed skeleton — capture is a single lightweight call.
 - `wiki_distill_skills` batches undistilled trajectories so the model can
   generalize them into reusable `skill` pages.
 - `wiki_recall_skill` filters layered recall to `skill`/`case` pages —

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,12 +43,18 @@ WIKI_ROOT/
     │   ├── original/          # Original artifact
     │   ├── extracted.md       # Normalized markdown
     │   └── attachments/       # Downloaded images, PDFs
+    ├── raw/trajectories/TRJ-*/ # Immutable agent task packets (extension-owned)
+    │   ├── manifest.json      # Capture metadata (format: trajectory)
+    │   ├── packet.json        # Full tool-call sequence
+    │   └── extracted.md       # README summary
     ├── wiki/                  # Editable knowledge pages (you + LLM)
     │   ├── sources/           # One summary per source
     │   ├── entities/          # People, orgs, tools, products
     │   ├── concepts/          # Ideas, patterns, frameworks
     │   ├── syntheses/         # Cross-cutting analyses
-    │   └── analyses/          # Durable query answers
+    │   ├── analyses/          # Durable query answers
+    │   ├── cases/             # One specific past task per trajectory
+    │   └── skills/            # Reusable patterns distilled from trajectories
     ├── meta/                  # Auto-generated (extension-owned)
     │   ├── registry.json      # Master page catalog
     │   ├── backlinks.json     # Inbound link map
@@ -89,11 +95,36 @@ Each captured source becomes a packet:
 - **concept** — ideas, patterns, frameworks
 - **synthesis** — cross-source theses and tensions
 - **analysis** — durable filed answers from queries
+- **requirement** — atomic requirements with status, priority, and traceability
+- **trajectory** — an immutable captured agent task run (working-memory source)
+- **case** — one specific past task implementation, citing its trajectory
+- **skill** — a reusable pattern distilled from one or more trajectories
+
+## Agent Working-Memory (Trajectories)
+
+The wiki captures not only what the agent *reads* (sources) but what it *does*
+(trajectories). A completed task is just another kind of source, so it flows
+through the same pipeline:
+
+```
+raw/trajectories/TRJ-*  →  wiki/cases/*  →  wiki/skills/*  →  meta/*
+```
+
+- `wiki_capture_trajectory` writes the immutable packet + a skeleton `case` page
+  (auto-extracting the tool-call sequence from the live session).
+- `wiki_distill_skills` batches undistilled trajectories so the model can
+  generalize them into reusable `skill` pages.
+- `wiki_recall_skill` filters layered recall to `skill`/`case` pages —
+  "have I done something like this before?".
+
+Trajectory packets live under `raw/**` and are therefore immutable under the
+same guardrail as source packets — no new ownership rule required.
 
 ## Linking Style
 
 - Internal: `[[folder/page-name]]`
 - Citation: `[[sources/SRC-YYYY-MM-DD-NNN]]`
+- Trajectory citation: `[[trajectories/TRJ-YYYY-MM-DD-NNN]]`
 
 ## Guardrails
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,12 +13,17 @@
 | `/wiki-status`   | Show wiki health                      |
 | `/wiki-digest`   | Daily/weekly summary                  |
 | `/wiki-retro`    | Save atomic insights from tasks        |
-| `/wiki-record`   | Capture the completed task's trajectory (agent working-memory) |
-| `/wiki-skills`   | Search distilled skills + past cases   |
+| `/wiki-model`    | View/set the background-task model     |
+| `/wiki-trajectories` | Enable/disable agent working-memory (`on`/`off`, opt-in) |
+| `/wiki-record`   | Capture the completed task's trajectory (requires trajectories enabled) |
+| `/wiki-skills`   | Search distilled skills + past cases (requires trajectories enabled) |
 
 ## Extension Tools
 
-The extension registers 16 tools the LLM can call directly:
+The extension always registers 13 tools the LLM can call directly. The 3 agent-trajectory
+tools (`wiki_capture_trajectory`, `wiki_distill_skills`, `wiki_recall_skill`) are **opt-in,
+off by default** (issue #80) — registered only when `llm-wiki.trajectories` is enabled
+(`/wiki-trajectories on`).
 
 | Tool                  | Purpose                                     |
 | --------------------- | ------------------------------------------- |
@@ -60,9 +65,10 @@ The extension registers 16 tools the LLM can call directly:
 
 ### Task → Record → Distill (agent working-memory)
 
+_Opt-in: enable first with `/wiki-trajectories on`._
+
 1. Finish a non-trivial task (debug, refactor, integration)
-2. `wiki_capture_trajectory(title="...")` — auto-extracts the tool-call trajectory from the live session into `raw/trajectories/TRJ-*` plus a skeleton `case` page
-3. Flesh out the `wiki/cases/` page (Task → Approach → Outcome)
-4. `wiki_distill_skills()` — get undistilled trajectories
-5. `wiki_ensure_page(type="skill", title="...")` — generalize into a reusable skill citing `[[trajectories/TRJ-...]]`
-6. Next time, `wiki_recall_skill(query="...")` surfaces the skill/case before you start
+2. `wiki_capture_trajectory(title="...")` — auto-extracts the tool-call trajectory from the live session into `raw/trajectories/TRJ-*` with a self-contained summary (no skeleton to flesh)
+3. `wiki_distill_skills()` — get undistilled trajectories
+4. `wiki_ensure_page(type="skill", title="...")` — generalize into a reusable skill citing `[[trajectories/TRJ-...]]` (and optionally a `case` page)
+5. Next time, `wiki_recall_skill(query="...")` surfaces the skill/case before you start

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,10 +13,12 @@
 | `/wiki-status`   | Show wiki health                      |
 | `/wiki-digest`   | Daily/weekly summary                  |
 | `/wiki-retro`    | Save atomic insights from tasks        |
+| `/wiki-record`   | Capture the completed task's trajectory (agent working-memory) |
+| `/wiki-skills`   | Search distilled skills + past cases   |
 
 ## Extension Tools
 
-The extension registers 12 tools the LLM can call directly:
+The extension registers 16 tools the LLM can call directly:
 
 | Tool                  | Purpose                                     |
 | --------------------- | ------------------------------------------- |
@@ -32,6 +34,9 @@ The extension registers 12 tools the LLM can call directly:
 | `wiki_rebuild_meta`   | Force metadata rebuild                      |
 | `wiki_log_event`      | Record custom event                         |
 | `wiki_watch`          | Schedule auto-updates                       |
+| `wiki_capture_trajectory` | Capture the completed task's tool-call trajectory |
+| `wiki_distill_skills` | Batch undistilled trajectories for skill synthesis |
+| `wiki_recall_skill`   | Recall distilled skills + similar past cases |
 
 ## Workflows
 
@@ -52,3 +57,12 @@ The extension registers 12 tools the LLM can call directly:
 3. Synthesize answer with `[[wikilink]]` citations
 4. If novel: create analysis page via `wiki_ensure_page(type="analysis")`
 5. Extension auto-updates metadata
+
+### Task → Record → Distill (agent working-memory)
+
+1. Finish a non-trivial task (debug, refactor, integration)
+2. `wiki_capture_trajectory(title="...")` — auto-extracts the tool-call trajectory from the live session into `raw/trajectories/TRJ-*` plus a skeleton `case` page
+3. Flesh out the `wiki/cases/` page (Task → Approach → Outcome)
+4. `wiki_distill_skills()` — get undistilled trajectories
+5. `wiki_ensure_page(type="skill", title="...")` — generalize into a reusable skill citing `[[trajectories/TRJ-...]]`
+6. Next time, `wiki_recall_skill(query="...")` surfaces the skill/case before you start

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -22,7 +22,7 @@ import {
 } from "./lib/recall.js";
 import { registerWikiRetro } from "./lib/retro.js";
 import { registerBackgroundRuntime } from "./lib/runtime.js";
-import { noticesEnabled } from "./lib/task-config.js";
+import { loadTaskConfig, noticesEnabled, trajectoriesEnabled } from "./lib/task-config.js";
 import {
   registerWikiBootstrap,
   registerWikiCaptureSource,
@@ -36,6 +36,7 @@ import {
   registerWikiStatus,
   registerWikiWatch,
 } from "./lib/tools.js";
+import { registerWikiTrajectoriesCommand } from "./lib/trajectories-command.js";
 import {
   registerWikiCaptureTrajectory,
   registerWikiDistillSkills,
@@ -53,7 +54,8 @@ import {
 /**
  * @zosmaai/pi-llm-wiki — LLM Wiki extension for Pi
  *
- * Registers 16 custom tools and installs guardrails:
+ * Registers 13 custom tools and installs guardrails (+3 agent-trajectory tools
+ * when `llm-wiki.trajectories` is enabled — opt-in, off by default, issue #80):
  * - wiki_recall (layered: personal + project vaults)
  * - wiki_retro (lightweight: single markdown file)
  * - wiki_capture_source (full 4-layer pipeline)
@@ -86,11 +88,23 @@ export default function (pi: ExtensionAPI) {
   registerWikiWatch(pi);
   registerWikiRecall(pi, runtime);
   registerWikiRetro(pi, runtime);
-  // Agent working-memory: capture what the agent *did* (its tool-call
-  // trajectory), distill it into reusable skills, and recall past skills/cases.
-  registerWikiCaptureTrajectory(pi);
-  registerWikiDistillSkills(pi);
-  registerWikiRecallSkill(pi);
+  // Agent working-memory (issue #80): capture what the agent *did* (its
+  // tool-call trajectory), distill it into reusable skills, and recall past
+  // skills/cases. OPT-IN, default OFF — registered ONLY when enabled so the 3
+  // tools cost nothing in the system prompt for users who don't opt in.
+  //
+  // Gate on loadTaskConfig(process.cwd()) at factory time, NOT runtime.config:
+  // runtime.config is empty ({}) until ensureConfig runs in a later hook, so a
+  // runtime.config gate here would read as permanently off. Toggling the flag
+  // via /wiki-trajectories reloads the extension, re-running this gate.
+  const trajectoriesOn = trajectoriesEnabled(loadTaskConfig(process.cwd()));
+  if (trajectoriesOn) {
+    registerWikiCaptureTrajectory(pi);
+    registerWikiDistillSkills(pi);
+    registerWikiRecallSkill(pi);
+  }
+  // Activation surface for the above (always available so users can turn it on).
+  registerWikiTrajectoriesCommand(pi);
   // Model selection surface (issue #69): /wiki-model command to view/set the
   // background task model. The taskModel config field + resolveModel already
   // exist; this exposes them to the user (default stays the session model).
@@ -161,7 +175,12 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (16 tools, trajectory + observe + recall active)");
+    ctx.ui.setStatus(
+      "llm-wiki",
+      trajectoriesOn
+        ? "🧠 LLM Wiki (16 tools, trajectory + observe + recall active)"
+        : "🧠 LLM Wiki (13 tools, observe + recall active)",
+    );
 
     // Surface the active background task model (issue #69). Defaults to the
     // session model when no taskModel is configured.

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -37,6 +37,11 @@ import {
   registerWikiWatch,
 } from "./lib/tools.js";
 import {
+  registerWikiCaptureTrajectory,
+  registerWikiDistillSkills,
+  registerWikiRecallSkill,
+} from "./lib/trajectory.js";
+import {
   ensureVaultStructure,
   fmtDate,
   getVaultPaths,
@@ -48,7 +53,7 @@ import {
 /**
  * @zosmaai/pi-llm-wiki — LLM Wiki extension for Pi
  *
- * Registers 12 custom tools and installs guardrails:
+ * Registers 16 custom tools and installs guardrails:
  * - wiki_recall (layered: personal + project vaults)
  * - wiki_retro (lightweight: single markdown file)
  * - wiki_capture_source (full 4-layer pipeline)
@@ -81,6 +86,11 @@ export default function (pi: ExtensionAPI) {
   registerWikiWatch(pi);
   registerWikiRecall(pi, runtime);
   registerWikiRetro(pi, runtime);
+  // Agent working-memory: capture what the agent *did* (its tool-call
+  // trajectory), distill it into reusable skills, and recall past skills/cases.
+  registerWikiCaptureTrajectory(pi);
+  registerWikiDistillSkills(pi);
+  registerWikiRecallSkill(pi);
   // Model selection surface (issue #69): /wiki-model command to view/set the
   // background task model. The taskModel config field + resolveModel already
   // exist; this exposes them to the user (default stays the session model).
@@ -151,7 +161,7 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
-    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (13 tools, observe + recall active)");
+    ctx.ui.setStatus("llm-wiki", "🧠 LLM Wiki (16 tools, trajectory + observe + recall active)");
 
     // Surface the active background task model (issue #69). Defaults to the
     // session model when no taskModel is configured.

--- a/extensions/llm-wiki/lib/metadata.ts
+++ b/extensions/llm-wiki/lib/metadata.ts
@@ -19,7 +19,16 @@ import {
  */
 
 export interface RegistryEntry {
-  type: "source" | "entity" | "concept" | "synthesis" | "analysis";
+  type:
+    | "source"
+    | "entity"
+    | "concept"
+    | "synthesis"
+    | "analysis"
+    | "requirement"
+    | "trajectory"
+    | "skill"
+    | "case";
   title: string;
   created: string;
   updated: string;
@@ -89,6 +98,30 @@ export function buildRegistry(paths: VaultPaths): Registry {
       if (!pages[sourcePage]) {
         pages[sourcePage] = {
           type: "source",
+          title: String(manifest.title || id),
+          created: String(manifest.captured || fmtDate()),
+          updated: String(manifest.captured || fmtDate()),
+          ...manifest,
+        };
+      }
+    }
+  }
+
+  // Scan raw trajectory packets (agent working-memory). These are catalogued
+  // under the `trajectories/` namespace so distillation and recall can find
+  // them even before a canonical case/skill page has been written.
+  if (existsSync(paths.rawTrajectories)) {
+    for (const entry of readdirSync(paths.rawTrajectories)) {
+      const manifestPath = join(paths.rawTrajectories, entry, "manifest.json");
+      if (!existsSync(manifestPath)) continue;
+
+      const manifest = readJson<Record<string, unknown>>(manifestPath, {});
+      const id = String(manifest.id || entry);
+      const trajectoryPage = `trajectories/${id}`;
+
+      if (!pages[trajectoryPage]) {
+        pages[trajectoryPage] = {
+          type: "trajectory",
           title: String(manifest.title || id),
           created: String(manifest.captured || fmtDate()),
           updated: String(manifest.captured || fmtDate()),

--- a/extensions/llm-wiki/lib/task-config.ts
+++ b/extensions/llm-wiki/lib/task-config.ts
@@ -79,6 +79,14 @@ export interface TaskConfig {
    * not want any chat-level wiki notices.
    */
   notices?: boolean;
+
+  /**
+   * Agent-trajectory working-memory (capture → distill → recall), issue #80.
+   * OPT-IN, default OFF: only an explicit `trajectories: true` enables it.
+   * When off, the trajectory tools are never registered (see index.ts), so
+   * they cost nothing in the system prompt for the ~95% who don't use them.
+   */
+  trajectories?: boolean;
 }
 
 export const TASK_DEFAULTS: TaskConfig = {};
@@ -89,6 +97,15 @@ export const TASK_DEFAULTS: TaskConfig = {};
  */
 export function noticesEnabled(config: TaskConfig | undefined): boolean {
   return config?.notices !== false;
+}
+
+/**
+ * Resolve whether agent-trajectory working-memory is enabled (issue #80).
+ * INVERSE polarity of `noticesEnabled`: defaults to `false`; only an explicit
+ * `trajectories: true` turns it on.
+ */
+export function trajectoriesEnabled(config: TaskConfig | undefined): boolean {
+  return config?.trajectories === true;
 }
 
 const SETTINGS_KEY = "llm-wiki";
@@ -136,6 +153,10 @@ function readNamespacedConfig(path: string): Partial<TaskConfig> {
 
     if (typeof section.notices === "boolean") {
       out.notices = section.notices;
+    }
+
+    if (typeof section.trajectories === "boolean") {
+      out.trajectories = section.trajectories;
     }
     return out;
   } catch {
@@ -193,6 +214,41 @@ export function persistTaskModel(
   } else {
     // biome-ignore lint/performance/noDelete: one-off settings rewrite, not a hot path; removing the key (vs setting undefined) keeps the JSON clean
     delete section.taskModel;
+  }
+  raw[SETTINGS_KEY] = section;
+
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, `${JSON.stringify(raw, null, 2)}\n`, "utf-8");
+}
+
+/**
+ * Persist the agent-trajectory flag in the PROJECT settings file
+ * `<cwd>/.pi/settings.json` under the namespaced `llm-wiki` key (issue #80).
+ * Mirrors `persistTaskModel`: project settings win in `loadTaskConfig`, other
+ * keys are preserved. `true` writes `trajectories: true`; `false` removes the
+ * key (reverting to the default-off behavior).
+ */
+export function persistTrajectoriesEnabled(cwd: string, enabled: boolean): void {
+  const settingsPath = join(cwd, ".pi", "settings.json");
+  let raw: Record<string, unknown> = {};
+  if (existsSync(settingsPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(settingsPath, "utf-8"));
+      if (parsed && typeof parsed === "object") raw = parsed as Record<string, unknown>;
+    } catch {
+      raw = {};
+    }
+  }
+
+  const existing = raw[SETTINGS_KEY];
+  const section: Record<string, unknown> =
+    existing && typeof existing === "object" ? { ...(existing as Record<string, unknown>) } : {};
+
+  if (enabled) {
+    section.trajectories = true;
+  } else {
+    // biome-ignore lint/performance/noDelete: one-off settings rewrite, not a hot path; removing the key keeps the JSON clean (default is off)
+    delete section.trajectories;
   }
   raw[SETTINGS_KEY] = section;
 

--- a/extensions/llm-wiki/lib/task-config.ts
+++ b/extensions/llm-wiki/lib/task-config.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
 
@@ -120,9 +120,8 @@ function readModelSpec(value: unknown): { provider: string; id: string } | undef
 }
 
 function readNamespacedConfig(path: string): Partial<TaskConfig> {
-  if (!existsSync(path)) return {};
   try {
-    const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+    const raw = readSettingsObject(path);
     const nested = raw[SETTINGS_KEY];
     if (!nested || typeof nested !== "object") return {};
     const section = nested as Record<string, unknown>;
@@ -182,6 +181,22 @@ export function parseModelRef(ref: string): { provider: string; id: string } | u
 }
 
 /**
+ * Read a settings JSON file as a plain object, or `{}` when it is absent or
+ * corrupt. Reads directly (no `existsSync` pre-check) so there is no
+ * check-then-use race: a missing file throws ENOENT, which the catch treats
+ * the same as an empty file.
+ */
+function readSettingsObject(path: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    if (parsed && typeof parsed === "object") return parsed as Record<string, unknown>;
+  } catch {
+    // Missing or corrupt settings file: start from an empty object.
+  }
+  return {};
+}
+
+/**
  * Persist (or clear) the wiki background `taskModel` in the PROJECT settings
  * file `<cwd>/.pi/settings.json` under the namespaced `llm-wiki` key (issue
  * #69). Project settings win over global in `loadTaskConfig`, so this takes
@@ -194,16 +209,7 @@ export function persistTaskModel(
   model: { provider: string; id: string } | undefined,
 ): void {
   const settingsPath = join(cwd, ".pi", "settings.json");
-  let raw: Record<string, unknown> = {};
-  if (existsSync(settingsPath)) {
-    try {
-      const parsed = JSON.parse(readFileSync(settingsPath, "utf-8"));
-      if (parsed && typeof parsed === "object") raw = parsed as Record<string, unknown>;
-    } catch {
-      // Corrupt settings file: start from an empty object rather than throw.
-      raw = {};
-    }
-  }
+  const raw = readSettingsObject(settingsPath);
 
   const existing = raw[SETTINGS_KEY];
   const section: Record<string, unknown> =
@@ -230,15 +236,7 @@ export function persistTaskModel(
  */
 export function persistTrajectoriesEnabled(cwd: string, enabled: boolean): void {
   const settingsPath = join(cwd, ".pi", "settings.json");
-  let raw: Record<string, unknown> = {};
-  if (existsSync(settingsPath)) {
-    try {
-      const parsed = JSON.parse(readFileSync(settingsPath, "utf-8"));
-      if (parsed && typeof parsed === "object") raw = parsed as Record<string, unknown>;
-    } catch {
-      raw = {};
-    }
-  }
+  const raw = readSettingsObject(settingsPath);
 
   const existing = raw[SETTINGS_KEY];
   const section: Record<string, unknown> =

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -513,7 +513,8 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
     ],
     parameters: Type.Object({
       type: Type.String({
-        description: "Page type: entity | concept | synthesis | analysis | requirement",
+        description:
+          "Page type: entity | concept | synthesis | analysis | requirement | skill | case",
       }),
       title: Type.String({ description: "Page title" }),
       content: Type.Optional(
@@ -531,7 +532,14 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
         };
       }
 
-      const type = params.type as "entity" | "concept" | "synthesis" | "analysis";
+      const type = params.type as
+        | "entity"
+        | "concept"
+        | "synthesis"
+        | "analysis"
+        | "requirement"
+        | "skill"
+        | "case";
       const slug = params.title
         .toLowerCase()
         .replace(/[^a-z0-9\s-]/g, "")
@@ -545,6 +553,8 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
         synthesis: "syntheses",
         analysis: "analyses",
         requirement: "requirements",
+        skill: "skills",
+        case: "cases",
       };
       const folder = folderMap[type] || "concepts";
       const pagePath = join(paths.wiki, folder, `${slug}.md`);
@@ -621,6 +631,76 @@ function buildPageTemplate(
       "[Description to be filled]",
       "Durable answer from a query.\n\n## Question\n\n[Original question]",
     );
+  }
+  if (type === "skill") {
+    return [
+      "---",
+      "type: skill",
+      `created: ${date}`,
+      `updated: ${date}`,
+      "status: draft",
+      "trajectories: []",
+      "tags: []",
+      "---",
+      "",
+      `# ${title}`,
+      "",
+      "_One-line summary of the reusable pattern this skill captures._",
+      "",
+      "## When to Use",
+      "",
+      "[Trigger conditions — when this pattern applies]",
+      "",
+      "## Procedure",
+      "",
+      "1. [Step 1]",
+      "2. [Step 2]",
+      "",
+      "## Pitfalls",
+      "",
+      "- [Known failure mode or caveat]",
+      "",
+      "## Distilled From",
+      "",
+      "_Trajectories this skill was generalized from._",
+      "",
+      "- [[trajectories/TRJ-...]]",
+      "",
+    ].join("\n");
+  }
+  if (type === "case") {
+    return [
+      "---",
+      "type: case",
+      `created: ${date}`,
+      `updated: ${date}`,
+      "status: draft",
+      "outcome: success",
+      "trajectory_id: ",
+      "tags: []",
+      "---",
+      "",
+      `# ${title}`,
+      "",
+      "_One-line summary of the specific task this case records._",
+      "",
+      "## Task",
+      "",
+      "[What was requested]",
+      "",
+      "## Approach",
+      "",
+      "[How the agent solved it — key steps and decisions]",
+      "",
+      "## Outcome",
+      "",
+      "[Result, and anything worth reusing or avoiding next time]",
+      "",
+      "## Trajectory",
+      "",
+      "- [[trajectories/TRJ-...]] — captured tool-call run",
+      "",
+    ].join("\n");
   }
   if (type === "requirement") {
     return [

--- a/extensions/llm-wiki/lib/trajectories-command.ts
+++ b/extensions/llm-wiki/lib/trajectories-command.ts
@@ -1,0 +1,67 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { loadTaskConfig, persistTrajectoriesEnabled, trajectoriesEnabled } from "./task-config.js";
+
+/**
+ * Activation surface for agent-trajectory working-memory (issue #80).
+ *
+ * The feature is opt-in / default-off. The trajectory tools
+ * (`wiki_capture_trajectory`, `wiki_distill_skills`, `wiki_recall_skill`) are
+ * registered conditionally at extension-load time (see index.ts) based on the
+ * `llm-wiki.trajectories` setting. Because pi has no runtime add/remove-tool
+ * API — the extension factory runs once at load — flipping the flag can only
+ * change the registered tool set by RELOADING extensions. This command does
+ * exactly that: persist the setting, then `ctx.reload()` so the gate
+ * re-evaluates and the tools appear (or disappear) immediately.
+ *
+ *   /wiki-trajectories            → show current state
+ *   /wiki-trajectories on         → enable + reload
+ *   /wiki-trajectories off        → disable + reload
+ */
+
+const ON_WORDS = new Set(["on", "true", "enable", "enabled", "yes", "1"]);
+const OFF_WORDS = new Set(["off", "false", "disable", "disabled", "no", "0"]);
+
+export function registerWikiTrajectoriesCommand(pi: ExtensionAPI): void {
+  pi.registerCommand("wiki-trajectories", {
+    description:
+      "Enable or disable agent-trajectory working-memory (capture/distill/recall). Off by default.",
+    handler: async (args, ctx) => {
+      const arg = args.trim().toLowerCase();
+      const current = trajectoriesEnabled(loadTaskConfig(ctx.cwd));
+
+      if (!arg) {
+        ctx.ui.notify(
+          `LLM Wiki trajectories are ${current ? "ON" : "OFF"}. Use \`/wiki-trajectories on\` or \`off\`.`,
+          "info",
+        );
+        return;
+      }
+
+      let next: boolean;
+      if (ON_WORDS.has(arg)) next = true;
+      else if (OFF_WORDS.has(arg)) next = false;
+      else {
+        ctx.ui.notify(
+          `LLM Wiki: could not parse "${args.trim()}". Use \`on\` or \`off\`.`,
+          "error",
+        );
+        return;
+      }
+
+      if (next === current) {
+        ctx.ui.notify(`LLM Wiki trajectories already ${current ? "ON" : "OFF"}.`, "info");
+        return;
+      }
+
+      persistTrajectoriesEnabled(ctx.cwd, next);
+      ctx.ui.notify(
+        `LLM Wiki: trajectory tools ${next ? "enabled" : "disabled"} — reloading extensions…`,
+        "info",
+      );
+      // pi has no runtime register/unregister-tool API: reload re-runs the
+      // extension factory so the conditional registration re-evaluates and the
+      // tool set (and status line) reflect the new state.
+      await ctx.reload();
+    },
+  });
+}

--- a/extensions/llm-wiki/lib/trajectory.ts
+++ b/extensions/llm-wiki/lib/trajectory.ts
@@ -10,7 +10,6 @@ import {
   nextTrajectoryId,
   readJson,
   resolveVaultPaths,
-  slugify,
   writeJson,
 } from "./utils.js";
 
@@ -19,12 +18,14 @@ import {
  *
  * Where wiki_capture_source captures what the agent *read* (URLs, files, text),
  * wiki_capture_trajectory captures what the agent *did*: the sequence of
- * tool calls that solved a real task. A completed task is just another kind of
- * source, so it flows through the same 4-layer pipeline:
+ * tool calls that solved a real task. Capture is deliberately lightweight — a
+ * single call writes an immutable packet plus a SELF-CONTAINED summary
+ * (extracted.md); it does NOT emit a to-be-fleshed skeleton (issue #80). The
+ * optional distillation step then turns trajectories into reusable pages:
  *
- *   raw/trajectories/TRJ-* (immutable packet)
- *     → wiki/cases/*  (one specific past task)
+ *   raw/trajectories/TRJ-* (immutable packet + self-contained summary)
  *     → wiki/skills/* (reusable pattern distilled from many trajectories)
+ *     → wiki/cases/*  (a specific past task, written during distillation)
  *     → meta/*        (auto-generated registry/backlinks)
  */
 
@@ -72,7 +73,6 @@ export interface CaptureTrajectoryInput {
 export interface CaptureTrajectoryResult {
   trajectoryId: string;
   packetPath: string;
-  casePagePath: string;
   stepCount: number;
 }
 
@@ -220,51 +220,11 @@ function buildTrajectoryReadme(packet: TrajectoryPacket, title: string): string 
   return lines.join("\n");
 }
 
-/** Build a skeleton `case` page for a captured trajectory. */
-function buildCasePageSkeleton(packet: TrajectoryPacket, title: string, outcome: string): string {
-  const preview = (packet.prompt || "").replace(/\s+/g, " ").trim().slice(0, 300);
-
-  return `---
-type: case
-title: "${title.replace(/"/g, "'")}"
-trajectory_id: ${packet.id}
-status: skeleton
-outcome: ${outcome}
-created: ${packet.captured}
-updated: ${packet.captured}
-model: ${packet.model || "unknown"}
----
-
-# ${title}
-
-> _Trajectory: [[trajectories/${packet.id}]]_
-
-## Task
-
-[LLM: Restate what was requested]
-
-> _Auto-preview: ${preview}${(packet.prompt || "").length > 300 ? "..." : ""}_
-
-## Approach
-
-[LLM: Summarize the key steps and decisions the agent made]
-
-## Outcome
-
-[LLM: What was the result? What is worth reusing or avoiding next time?]
-
-## Trajectory
-
-- **ID:** \`[[trajectories/${packet.id}]]\`
-- **Packet:** [raw/trajectories/${packet.id}/packet.json](../../raw/trajectories/${packet.id}/packet.json)
-- **Steps:** ${packet.steps.length}
-`;
-}
-
 /**
- * Capture an agent task trajectory into an immutable packet plus a skeleton
- * case page. Mirrors the source-packet capture flow:
- *   raw/trajectories/TRJ-*  →  wiki/cases/<slug>.md
+ * Capture an agent task trajectory into an immutable packet plus a
+ * self-contained summary (extracted.md). No `[LLM:]` case skeleton is emitted
+ * (issue #80) — case pages, if wanted, are written during distillation via
+ * wiki_ensure_page(type='case').
  */
 export function captureTrajectory(
   paths: VaultPaths,
@@ -279,7 +239,6 @@ export function captureTrajectory(
   const title =
     input.title?.trim() ||
     (prompt ? prompt.replace(/\s+/g, " ").slice(0, 60) : `Task ${trajectoryId}`);
-  const outcome = input.outcome ?? "success";
 
   const packet: TrajectoryPacket = {
     id: trajectoryId,
@@ -302,19 +261,13 @@ export function captureTrajectory(
     title,
     format: "trajectory",
     model: packet.model || "unknown",
+    outcome: input.outcome ?? "success",
     step_count: steps.length,
     tool_call_count: toolCallCount,
   });
 
-  // Human/LLM-readable summary (the issue's README.md role).
+  // Self-contained, human/LLM-readable summary — no skeleton to flesh later.
   writeFileSync(join(packetPath, "extracted.md"), buildTrajectoryReadme(packet, title), "utf-8");
-
-  // Skeleton case page (the specific past task), parallel to skeleton source pages.
-  const slug = `${slugify(title)}-${trajectoryId.toLowerCase()}`.slice(0, 80);
-  const caseDir = join(paths.wiki, "cases");
-  mkdirSync(caseDir, { recursive: true });
-  const casePagePath = join(caseDir, `${slug}.md`);
-  writeFileSync(casePagePath, buildCasePageSkeleton(packet, title, outcome), "utf-8");
 
   appendEvent(paths, {
     kind: "capture_trajectory",
@@ -328,7 +281,6 @@ export function captureTrajectory(
   return {
     trajectoryId,
     packetPath,
-    casePagePath,
     stepCount: steps.length,
   };
 }
@@ -446,16 +398,16 @@ export function registerWikiCaptureTrajectory(pi: ExtensionAPI): void {
               `🧭 **Trajectory captured**: ${result.trajectoryId}`,
               "",
               `- Packet: \`${result.packetPath}/packet.json\``,
-              `- Case skeleton: \`${result.casePagePath}\``,
+              `- Summary: \`${result.packetPath}/extracted.md\``,
               `- Steps: ${result.stepCount}`,
               "",
-              "**Next:** Flesh out the case page's Approach/Outcome, then run `wiki_distill_skills` to generalize this into a reusable skill.",
+              "**Next (optional):** run `wiki_distill_skills` to generalize captured trajectories into reusable skill pages.",
             ].join("\n"),
           },
         ],
         details: {
           trajectoryId: result.trajectoryId,
-          casePagePath: result.casePagePath,
+          packetPath: result.packetPath,
           stepCount: result.stepCount,
         } as Record<string, unknown>,
       };
@@ -577,8 +529,8 @@ export function registerWikiDistillSkills(pi: ExtensionAPI): void {
               "",
               "**Next steps for each trajectory:**",
               "1. Read packet.json (full tool-call sequence) and extracted.md (summary)",
-              "2. Refine the skeleton case page in wiki/cases/",
-              "3. Create/refine reusable skill pages via wiki_ensure_page(type='skill')",
+              "2. Create/refine reusable skill pages via wiki_ensure_page(type='skill')",
+              "3. Optionally write a case page (a specific past task) via wiki_ensure_page(type='case')",
               "4. Cite the trajectory with [[trajectories/TRJ-...]] in each skill's 'Distilled From'",
               "",
               "The extension auto-updates metadata when you're done.",

--- a/extensions/llm-wiki/lib/trajectory.ts
+++ b/extensions/llm-wiki/lib/trajectory.ts
@@ -1,0 +1,661 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Type } from "typebox";
+import { appendEvent, rebuildMetadataLight } from "./metadata.js";
+import { searchWikiLayered } from "./recall.js";
+import {
+  type VaultPaths,
+  fmtDate,
+  nextTrajectoryId,
+  readJson,
+  resolveVaultPaths,
+  slugify,
+  writeJson,
+} from "./utils.js";
+
+/**
+ * Agent trajectory memory — the working-memory half of the wiki.
+ *
+ * Where wiki_capture_source captures what the agent *read* (URLs, files, text),
+ * wiki_capture_trajectory captures what the agent *did*: the sequence of
+ * tool calls that solved a real task. A completed task is just another kind of
+ * source, so it flows through the same 4-layer pipeline:
+ *
+ *   raw/trajectories/TRJ-* (immutable packet)
+ *     → wiki/cases/*  (one specific past task)
+ *     → wiki/skills/* (reusable pattern distilled from many trajectories)
+ *     → meta/*        (auto-generated registry/backlinks)
+ */
+
+// ─── Types ─────────────────────────────────────────────
+
+/** A single normalized step in a captured trajectory. */
+export interface TrajectoryStep {
+  role: "user" | "assistant" | "tool";
+  /** Free text (user prompt, assistant prose, or tool output preview). */
+  text?: string;
+  /** Tool calls issued by an assistant step. */
+  tool_calls?: Array<{ id: string; name: string; arguments: unknown }>;
+  /** Identifies which tool_call a tool step responds to. */
+  tool_call_id?: string;
+  /** Tool name for a tool step. */
+  tool_name?: string;
+  /** Whether a tool step reported an error. */
+  is_error?: boolean;
+}
+
+export interface TrajectoryPacket {
+  id: string;
+  captured: string;
+  packet_version: string;
+  /** The prompt that started the task. */
+  prompt: string;
+  /** Model that ran the task, if known. */
+  model?: string;
+  steps: TrajectoryStep[];
+}
+
+export interface CaptureTrajectoryInput {
+  /** Short descriptive title for the task. */
+  title?: string;
+  /** The task/prompt that started the work. Inferred from the session if omitted. */
+  task?: string;
+  /** Explicit trajectory steps. When omitted, extracted from the live session. */
+  steps?: TrajectoryStep[];
+  /** Model identifier, inferred from the session when available. */
+  model?: string;
+  /** Outcome label for the case skeleton. */
+  outcome?: "success" | "failure" | "partial";
+}
+
+export interface CaptureTrajectoryResult {
+  trajectoryId: string;
+  packetPath: string;
+  casePagePath: string;
+  stepCount: number;
+}
+
+// Max characters of a single tool result preserved in the packet preview.
+const TOOL_PREVIEW_LIMIT = 600;
+const ASSISTANT_PREVIEW_LIMIT = 1200;
+
+// ─── Session extraction ────────────────────────────────
+
+type SessionLike = {
+  getBranch?: () => unknown[];
+  getEntries?: () => unknown[];
+};
+
+function textFromContent(content: unknown, limit: number): string {
+  if (typeof content === "string") return content.slice(0, limit);
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block && typeof block === "object" && (block as { type?: string }).type === "text") {
+      parts.push(String((block as { text?: string }).text ?? ""));
+    }
+  }
+  return parts.join("\n").trim().slice(0, limit);
+}
+
+/**
+ * Extract a normalized trajectory from the live session.
+ *
+ * Reads message entries from the current branch and flattens pi's
+ * AgentMessage content blocks (text / toolCall / toolResult) into compact
+ * steps. Defensive about shapes so it degrades gracefully across pi versions.
+ */
+export function extractTrajectoryFromSession(sessionManager: unknown): {
+  steps: TrajectoryStep[];
+  model?: string;
+  prompt: string;
+} {
+  const sm = sessionManager as SessionLike;
+  const entries: unknown[] =
+    (typeof sm?.getBranch === "function" ? sm.getBranch() : undefined) ??
+    (typeof sm?.getEntries === "function" ? sm.getEntries() : undefined) ??
+    [];
+
+  const steps: TrajectoryStep[] = [];
+  let model: string | undefined;
+  let prompt = "";
+
+  for (const entry of entries) {
+    const e = entry as { type?: string; message?: unknown };
+    if (e?.type !== "message" || !e.message) continue;
+    const msg = e.message as {
+      role?: string;
+      content?: unknown;
+      model?: string;
+      toolName?: string;
+      toolCallId?: string;
+      isError?: boolean;
+    };
+
+    if (msg.role === "user") {
+      const text = textFromContent(msg.content, ASSISTANT_PREVIEW_LIMIT);
+      if (!prompt && text) prompt = text;
+      steps.push({ role: "user", text });
+    } else if (msg.role === "assistant") {
+      if (!model && msg.model) model = msg.model;
+      const toolCalls: TrajectoryStep["tool_calls"] = [];
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          const b = block as {
+            type?: string;
+            id?: string;
+            name?: string;
+            arguments?: unknown;
+          };
+          if (b?.type === "toolCall") {
+            toolCalls.push({
+              id: String(b.id ?? ""),
+              name: String(b.name ?? "unknown"),
+              arguments: b.arguments ?? {},
+            });
+          }
+        }
+      }
+      const text = textFromContent(msg.content, ASSISTANT_PREVIEW_LIMIT);
+      const step: TrajectoryStep = { role: "assistant" };
+      if (text) step.text = text;
+      if (toolCalls.length > 0) step.tool_calls = toolCalls;
+      if (step.text || step.tool_calls) steps.push(step);
+    } else if (msg.role === "toolResult") {
+      steps.push({
+        role: "tool",
+        tool_call_id: msg.toolCallId ? String(msg.toolCallId) : undefined,
+        tool_name: msg.toolName ? String(msg.toolName) : undefined,
+        text: textFromContent(msg.content, TOOL_PREVIEW_LIMIT),
+        is_error: Boolean(msg.isError),
+      });
+    }
+  }
+
+  return { steps, model, prompt };
+}
+
+// ─── Capture ───────────────────────────────────────────
+
+/** Build a human/LLM-readable README summary of a trajectory packet. */
+function buildTrajectoryReadme(packet: TrajectoryPacket, title: string): string {
+  const toolCalls = packet.steps.flatMap((s) => s.tool_calls ?? []);
+  const toolCounts = new Map<string, number>();
+  for (const tc of toolCalls) toolCounts.set(tc.name, (toolCounts.get(tc.name) ?? 0) + 1);
+  const toolSummary =
+    [...toolCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([name, n]) => `${name}×${n}`)
+      .join(", ") || "none";
+
+  const lines: string[] = [
+    `# Trajectory ${packet.id}: ${title}`,
+    "",
+    `- **Captured:** ${packet.captured}`,
+    `- **Model:** ${packet.model || "unknown"}`,
+    `- **Steps:** ${packet.steps.length}`,
+    `- **Tools used:** ${toolSummary}`,
+    "",
+    "## Task",
+    "",
+    packet.prompt || "_No prompt recorded._",
+    "",
+    "## Tool-call sequence",
+    "",
+  ];
+
+  let i = 1;
+  for (const step of packet.steps) {
+    if (step.role === "assistant" && step.tool_calls?.length) {
+      for (const tc of step.tool_calls) {
+        lines.push(`${i}. \`${tc.name}\``);
+        i++;
+      }
+    }
+  }
+  if (i === 1) lines.push("_No tool calls recorded._");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/** Build a skeleton `case` page for a captured trajectory. */
+function buildCasePageSkeleton(packet: TrajectoryPacket, title: string, outcome: string): string {
+  const preview = (packet.prompt || "").replace(/\s+/g, " ").trim().slice(0, 300);
+
+  return `---
+type: case
+title: "${title.replace(/"/g, "'")}"
+trajectory_id: ${packet.id}
+status: skeleton
+outcome: ${outcome}
+created: ${packet.captured}
+updated: ${packet.captured}
+model: ${packet.model || "unknown"}
+---
+
+# ${title}
+
+> _Trajectory: [[trajectories/${packet.id}]]_
+
+## Task
+
+[LLM: Restate what was requested]
+
+> _Auto-preview: ${preview}${(packet.prompt || "").length > 300 ? "..." : ""}_
+
+## Approach
+
+[LLM: Summarize the key steps and decisions the agent made]
+
+## Outcome
+
+[LLM: What was the result? What is worth reusing or avoiding next time?]
+
+## Trajectory
+
+- **ID:** \`[[trajectories/${packet.id}]]\`
+- **Packet:** [raw/trajectories/${packet.id}/packet.json](../../raw/trajectories/${packet.id}/packet.json)
+- **Steps:** ${packet.steps.length}
+`;
+}
+
+/**
+ * Capture an agent task trajectory into an immutable packet plus a skeleton
+ * case page. Mirrors the source-packet capture flow:
+ *   raw/trajectories/TRJ-*  →  wiki/cases/<slug>.md
+ */
+export function captureTrajectory(
+  paths: VaultPaths,
+  input: CaptureTrajectoryInput,
+): CaptureTrajectoryResult {
+  const trajectoryId = nextTrajectoryId(paths);
+  const packetPath = join(paths.rawTrajectories, trajectoryId);
+  mkdirSync(packetPath, { recursive: true });
+
+  const steps = input.steps ?? [];
+  const prompt = input.task?.trim() || steps.find((s) => s.role === "user")?.text?.trim() || "";
+  const title =
+    input.title?.trim() ||
+    (prompt ? prompt.replace(/\s+/g, " ").slice(0, 60) : `Task ${trajectoryId}`);
+  const outcome = input.outcome ?? "success";
+
+  const packet: TrajectoryPacket = {
+    id: trajectoryId,
+    captured: fmtDate(),
+    packet_version: "1.0",
+    prompt,
+    ...(input.model ? { model: input.model } : {}),
+    steps,
+  };
+
+  // Immutable full trajectory.
+  writeJson(join(packetPath, "packet.json"), packet);
+
+  // Lightweight manifest so buildRegistry catalogs it uniformly with sources.
+  const toolCallCount = steps.reduce((n, s) => n + (s.tool_calls?.length ?? 0), 0);
+  writeJson(join(packetPath, "manifest.json"), {
+    id: trajectoryId,
+    captured: packet.captured,
+    packet_version: "1.0",
+    title,
+    format: "trajectory",
+    model: packet.model || "unknown",
+    step_count: steps.length,
+    tool_call_count: toolCallCount,
+  });
+
+  // Human/LLM-readable summary (the issue's README.md role).
+  writeFileSync(join(packetPath, "extracted.md"), buildTrajectoryReadme(packet, title), "utf-8");
+
+  // Skeleton case page (the specific past task), parallel to skeleton source pages.
+  const slug = `${slugify(title)}-${trajectoryId.toLowerCase()}`.slice(0, 80);
+  const caseDir = join(paths.wiki, "cases");
+  mkdirSync(caseDir, { recursive: true });
+  const casePagePath = join(caseDir, `${slug}.md`);
+  writeFileSync(casePagePath, buildCasePageSkeleton(packet, title, outcome), "utf-8");
+
+  appendEvent(paths, {
+    kind: "capture_trajectory",
+    trajectory_id: trajectoryId,
+    step_count: steps.length,
+    tool_call_count: toolCallCount,
+  });
+
+  rebuildMetadataLight(paths);
+
+  return {
+    trajectoryId,
+    packetPath,
+    casePagePath,
+    stepCount: steps.length,
+  };
+}
+
+// ─── Tool: wiki_capture_trajectory ─────────────────────
+
+function vaultMissing() {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: "No wiki vault found at this location. Initialize one with wiki_bootstrap first.",
+      },
+    ],
+    details: { error: "no_vault" } as Record<string, unknown>,
+    isError: true,
+  };
+}
+
+const StepSchema = Type.Object({
+  role: Type.Union([Type.Literal("user"), Type.Literal("assistant"), Type.Literal("tool")]),
+  text: Type.Optional(Type.String()),
+  tool_calls: Type.Optional(
+    Type.Array(
+      Type.Object({
+        id: Type.String(),
+        name: Type.String(),
+        arguments: Type.Unknown(),
+      }),
+    ),
+  ),
+  tool_call_id: Type.Optional(Type.String()),
+  tool_name: Type.Optional(Type.String()),
+  is_error: Type.Optional(Type.Boolean()),
+});
+
+export function registerWikiCaptureTrajectory(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "wiki_capture_trajectory",
+    label: "Wiki Capture Trajectory",
+    description:
+      "Capture the just-completed task's tool-call trajectory into an immutable " +
+      "packet plus a skeleton case page. By default the trajectory is extracted " +
+      "automatically from the live session; pass `steps` to override. This is the " +
+      "working-memory counterpart to wiki_capture_source.",
+    promptSnippet: "Record the completed task trajectory into the wiki",
+    promptGuidelines: [
+      "Use wiki_capture_trajectory after a non-trivial task worth learning from. The extension auto-extracts the tool-call trajectory from the session — you usually only need to pass a title.",
+      "Then run wiki_distill_skills to generalize captured trajectories into reusable skill pages.",
+    ],
+    parameters: Type.Object({
+      title: Type.Optional(
+        Type.String({ description: "Short descriptive title for the task (≤60 chars)." }),
+      ),
+      task: Type.Optional(
+        Type.String({
+          description:
+            "The task/prompt that started the work. Inferred from the session if omitted.",
+        }),
+      ),
+      outcome: Type.Optional(
+        Type.Union([Type.Literal("success"), Type.Literal("failure"), Type.Literal("partial")], {
+          description: "Outcome of the task (default: success).",
+        }),
+      ),
+      steps: Type.Optional(
+        Type.Array(StepSchema, {
+          description:
+            "Explicit trajectory steps (OpenAI-ish tool-call history). Omit to auto-extract from the live session.",
+        }),
+      ),
+      model: Type.Optional(Type.String({ description: "Model that ran the task." })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx: ExtensionContext) {
+      const paths = resolveVaultPaths(ctx.cwd ?? process.cwd());
+      if (!existsSync(join(paths.dotWiki, "config.json"))) return vaultMissing();
+
+      let steps = params.steps as TrajectoryStep[] | undefined;
+      let model = params.model;
+      let task = params.task;
+
+      if (!steps || steps.length === 0) {
+        const extracted = extractTrajectoryFromSession(ctx.sessionManager);
+        steps = extracted.steps;
+        model = model || extracted.model;
+        task = task || extracted.prompt;
+      }
+
+      if (!steps || steps.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "No trajectory could be extracted from the session. Pass `steps` explicitly to capture a trajectory.",
+            },
+          ],
+          details: { error: "empty_trajectory" } as Record<string, unknown>,
+          isError: true,
+        };
+      }
+
+      const result = captureTrajectory(paths, {
+        title: params.title,
+        task,
+        steps,
+        model,
+        outcome: params.outcome,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: [
+              `🧭 **Trajectory captured**: ${result.trajectoryId}`,
+              "",
+              `- Packet: \`${result.packetPath}/packet.json\``,
+              `- Case skeleton: \`${result.casePagePath}\``,
+              `- Steps: ${result.stepCount}`,
+              "",
+              "**Next:** Flesh out the case page's Approach/Outcome, then run `wiki_distill_skills` to generalize this into a reusable skill.",
+            ].join("\n"),
+          },
+        ],
+        details: {
+          trajectoryId: result.trajectoryId,
+          casePagePath: result.casePagePath,
+          stepCount: result.stepCount,
+        } as Record<string, unknown>,
+      };
+    },
+  });
+}
+
+// ─── Tool: wiki_distill_skills ─────────────────────────
+
+/** Determine which trajectory IDs have already been cited by a skill page. */
+function distilledTrajectoryIds(paths: VaultPaths): Set<string> {
+  const backlinks = readJson<Record<string, string[]>>(join(paths.meta, "backlinks.json"), {});
+  const distilled = new Set<string>();
+  for (const [pageId, inbound] of Object.entries(backlinks)) {
+    if (!pageId.startsWith("trajectories/")) continue;
+    if (inbound.some((src) => src.startsWith("skills/"))) {
+      distilled.add(pageId.split("/").pop() as string);
+    }
+  }
+  return distilled;
+}
+
+export function registerWikiDistillSkills(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "wiki_distill_skills",
+    label: "Wiki Distill Skills",
+    description:
+      "Return a batch of captured trajectories (agent working-memory) that have not " +
+      "yet been distilled into skill pages. Read each packet and synthesize reusable " +
+      "skill pages (and/or refine case pages) that cite the trajectory IDs.",
+    promptSnippet: "Distill captured trajectories into reusable skill pages",
+    promptGuidelines: [
+      "Use wiki_distill_skills to generalize one or more captured trajectories into reusable skill pages via wiki_ensure_page(type='skill').",
+      "Every skill page must cite the trajectory IDs it was distilled from with [[trajectories/TRJ-...]] wikilinks.",
+    ],
+    parameters: Type.Object({
+      trajectory_id: Type.Optional(
+        Type.String({
+          description: "Specific trajectory ID to distill. Omit for all undistilled.",
+        }),
+      ),
+      batch_size: Type.Optional(
+        Type.Number({ description: "Max trajectories to return (default: 3, max: 5)", default: 3 }),
+      ),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx: ExtensionContext) {
+      const paths = resolveVaultPaths(ctx.cwd ?? process.cwd());
+      if (!existsSync(join(paths.dotWiki, "config.json"))) return vaultMissing();
+
+      const batchSize = Math.min(params.batch_size ?? 3, 5);
+
+      if (!existsSync(paths.rawTrajectories)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "No raw/trajectories/ directory. Capture trajectories first with wiki_capture_trajectory.",
+            },
+          ],
+          details: { error: "no_trajectories" } as Record<string, unknown>,
+        };
+      }
+
+      const packets = readdirSync(paths.rawTrajectories)
+        .filter((d) => d.startsWith("TRJ-"))
+        .sort();
+      const distilled = distilledTrajectoryIds(paths);
+
+      let toProcess = packets.filter((p) => !distilled.has(p));
+      if (params.trajectory_id) {
+        if (!packets.includes(params.trajectory_id)) {
+          return {
+            content: [{ type: "text", text: `Trajectory ${params.trajectory_id} not found.` }],
+            details: { trajectory_id: params.trajectory_id, status: "not_found" } as Record<
+              string,
+              unknown
+            >,
+          };
+        }
+        toProcess = [params.trajectory_id];
+      }
+
+      const batch = toProcess.slice(0, batchSize);
+      if (batch.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "✅ All trajectories distilled. Capture more with wiki_capture_trajectory.",
+            },
+          ],
+          details: { distilled: distilled.size, total: packets.length } as Record<string, unknown>,
+        };
+      }
+
+      const trajectories = batch.map((id) => {
+        const readmePath = join(paths.rawTrajectories, id, "extracted.md");
+        const manifestPath = join(paths.rawTrajectories, id, "manifest.json");
+        const readme = existsSync(readmePath) ? readFileSync(readmePath, "utf-8") : "";
+        const manifest = readJson<Record<string, unknown>>(manifestPath, {});
+        return { id, readme, manifest };
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: [
+              `🧪 **${batch.length} trajectory(ies) ready** (${toProcess.length - batch.length} remaining)`,
+              "",
+              ...trajectories.map((t) =>
+                [
+                  `- **${t.id}**: ${t.manifest.title || t.id}`,
+                  `  - Tool calls: ${t.manifest.tool_call_count ?? "?"}, steps: ${t.manifest.step_count ?? "?"}`,
+                  `  - Packet: \`raw/trajectories/${t.id}/packet.json\``,
+                  `  - Summary: \`raw/trajectories/${t.id}/extracted.md\``,
+                ].join("\n"),
+              ),
+              "",
+              "**Next steps for each trajectory:**",
+              "1. Read packet.json (full tool-call sequence) and extracted.md (summary)",
+              "2. Refine the skeleton case page in wiki/cases/",
+              "3. Create/refine reusable skill pages via wiki_ensure_page(type='skill')",
+              "4. Cite the trajectory with [[trajectories/TRJ-...]] in each skill's 'Distilled From'",
+              "",
+              "The extension auto-updates metadata when you're done.",
+            ].join("\n"),
+          },
+        ],
+        details: {
+          batch: trajectories.map((t) => t.id),
+          remaining: toProcess.length - batch.length,
+        } as Record<string, unknown>,
+      };
+    },
+  });
+}
+
+// ─── Tool: wiki_recall_skill ───────────────────────────
+
+export function registerWikiRecallSkill(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "wiki_recall_skill",
+    label: "Wiki Recall Skill",
+    description:
+      "Search distilled skills and past cases (agent working-memory) for patterns " +
+      "relevant to the current task — answers 'have I done something like this before?'. " +
+      "Filters layered recall to skill and case pages.",
+    promptSnippet: "Recall distilled skills and past cases relevant to the task",
+    promptGuidelines: [
+      "Use wiki_recall_skill at the START of a task to find reusable skills and similar past cases before doing the work.",
+    ],
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query — use the task description or key terms" }),
+      kind: Type.Optional(
+        Type.Union([Type.Literal("skill"), Type.Literal("case"), Type.Literal("any")], {
+          description: "Filter to skills, cases, or both (default: any).",
+        }),
+      ),
+      max_results: Type.Optional(
+        Type.Number({ description: "Max results (default: 5, max: 10)", default: 5 }),
+      ),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx: ExtensionContext) {
+      const paths = resolveVaultPaths(ctx.cwd ?? process.cwd());
+      if (!existsSync(join(paths.dotWiki, "config.json"))) return vaultMissing();
+
+      const maxResults = Math.min(params.max_results ?? 5, 10);
+      const kind = params.kind ?? "any";
+      // Over-fetch then filter by type, since searchWikiLayered is type-agnostic.
+      const raw = searchWikiLayered(paths, params.query, maxResults * 4, 0);
+      const wanted = kind === "any" ? ["skill", "case"] : [kind];
+      const results = raw.filter((r) => wanted.includes(r.type)).slice(0, maxResults);
+
+      if (results.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `No ${kind === "any" ? "skills or cases" : `${kind}s`} found matching "${params.query}". Capture work with wiki_capture_trajectory and distill it with wiki_distill_skills.`,
+            },
+          ],
+          details: { query: params.query, kind, matches: [] } as Record<string, unknown>,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Found ${results.length} ${kind === "any" ? "skill/case" : kind} page(s) matching "${params.query}":\n\n${results
+              .map((r) => {
+                const vault = r.vaultLabel ? ` ${r.vaultLabel}` : "";
+                return `## [[${r.id}]] — ${r.title}${vault}\nType: ${r.type}\nPath: ${r.path}\n\n${r.preview}`;
+              })
+              .join("\n\n---\n\n")}`,
+          },
+        ],
+        details: { query: params.query, kind, matches: results } as Record<string, unknown>,
+      };
+    },
+  });
+}

--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -195,9 +195,12 @@ export function resolveVaultPaths(cwd: string): VaultPaths {
 
 /** Ensure all vault directories exist. */
 export function ensureVaultStructure(paths: VaultPaths): void {
+  // NOTE: the agent-trajectory dirs (raw/trajectories, wiki/skills, wiki/cases)
+  // are intentionally NOT created here — they are created lazily on first
+  // capture/distill (issue #80), so a vault with the feature off carries no
+  // trace of it. All readers of these paths are existsSync-guarded.
   const dirs = [
     paths.rawSources,
-    paths.rawTrajectories,
     join(paths.raw, "assets"),
     join(paths.wiki, "sources"),
     join(paths.wiki, "entities"),
@@ -205,8 +208,6 @@ export function ensureVaultStructure(paths: VaultPaths): void {
     join(paths.wiki, "syntheses"),
     join(paths.wiki, "analyses"),
     join(paths.wiki, "requirements"),
-    join(paths.wiki, "skills"),
-    join(paths.wiki, "cases"),
     paths.meta,
     paths.dotWiki,
     paths.outputs,

--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -20,6 +20,7 @@ export interface VaultPaths {
   root: string;
   raw: string;
   rawSources: string;
+  rawTrajectories: string;
   wiki: string;
   meta: string;
   dotWiki: string;
@@ -157,6 +158,7 @@ export function getVaultPaths(root: string): VaultPaths {
     root,
     raw: join(root, ".llm-wiki", "raw"),
     rawSources: join(root, ".llm-wiki", "raw", "sources"),
+    rawTrajectories: join(root, ".llm-wiki", "raw", "trajectories"),
     wiki: join(root, ".llm-wiki", "wiki"),
     meta: join(root, ".llm-wiki", "meta"),
     dotWiki: join(root, ".llm-wiki"),
@@ -171,6 +173,7 @@ export function getLegacyVaultPaths(root: string): VaultPaths {
     root,
     raw: join(root, "raw"),
     rawSources: join(root, "raw", "sources"),
+    rawTrajectories: join(root, "raw", "trajectories"),
     wiki: join(root, "wiki"),
     meta: join(root, "meta"),
     dotWiki: join(root, ".wiki"),
@@ -194,6 +197,7 @@ export function resolveVaultPaths(cwd: string): VaultPaths {
 export function ensureVaultStructure(paths: VaultPaths): void {
   const dirs = [
     paths.rawSources,
+    paths.rawTrajectories,
     join(paths.raw, "assets"),
     join(paths.wiki, "sources"),
     join(paths.wiki, "entities"),
@@ -201,6 +205,8 @@ export function ensureVaultStructure(paths: VaultPaths): void {
     join(paths.wiki, "syntheses"),
     join(paths.wiki, "analyses"),
     join(paths.wiki, "requirements"),
+    join(paths.wiki, "skills"),
+    join(paths.wiki, "cases"),
     paths.meta,
     paths.dotWiki,
     paths.outputs,
@@ -238,12 +244,22 @@ export function readText(path: string): string {
 
 /** Generate the next source ID. */
 export function nextSourceId(paths: VaultPaths): string {
+  return nextSequentialId(paths.rawSources, "SRC");
+}
+
+/** Generate the next trajectory ID. */
+export function nextTrajectoryId(paths: VaultPaths): string {
+  return nextSequentialId(paths.rawTrajectories, "TRJ");
+}
+
+/** Generate the next sequential, date-stamped packet ID for a raw subdir. */
+function nextSequentialId(dir: string, kind: string): string {
   const today = new Date().toISOString().split("T")[0];
-  const prefix = `SRC-${today}`;
+  const prefix = `${kind}-${today}`;
 
-  if (!existsSync(paths.rawSources)) return `${prefix}-001`;
+  if (!existsSync(dir)) return `${prefix}-001`;
 
-  const dirs = readdirSync(paths.rawSources)
+  const dirs = readdirSync(dir)
     .filter((d) => d.startsWith(prefix))
     .sort();
 

--- a/prompts/wiki-record.md
+++ b/prompts/wiki-record.md
@@ -1,0 +1,36 @@
+---
+description: Capture the just-completed task's tool-call trajectory into the wiki as agent working-memory, then optionally distill it into a reusable skill.
+argument-hint: "<title> [--outcome success|failure|partial]"
+section: LLM Wiki
+topLevelCli: true
+---
+
+# /wiki-record
+
+Capture the trajectory of the task you just completed — the sequence of tool calls that solved it — into the wiki's working-memory layer.
+
+This is the counterpart to source capture: instead of recording what you *read*, it records what you *did*, so the wiki compounds over your own work.
+
+## User Arguments
+
+$ARGUMENTS
+
+Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand the wiki conventions.
+
+## Steps
+
+1. Call `wiki_capture_trajectory` with:
+   - `title`: short descriptive phrase for the task (≤60 chars, noun phrase)
+   - `outcome`: optional — `success` (default), `failure`, or `partial`
+   - The extension auto-extracts the tool-call trajectory from the live session, so you usually do **not** pass `steps` manually.
+2. Open the generated skeleton case page in `wiki/cases/` and flesh out:
+   - **Task** — what was requested
+   - **Approach** — the key steps and decisions (not every tool call, just the meaningful ones)
+   - **Outcome** — the result, and anything worth reusing or avoiding next time
+3. If the task taught a reusable pattern, run `wiki_distill_skills` and create a `skill` page via `wiki_ensure_page(type="skill")` that cites `[[trajectories/TRJ-...]]`.
+4. Confirm the case (and any skill) will be surfaced by `wiki_recall` / `wiki_recall_skill` in future sessions.
+
+**Rules:**
+- Only record tasks worth learning from — non-trivial debugging, refactors, integrations, multi-step workflows. Skip trivial one-shot answers.
+- The raw trajectory packet under `raw/trajectories/` is immutable. Edit the `case`/`skill` pages, never the packet.
+- One trajectory per `wiki_capture_trajectory` call.

--- a/prompts/wiki-skills.md
+++ b/prompts/wiki-skills.md
@@ -1,0 +1,26 @@
+---
+description: Search the wiki's distilled skills and past cases for patterns relevant to the current task — "have I done something like this before?".
+argument-hint: "[query] [--kind skill|case]"
+section: LLM Wiki
+topLevelCli: true
+---
+
+# /wiki-skills
+
+Search the agent working-memory layer of the wiki: reusable **skills** distilled from past trajectories, and specific past **cases**.
+
+## User Arguments
+
+$ARGUMENTS
+
+## Steps
+
+1. Call `wiki_recall_skill` with:
+   - `query`: the current task description or key terms (defaults to `$ARGUMENTS`)
+   - `kind`: optional — `skill`, `case`, or `any` (default)
+   - `max_results`: optional (default 5)
+2. Read the most relevant skill/case pages with `read`.
+3. Apply the recalled pattern to the current task, citing the source page with `[[skills/...]]` or `[[cases/...]]` where helpful.
+4. If no relevant skill/case exists, proceed with the task and consider running `/wiki-record` afterward so the next attempt benefits.
+
+**Tip:** Skills generalize across many trajectories ("how I do X"); cases are concrete past runs ("the time I did X for project Y"). Search `any` first, then narrow.

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: llm-wiki
-description: Build and maintain a persistent, interlinked Obsidian-compatible markdown wiki using Karpathy's LLM Wiki pattern. Extension-backed with auto-generated metadata, guardrails, and 12 custom tools.
-whenToUse: Call wiki_recall at task start to find relevant wiki pages. Call wiki_retro at task end to save new insights. The extension injects a brief status line, but explicit wiki_recall calls with task-specific terms get better results.
+description: Build and maintain a persistent, interlinked Obsidian-compatible markdown wiki using Karpathy's LLM Wiki pattern. Extension-backed with auto-generated metadata, guardrails, and 16 custom tools.
+whenToUse: Call wiki_recall at task start to find relevant wiki pages, and wiki_recall_skill to find reusable skills / past cases ("have I done this before?"). Call wiki_retro at task end to save new insights, and wiki_capture_trajectory after non-trivial tasks to record how you solved them. The extension injects a brief status line, but explicit calls with task-specific terms get better results.
 ---
 
 # LLM Wiki for Pi
@@ -20,12 +20,18 @@ WIKI_ROOT/
     │   ├── original/
     │   ├── extracted.md
     │   └── attachments/
+    ├── raw/trajectories/TRJ-*/ # Immutable agent task packets (extension-owned)
+    │   ├── manifest.json      # Capture metadata (format: trajectory)
+    │   ├── packet.json        # Full tool-call sequence
+    │   └── extracted.md       # README summary
     ├── wiki/                  # Editable knowledge pages (you own this)
     │   ├── sources/           # One summary per source
     │   ├── entities/          # People, orgs, tools, products
     │   ├── concepts/          # Ideas, patterns, frameworks
     │   ├── syntheses/         # Cross-cutting analyses
-    │   └── analyses/          # Durable query answers
+    │   ├── analyses/          # Durable query answers
+    │   ├── cases/             # One specific past task per trajectory
+    │   └── skills/            # Reusable patterns distilled from trajectories
     ├── meta/                  # Auto-generated (extension-owned)
     │   ├── registry.json      # Master page catalog
     │   ├── backlinks.json     # Inbound link map
@@ -45,6 +51,29 @@ WIKI_ROOT/
 5. **CROSS-REFERENCE EVERYTHING.** Every page needs at least 2 `[[wikilinks]]`.
 6. **CITE SOURCES.** Every claim links back to its raw source packet.
 7. **FLAG CONTRADICTIONS.** When sources disagree, document both sides.
+
+## Agent Working-Memory (Trajectories)
+
+The wiki captures not only what you *read* (sources) but what you *do*
+(trajectories). A completed task is just another kind of source, so it flows
+through the same pipeline:
+
+```
+raw/trajectories/TRJ-*  →  wiki/cases/*  →  wiki/skills/*  →  meta/*
+```
+
+- `wiki_capture_trajectory` writes the immutable packet + a skeleton `case` page,
+  auto-extracting the tool-call sequence from the live session (you usually only
+  pass a `title`).
+- `wiki_distill_skills` returns undistilled trajectories so you can generalize them
+  into reusable `skill` pages via `wiki_ensure_page(type="skill")`.
+- `wiki_recall_skill` filters layered recall to `skill`/`case` pages —
+  "have I done something like this before?". Call it at task start.
+
+A **skill** generalizes across many trajectories ("how I do X"); a **case** is one
+concrete past run ("the time I did X for project Y"). Trajectory packets live under
+`raw/**` and are therefore immutable under the same guardrail as source packets —
+edit the `case`/`skill` pages, never the packet.
 
 ## How the Extension Helps You
 
@@ -150,6 +179,9 @@ Use these directly — they handle scaffolding, bookkeeping, recall, and capture
 - `wiki_rebuild_meta` — Force metadata rebuild
 - `wiki_log_event` — Record a custom event
 - `wiki_watch` — Schedule auto-updates
+- `wiki_capture_trajectory` — Capture the completed task's tool-call trajectory (working-memory)
+- `wiki_distill_skills` — Batch undistilled trajectories for skill synthesis
+- `wiki_recall_skill` — Recall distilled skills + similar past cases
 
 ## Workflows
 
@@ -180,6 +212,15 @@ Use these directly — they handle scaffolding, bookkeeping, recall, and capture
 4. Extension auto-updates metadata
 5. Next time, layered recall surfaces your saved insight
 
+### Task → Record → Distill (agent working-memory)
+
+1. Finish a non-trivial task (debug, refactor, integration)
+2. `wiki_capture_trajectory(title="...")` — auto-extracts the tool-call trajectory into `raw/trajectories/TRJ-*` plus a skeleton `case` page
+3. Flesh out the `wiki/cases/` page (Task → Approach → Outcome)
+4. `wiki_distill_skills()` — get undistilled trajectories
+5. `wiki_ensure_page(type="skill", title="...")` — generalize into a reusable skill citing `[[trajectories/TRJ-...]]`
+6. Next time, `wiki_recall_skill(query="...")` surfaces the skill/case before you start
+
 ## Page Conventions
 
 ### Naming
@@ -191,7 +232,7 @@ Use these directly — they handle scaffolding, bookkeeping, recall, and capture
 
 ```yaml
 ---
-type: entity | concept | source | synthesis | analysis
+type: entity | concept | source | synthesis | analysis | skill | case | trajectory
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 sources: [sources/SRC-YYYY-MM-DD-NNN]
@@ -200,10 +241,13 @@ sources: [sources/SRC-YYYY-MM-DD-NNN]
 
 Entity: add `category: person | organization | tool | project | product`
 Concept: add `domain: ai | engineering | business | product | design | personal`
+Skill: add `trajectories: [trajectories/TRJ-YYYY-MM-DD-NNN]`
+Case: add `trajectory_id: TRJ-YYYY-MM-DD-NNN` and `outcome: success | failure | partial`
 
 ### Citations
 
 Use stable source IDs: `[[sources/SRC-2026-04-28-001]]`
+Cite trajectories with their stable IDs: `[[trajectories/TRJ-2026-04-28-001]]`
 
 ### Contradictions
 

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: llm-wiki
-description: Build and maintain a persistent, interlinked Obsidian-compatible markdown wiki using Karpathy's LLM Wiki pattern. Extension-backed with auto-generated metadata, guardrails, and 16 custom tools.
-whenToUse: Call wiki_recall at task start to find relevant wiki pages, and wiki_recall_skill to find reusable skills / past cases ("have I done this before?"). Call wiki_retro at task end to save new insights, and wiki_capture_trajectory after non-trivial tasks to record how you solved them. The extension injects a brief status line, but explicit calls with task-specific terms get better results.
+description: Build and maintain a persistent, interlinked Obsidian-compatible markdown wiki using Karpathy's LLM Wiki pattern. Extension-backed with auto-generated metadata, guardrails, and 13 custom tools (+3 opt-in agent-trajectory tools).
+whenToUse: Call wiki_recall at task start to find relevant wiki pages. Call wiki_retro at task end to save new insights. When agent-trajectory working-memory is enabled (opt-in, /wiki-trajectories on), also call wiki_recall_skill at task start to find reusable skills / past cases ("have I done this before?") and wiki_capture_trajectory after non-trivial tasks to record how you solved them. The extension injects a brief status line, but explicit calls with task-specific terms get better results.
 ---
 
 # LLM Wiki for Pi
@@ -59,14 +59,20 @@ The wiki captures not only what you *read* (sources) but what you *do*
 through the same pipeline:
 
 ```
-raw/trajectories/TRJ-*  →  wiki/cases/*  →  wiki/skills/*  →  meta/*
+raw/trajectories/TRJ-*  →  wiki/skills/*  (+ optional wiki/cases/*)  →  meta/*
 ```
 
-- `wiki_capture_trajectory` writes the immutable packet + a skeleton `case` page,
-  auto-extracting the tool-call sequence from the live session (you usually only
-  pass a `title`).
+> **Opt-in, off by default** (issue #80). The three tools below are only registered
+> when `llm-wiki.trajectories` is enabled. Turn it on with `/wiki-trajectories on`
+> (off with `/wiki-trajectories off`); toggling reloads the extension. When off, the
+> tools are absent entirely — no system-prompt cost.
+
+- `wiki_capture_trajectory` writes the immutable packet + a **self-contained summary**
+  (`extracted.md`), auto-extracting the tool-call sequence from the live session (you
+  usually only pass a `title`). It does **not** emit a to-be-fleshed skeleton — capture
+  is a single lightweight call.
 - `wiki_distill_skills` returns undistilled trajectories so you can generalize them
-  into reusable `skill` pages via `wiki_ensure_page(type="skill")`.
+  into reusable `skill` pages (and optionally `case` pages) via `wiki_ensure_page`.
 - `wiki_recall_skill` filters layered recall to `skill`/`case` pages —
   "have I done something like this before?". Call it at task start.
 
@@ -74,6 +80,20 @@ A **skill** generalizes across many trajectories ("how I do X"); a **case** is o
 concrete past run ("the time I did X for project Y"). Trajectory packets live under
 `raw/**` and are therefore immutable under the same guardrail as source packets —
 edit the `case`/`skill` pages, never the packet.
+
+### When to use which memory tool
+
+| Tool | Stores | Use for |
+|------|--------|---------|
+| `wiki_capture_trajectory` | A structured, **replayable** tool-call packet (`packet.json`: tool names + arguments + results + errors) | "How did I *mechanically* solve this?" — the exact step sequence, to distill into a repeatable skill |
+| `wiki_retro` | A durable prose **insight** (one markdown file) | "What did I learn?" — a lesson/gotcha worth keeping, not a step list |
+| `wiki_observe` | A timestamped prose **observation** | Lightweight running notes the extension reminds you to jot during a task |
+
+Why a separate trajectory store and not pi's built-in observational-memory? pi's
+observational-memory keeps **prose** for context-compaction survival — it does not
+persist the structured tool-call sequence (names, arguments, results). The trajectory
+packet is the only artifact that captures a task as a replayable record, which is what
+makes skill distillation possible.
 
 ## How the Extension Helps You
 
@@ -215,7 +235,7 @@ Use these directly — they handle scaffolding, bookkeeping, recall, and capture
 ### Task → Record → Distill (agent working-memory)
 
 1. Finish a non-trivial task (debug, refactor, integration)
-2. `wiki_capture_trajectory(title="...")` — auto-extracts the tool-call trajectory into `raw/trajectories/TRJ-*` plus a skeleton `case` page
+2. `wiki_capture_trajectory(title="...")` — auto-extracts the tool-call trajectory into `raw/trajectories/TRJ-*` with a self-contained summary (no skeleton)
 3. Flesh out the `wiki/cases/` page (Task → Approach → Outcome)
 4. `wiki_distill_skills()` — get undistilled trajectories
 5. `wiki_ensure_page(type="skill", title="...")` — generalize into a reusable skill citing `[[trajectories/TRJ-...]]`

--- a/test/trajectory-flag.test.ts
+++ b/test/trajectory-flag.test.ts
@@ -1,0 +1,121 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { searchWikiLayered } from "../extensions/llm-wiki/lib/recall.js";
+import {
+  loadTaskConfig,
+  persistTaskModel,
+  persistTrajectoriesEnabled,
+  trajectoriesEnabled,
+} from "../extensions/llm-wiki/lib/task-config.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+
+/**
+ * Issue #80: trajectory working-memory is opt-in / default-off, gated at
+ * extension-load time via `trajectoriesEnabled(loadTaskConfig(cwd))` — the
+ * exact expression index.ts uses to decide whether to register the 3 tools.
+ * These tests pin the flag resolution, persistence round-trip, and the
+ * lazy-directory tolerance that the default-off footprint depends on.
+ */
+
+describe("trajectoriesEnabled (issue #80, default-off polarity)", () => {
+  it("defaults to false for undefined / empty config", () => {
+    expect(trajectoriesEnabled(undefined)).toBe(false);
+    expect(trajectoriesEnabled({})).toBe(false);
+  });
+
+  it("is true only for an explicit trajectories: true", () => {
+    expect(trajectoriesEnabled({ trajectories: true })).toBe(true);
+    expect(trajectoriesEnabled({ trajectories: false })).toBe(false);
+  });
+});
+
+describe("trajectories flag persistence round-trip", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dirname, "..", "tmp", `trj-flag-${Date.now()}-${Math.random()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("loadTaskConfig reads trajectories from <cwd>/.pi/settings.json", () => {
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { trajectories: true } }),
+    );
+    expect(trajectoriesEnabled(loadTaskConfig(tmpDir))).toBe(true);
+  });
+
+  it("persistTrajectoriesEnabled(true) then loadTaskConfig resolves enabled", () => {
+    persistTrajectoriesEnabled(tmpDir, true);
+    expect(trajectoriesEnabled(loadTaskConfig(tmpDir))).toBe(true);
+  });
+
+  it("persistTrajectoriesEnabled(false) removes the key (reverts to default-off)", () => {
+    persistTrajectoriesEnabled(tmpDir, true);
+    persistTrajectoriesEnabled(tmpDir, false);
+    expect(trajectoriesEnabled(loadTaskConfig(tmpDir))).toBe(false);
+    const settings = JSON.parse(readFileSync(join(tmpDir, ".pi", "settings.json"), "utf-8"));
+    expect(settings["llm-wiki"].trajectories).toBeUndefined();
+  });
+
+  it("preserves other llm-wiki settings when toggling the flag", () => {
+    persistTaskModel(tmpDir, { provider: "anthropic", id: "claude-haiku-4-5" });
+    persistTrajectoriesEnabled(tmpDir, true);
+    const cfg = loadTaskConfig(tmpDir);
+    expect(cfg.trajectories).toBe(true);
+    expect(cfg.taskModel).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
+
+    // Turning trajectories off must not clobber the task model.
+    persistTrajectoriesEnabled(tmpDir, false);
+    expect(loadTaskConfig(tmpDir).taskModel).toEqual({
+      provider: "anthropic",
+      id: "claude-haiku-4-5",
+    });
+  });
+});
+
+describe("lazy-dir tolerance (recall over a vault without trajectory dirs)", () => {
+  let tmpDir: string;
+  let wikiDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dirname, "..", "tmp", `trj-lazy-${Date.now()}-${Math.random()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    wikiDir = join(tmpDir, "vault");
+    mkdirSync(wikiDir, { recursive: true });
+    const paths = getVaultPaths(wikiDir);
+    ensureVaultStructure(paths);
+    writeFileSync(
+      join(paths.dotWiki, "config.json"),
+      JSON.stringify({ topic: "Lazy", mode: "personal" }),
+    );
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("ensureVaultStructure leaves trajectory dirs uncreated", () => {
+    const paths = getVaultPaths(wikiDir);
+    expect(existsSync(paths.rawTrajectories)).toBe(false);
+    expect(existsSync(join(paths.wiki, "cases"))).toBe(false);
+    expect(existsSync(join(paths.wiki, "skills"))).toBe(false);
+  });
+
+  it("searchWikiLayered does not throw when wiki/cases & wiki/skills are absent", () => {
+    const paths = getVaultPaths(wikiDir);
+    // includePersonal=false keeps the test off any machine-local personal vault.
+    const results = searchWikiLayered(paths, "anything", 5, 0, false);
+    expect(Array.isArray(results)).toBe(true);
+  });
+});

--- a/test/trajectory-integration.test.ts
+++ b/test/trajectory-integration.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -141,8 +141,7 @@ describe("trajectory extraction — real pi SessionManager", () => {
     expect(packet.model).toBe("claude-haiku-4-5");
     expect((packet.steps as unknown[]).length).toBe(2);
 
-    // Skeleton case page + README produced.
-    expect(existsSync(result.casePagePath)).toBe(true);
+    // Self-contained summary produced (no skeleton case page).
     const readme = readFile(join(result.packetPath, "extracted.md"));
     expect(readme).toContain("`read`");
   });

--- a/test/trajectory-integration.test.ts
+++ b/test/trajectory-integration.test.ts
@@ -1,0 +1,149 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  captureTrajectory,
+  extractTrajectoryFromSession,
+} from "../extensions/llm-wiki/lib/trajectory.js";
+import { ensureVaultStructure, getVaultPaths, readJson } from "../extensions/llm-wiki/lib/utils.js";
+import { readFile } from "./helpers.js";
+
+/**
+ * Integration test against pi's REAL SessionManager (not a hand-rolled mock).
+ *
+ * The unit tests in trajectory.test.ts feed extractTrajectoryFromSession a
+ * hand-authored object shaped like a session. That proves the extractor works
+ * on the *assumed* shape — but not that the shape matches what pi actually
+ * produces. Because the extractor is intentionally shape-defensive (casts to
+ * `unknown`), the TypeScript compiler does not enforce the contract either.
+ *
+ * This test closes that gap: it builds a real `SessionManager.inMemory()`,
+ * appends messages through pi's real `appendMessage()` API (so pi — not us —
+ * wraps them into SessionMessageEntry with the real `type:"message"` envelope),
+ * then reads them back via the real `getBranch()` and runs the extractor on the
+ * result. If pi ever changes its message/entry shape, this test breaks.
+ */
+
+describe("trajectory extraction — real pi SessionManager", () => {
+  let tmpDir: string;
+  let wikiDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dirname, "..", "tmp", `trj-int-${Date.now()}-${Math.random()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    wikiDir = join(tmpDir, "vault");
+    mkdirSync(wikiDir, { recursive: true });
+    const paths = getVaultPaths(wikiDir);
+    ensureVaultStructure(paths);
+    writeFileSync(
+      join(paths.dotWiki, "config.json"),
+      JSON.stringify({ topic: "Integration", mode: "personal" }),
+    );
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("extracts a normalized trajectory from a real SessionManager.inMemory()", () => {
+    const sm = SessionManager.inMemory(tmpDir);
+
+    // Append through pi's REAL API. pi owns the entry envelope and ordering.
+    sm.appendModelChange("anthropic", "claude-haiku-4-5");
+    sm.appendMessage({
+      role: "user",
+      content: "List the files and read notes.txt",
+      timestamp: 1,
+    });
+    sm.appendMessage({
+      role: "assistant",
+      content: [
+        { type: "text", text: "I'll list the files first." },
+        { type: "toolCall", id: "tc-1", name: "bash", arguments: { cmd: "ls -la" } },
+      ],
+      // Required AssistantMessage fields, supplied as a real model would.
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      usage: {
+        input: 10,
+        output: 5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 15,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "toolUse",
+      timestamp: 2,
+      // biome-ignore lint/suspicious/noExplicitAny: constructing a real AssistantMessage in a test
+    } as any);
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "tc-1",
+      toolName: "bash",
+      content: [{ type: "text", text: "notes.txt\npackage.json" }],
+      isError: false,
+      timestamp: 3,
+      // biome-ignore lint/suspicious/noExplicitAny: constructing a real ToolResultMessage in a test
+    } as any);
+
+    // Read back through the REAL getBranch() and run the extractor.
+    const { steps, model, prompt } = extractTrajectoryFromSession(sm);
+
+    expect(prompt).toBe("List the files and read notes.txt");
+    expect(model).toBe("claude-haiku-4-5");
+    expect(steps).toHaveLength(3);
+    expect(steps[0]).toEqual({ role: "user", text: "List the files and read notes.txt" });
+    expect(steps[1].role).toBe("assistant");
+    expect(steps[1].text).toContain("list the files");
+    expect(steps[1].tool_calls?.[0]).toMatchObject({ id: "tc-1", name: "bash" });
+    expect(steps[2]).toMatchObject({ role: "tool", tool_name: "bash", is_error: false });
+    expect(steps[2].text).toContain("notes.txt");
+  });
+
+  it("captures a full packet from a real-SessionManager extraction (end-to-end)", () => {
+    const sm = SessionManager.inMemory(tmpDir);
+    sm.appendMessage({ role: "user", content: "Fix the failing build", timestamp: 1 });
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "c1", name: "read", arguments: { path: "tsconfig.json" } }],
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "toolUse",
+      timestamp: 2,
+      // biome-ignore lint/suspicious/noExplicitAny: constructing a real AssistantMessage in a test
+    } as any);
+
+    const extracted = extractTrajectoryFromSession(sm);
+    const paths = getVaultPaths(wikiDir);
+    const result = captureTrajectory(paths, {
+      title: "Fix the failing build",
+      task: extracted.prompt,
+      steps: extracted.steps,
+      model: extracted.model,
+    });
+
+    // Packet written from a real-session extraction.
+    const packet = readJson<Record<string, unknown>>(join(result.packetPath, "packet.json"), {});
+    expect(packet.prompt).toBe("Fix the failing build");
+    expect(packet.model).toBe("claude-haiku-4-5");
+    expect((packet.steps as unknown[]).length).toBe(2);
+
+    // Skeleton case page + README produced.
+    expect(existsSync(result.casePagePath)).toBe(true);
+    const readme = readFile(join(result.packetPath, "extracted.md"));
+    expect(readme).toContain("`read`");
+  });
+});

--- a/test/trajectory.test.ts
+++ b/test/trajectory.test.ts
@@ -1,0 +1,168 @@
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  captureTrajectory,
+  extractTrajectoryFromSession,
+} from "../extensions/llm-wiki/lib/trajectory.js";
+import { ensureVaultStructure, getVaultPaths, readJson } from "../extensions/llm-wiki/lib/utils.js";
+import { readFile } from "./helpers.js";
+
+describe("agent trajectory memory", () => {
+  let wikiDir: string;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dirname, "..", "tmp", `trajectory-${Date.now()}-${Math.random()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    wikiDir = join(tmpDir, "vault");
+    mkdirSync(wikiDir, { recursive: true });
+    const paths = getVaultPaths(wikiDir);
+    ensureVaultStructure(paths);
+    writeFileSync(
+      join(paths.dotWiki, "config.json"),
+      JSON.stringify({ topic: "Test", mode: "personal" }),
+    );
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("creates raw/trajectories/ and wiki/cases/ in the vault structure", () => {
+    const paths = getVaultPaths(wikiDir);
+    expect(existsSync(paths.rawTrajectories)).toBe(true);
+    expect(existsSync(join(paths.wiki, "cases"))).toBe(true);
+    expect(existsSync(join(paths.wiki, "skills"))).toBe(true);
+  });
+
+  it("captures a trajectory packet and skeleton case page", () => {
+    const paths = getVaultPaths(wikiDir);
+    const result = captureTrajectory(paths, {
+      title: "Fix login timeout",
+      task: "The login endpoint times out under load",
+      model: "test/model-1",
+      steps: [
+        { role: "user", text: "The login endpoint times out under load" },
+        {
+          role: "assistant",
+          text: "Let me check the query.",
+          tool_calls: [{ id: "c1", name: "read", arguments: { path: "auth.ts" } }],
+        },
+        {
+          role: "tool",
+          tool_call_id: "c1",
+          tool_name: "read",
+          text: "...file...",
+          is_error: false,
+        },
+      ],
+    });
+
+    // ID format
+    expect(result.trajectoryId).toMatch(/^TRJ-\d{4}-\d{2}-\d{2}-\d{3}$/);
+
+    // packet.json is the immutable full trajectory
+    const packet = readJson<Record<string, unknown>>(join(result.packetPath, "packet.json"), {});
+    expect(packet.id).toBe(result.trajectoryId);
+    expect(packet.prompt).toBe("The login endpoint times out under load");
+    expect(packet.model).toBe("test/model-1");
+    expect(Array.isArray(packet.steps)).toBe(true);
+    expect((packet.steps as unknown[]).length).toBe(3);
+
+    // manifest.json keeps it uniform with source packets
+    const manifest = readJson<Record<string, unknown>>(
+      join(result.packetPath, "manifest.json"),
+      {},
+    );
+    expect(manifest.format).toBe("trajectory");
+    expect(manifest.tool_call_count).toBe(1);
+
+    // README/extracted summary
+    const readme = readFile(join(result.packetPath, "extracted.md"));
+    expect(readme).toContain("Fix login timeout");
+    expect(readme).toContain("`read`");
+
+    // skeleton case page
+    expect(existsSync(result.casePagePath)).toBe(true);
+    const casePage = readFile(result.casePagePath);
+    expect(casePage).toContain("type: case");
+    expect(casePage).toContain(`trajectory_id: ${result.trajectoryId}`);
+    expect(casePage).toContain(`[[trajectories/${result.trajectoryId}]]`);
+  });
+
+  it("registers the trajectory in metadata as type 'trajectory'", () => {
+    const paths = getVaultPaths(wikiDir);
+    const result = captureTrajectory(paths, {
+      title: "Refactor parser",
+      steps: [{ role: "user", text: "refactor the parser" }],
+    });
+    const registry = readJson<{ pages: Record<string, { type: string }> }>(
+      join(paths.meta, "registry.json"),
+      { pages: {} },
+    );
+    const trajId = `trajectories/${result.trajectoryId}`;
+    expect(registry.pages[trajId]).toBeTruthy();
+    expect(registry.pages[trajId].type).toBe("trajectory");
+  });
+
+  it("assigns sequential TRJ ids on the same day", () => {
+    const paths = getVaultPaths(wikiDir);
+    const r1 = captureTrajectory(paths, { steps: [{ role: "user", text: "a" }] });
+    const r2 = captureTrajectory(paths, { steps: [{ role: "user", text: "b" }] });
+    expect(r1.trajectoryId).not.toBe(r2.trajectoryId);
+    const dirs = readdirSync(paths.rawTrajectories).filter((d) => d.startsWith("TRJ-"));
+    expect(dirs.length).toBe(2);
+  });
+
+  it("extracts a normalized trajectory from a session-manager-like object", () => {
+    const sessionManager = {
+      getBranch: () => [
+        { type: "model_change", provider: "x", modelId: "y" },
+        {
+          type: "message",
+          message: { role: "user", content: "do the thing", timestamp: 1 },
+        },
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            model: "anthropic/claude",
+            content: [
+              { type: "text", text: "working on it" },
+              { type: "toolCall", id: "t1", name: "bash", arguments: { cmd: "ls" } },
+            ],
+            timestamp: 2,
+          },
+        },
+        {
+          type: "message",
+          message: {
+            role: "toolResult",
+            toolCallId: "t1",
+            toolName: "bash",
+            content: [{ type: "text", text: "file1\nfile2" }],
+            isError: false,
+            timestamp: 3,
+          },
+        },
+      ],
+    };
+
+    const { steps, model, prompt } = extractTrajectoryFromSession(sessionManager);
+    expect(prompt).toBe("do the thing");
+    expect(model).toBe("anthropic/claude");
+    expect(steps).toHaveLength(3);
+    expect(steps[0]).toEqual({ role: "user", text: "do the thing" });
+    expect(steps[1].tool_calls?.[0]).toMatchObject({ id: "t1", name: "bash" });
+    expect(steps[2]).toMatchObject({ role: "tool", tool_name: "bash", is_error: false });
+  });
+
+  it("returns empty steps for an empty / unknown session manager", () => {
+    expect(extractTrajectoryFromSession(undefined).steps).toEqual([]);
+    expect(extractTrajectoryFromSession({}).steps).toEqual([]);
+    expect(extractTrajectoryFromSession({ getBranch: () => [] }).steps).toEqual([]);
+  });
+});

--- a/test/trajectory.test.ts
+++ b/test/trajectory.test.ts
@@ -31,14 +31,19 @@ describe("agent trajectory memory", () => {
     } catch {}
   });
 
-  it("creates raw/trajectories/ and wiki/cases/ in the vault structure", () => {
+  it("does not eagerly create trajectory dirs (opt-in, lazy on first capture)", () => {
+    // Issue #80: an inactive vault carries no trace of the feature.
     const paths = getVaultPaths(wikiDir);
+    expect(existsSync(paths.rawTrajectories)).toBe(false);
+    expect(existsSync(join(paths.wiki, "cases"))).toBe(false);
+    expect(existsSync(join(paths.wiki, "skills"))).toBe(false);
+
+    // raw/trajectories is created on demand by the first capture.
+    captureTrajectory(paths, { steps: [{ role: "user", text: "hi" }] });
     expect(existsSync(paths.rawTrajectories)).toBe(true);
-    expect(existsSync(join(paths.wiki, "cases"))).toBe(true);
-    expect(existsSync(join(paths.wiki, "skills"))).toBe(true);
   });
 
-  it("captures a trajectory packet and skeleton case page", () => {
+  it("captures a trajectory packet with a self-contained summary (no skeleton)", () => {
     const paths = getVaultPaths(wikiDir);
     const result = captureTrajectory(paths, {
       title: "Fix login timeout",
@@ -80,17 +85,14 @@ describe("agent trajectory memory", () => {
     expect(manifest.format).toBe("trajectory");
     expect(manifest.tool_call_count).toBe(1);
 
-    // README/extracted summary
+    // README/extracted summary is self-contained — no [LLM:] placeholders to flesh.
     const readme = readFile(join(result.packetPath, "extracted.md"));
     expect(readme).toContain("Fix login timeout");
     expect(readme).toContain("`read`");
+    expect(readme).not.toContain("[LLM:");
 
-    // skeleton case page
-    expect(existsSync(result.casePagePath)).toBe(true);
-    const casePage = readFile(result.casePagePath);
-    expect(casePage).toContain("type: case");
-    expect(casePage).toContain(`trajectory_id: ${result.trajectoryId}`);
-    expect(casePage).toContain(`[[trajectories/${result.trajectoryId}]]`);
+    // No skeleton case page is emitted; capture does not create wiki/cases/.
+    expect(existsSync(join(paths.wiki, "cases"))).toBe(false);
   });
 
   it("registers the trajectory in metadata as type 'trajectory'", () => {


### PR DESCRIPTION
Closes #62.

## Agent working-memory: capture → distill → recall

The wiki already captures what the agent **reads** (sources). This adds the other
half: capturing what the agent **does** — its tool-call trajectory on a real task.
A completed task is just another kind of source, so it flows through the same
4-layer pipeline:

```
raw/trajectories/TRJ-*   (immutable task packet)
  → wiki/cases/*         (one specific past task)
  → wiki/skills/*        (reusable pattern distilled from many trajectories)
  → meta/*               (auto-generated registry/backlinks)
```

### What's added

**Three tools** (mirroring the source-capture flow):

| Tool | Purpose |
|------|---------|
| `wiki_capture_trajectory` | Auto-extracts the live session's tool-call sequence into an immutable packet + skeleton `case` page. Usually you only pass a `title`. |
| `wiki_distill_skills` | Returns batches of undistilled trajectories to generalize into reusable `skill` pages. |
| `wiki_recall_skill` | Recall filtered to `skill`/`case` pages — "have I done something like this before?" Call at task start. |

**Supporting changes:**
- New page types `skill` + `case` (templates in `tools.ts`), new folders
  `wiki/cases/`, `wiki/skills/`, `raw/trajectories/`.
- `nextTrajectoryId()` + trajectory cataloguing in the registry (`metadata.ts`).
- Two slash-command prompts: `/wiki-record`, `/wiki-skills` (auto-registered).
- Docs updated to 16 tools (`SKILL.md`, `docs/api.md`, `docs/architecture.md`,
  `docs/commands.md`, `README.md`).

### Verification

- `tsc --noEmit`, `biome check`, and the **full suite (306 tests, 22 files)** pass —
  including a real-`SessionManager` integration test (`test/trajectory-integration.test.ts`)
  that exercises pi's actual `appendMessage`/`getBranch` API rather than a hand-mock.
- **Live-verified** end-to-end against the real `pi` CLI binary: bootstrap → task →
  `wiki_capture_trajectory` produces a correct packet (prompt, model, normalized
  steps with real tool-call IDs), and `wiki_distill_skills` → `wiki_recall_skill`
  completes the loop with backlinks recorded.

### Notes for reviewers

- **Capture is opt-in** — the agent calls `wiki_capture_trajectory` explicitly
  (prompted via guidelines + `/wiki-record`); nothing is recorded automatically.
- **Recall is lexical** (BM25-style, same engine as `wiki_recall`), so it composes
  with the existing layered recall and the new optional semantic context.
- Skeleton `case` pages are intentionally minimal — the `## Approach`/`## Outcome`
  sections are filled in during distillation, keeping raw packets immutable.


---

## Update — addressing review (#80): opt-in / default-off + trimmed

Per @arjun-zosma's review, the feature now lands **opt-in, off by default** (commit `e254b5d`):

- **Flag + conditional registration** — `trajectoriesEnabled(config)` (default `false`); the 3 trajectory tools are registered **only** when `llm-wiki.trajectories` is enabled, so they cost nothing in the system prompt when off. Gated at factory time via `loadTaskConfig(process.cwd())` (not `runtime.config`, which is empty until a later hook).
- **`/wiki-trajectories on|off`** — toggles the flag and `ctx.reload()`s so the tool set applies immediately (pi has no runtime register/unregister-tool API). Status line reflects state (13 ↔ 16 tools).
- **Self-contained capture** — dropped the `[LLM:]` case-page skeleton; `extracted.md` is already a complete summary and distill never read the skeleton. `outcome` is now recorded in the manifest.
- **`wiki_distill_skills`** stays behind the same flag (free via conditional registration).
- **Lazy directories** — `raw/trajectories`, `wiki/skills`, `wiki/cases` are created on first use, so an inactive vault carries no trace of the feature.
- **Docs** — opt-in notes across SKILL.md / README / api / commands / architecture, plus a `capture_trajectory` vs `retro` vs `observe` decision table and a note on why a structured trajectory packet is distinct from pi's prose observational-memory.

**Verification:** `tsc` + `biome` clean; **314 tests pass** (incl. new flag/lazy-dir tests); live-checked against the real `pi` binary — **off → tools absent**, **on → tools registered and capture works** (confirming the factory-time gate reads the flag).
