### PR TITLE
fix(recall): reliable skill/case recall adherence — resolvable paths + fence-safe inline (gated, configurable, eval-backed)

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -270,7 +270,10 @@ Then call wiki_bootstrap with the inferred topic and mode to finalize the setup.
         // large vault never floods the system prompt with inline previews.
         // includePersonal=false here mirrors the auto-injection search scope.
         const linksOnly = shouldUseLinksFirst(vaultPageCount(paths, false), runtime.config);
-        const recallContext = formatRecallContext(results, { linksOnly });
+        const recallContext = formatRecallContext(results, {
+          linksOnly,
+          skillInlineMax: runtime.config?.recallSkillInlineMax,
+        });
         if (recallContext) {
           injectedContext += `\n\n${recallContext}`;
         }

--- a/extensions/llm-wiki/lib/recall.ts
+++ b/extensions/llm-wiki/lib/recall.ts
@@ -33,7 +33,7 @@ export interface RecallResult {
   type: string;
   /** First N chars of page content for context */
   preview: string;
-  /** Relative path from wiki root */
+  /** Absolute filesystem path to the page (resolvable by the `read` tool). */
   path: string;
   /** Vault source label for dual-vault results */
   vaultLabel?: string;
@@ -743,8 +743,12 @@ function linkSnippet(preview: string): string {
   return oneLine.length > LINKS_SNIPPET_MAX ? `${oneLine.slice(0, LINKS_SNIPPET_MAX)}…` : oneLine;
 }
 
-/** Max chars of a skill/case body inlined directly into the recall block. */
-const SKILL_INLINE_MAX = 1600;
+/**
+ * Default cap on chars of a skill/case body inlined directly into a recall
+ * block. Overridable per-vault via `recallSkillInlineMax` (0 disables inlining).
+ * Mirrors `DEFAULT_RECALL_LINKS_THRESHOLD` — the sibling context-window lever.
+ */
+export const DEFAULT_RECALL_SKILL_INLINE_MAX = 1600;
 
 /**
  * Skills/working-memory carve-out from links-first: short, high-value
@@ -762,34 +766,75 @@ function isSkillOrCase(r: RecallResult): boolean {
   );
 }
 
-function inlineSkillBody(r: RecallResult): string | null {
+/**
+ * Inlined body for a skill/case page, or null. `max <= 0` disables inlining and
+ * short-circuits BEFORE any filesystem access, so a vault that opts out keeps
+ * recall page-body-I/O-free (issue #68's cheap-recall invariant). Otherwise the
+ * read is bounded: it fires only for skill/case results (which exist only when
+ * the trajectories feature is on) and only the top-N ranked hits.
+ */
+function inlineSkillBody(r: RecallResult, max = DEFAULT_RECALL_SKILL_INLINE_MAX): string | null {
+  if (max <= 0) return null;
   if (!isSkillOrCase(r)) return null;
   if (!r.path || !existsSync(r.path)) return null;
-  let body = readFileSync(r.path, "utf-8");
+  // Normalize CRLF first so the LF-anchored frontmatter strip below works on
+  // Windows-authored / git-autocrlf'd vaults (otherwise the raw YAML leaks in).
+  let body = readFileSync(r.path, "utf-8").replace(/\r\n/g, "\n");
   body = body.replace(/^---\n[\s\S]*?\n---\n/, "").trim(); // strip YAML frontmatter
   if (!body) return null;
-  if (body.length > SKILL_INLINE_MAX) {
-    body = `${body.slice(0, SKILL_INLINE_MAX)}\n…(truncated — \`read\` the path above for the full page)`;
+  if (body.length > max) {
+    body = `${body.slice(0, max)}\n…(truncated — \`read\` the path above for the full page)`;
   }
   return body;
+}
+
+/**
+ * A backtick fence guaranteed longer than any backtick run inside `body`.
+ * Skill/case pages routinely embed their own fenced code blocks; CommonMark
+ * closes a fenced block only on a fence of length >= the opener, so opening
+ * with (longest inner run + 1, min 3) keeps an inlined body from terminating
+ * the wrapper early — and stays safe even when truncation cuts mid-fence.
+ */
+function codeFenceFor(body: string): string {
+  let longest = 0;
+  for (const run of body.match(/`+/g) ?? []) longest = Math.max(longest, run.length);
+  return "`".repeat(Math.max(3, longest + 1));
+}
+
+/** Indented, fence-safe lines wrapping an inlined skill/case body. */
+function inlineBlockLines(body: string, indent: string): string[] {
+  const fence = codeFenceFor(body);
+  return [
+    "",
+    `${indent}${fence}`,
+    ...body.split("\n").map((line) => `${indent}${line}`),
+    `${indent}${fence}`,
+  ];
 }
 
 /**
  * Format recall results as a compact system-prompt section.
  *
  * Two render modes (issue #68):
- * - Default / `linksOnly: false` — preview-inline (unchanged for small vaults).
+ * - Default / `linksOnly: false` — preview-inline. For ordinary pages this is
+ *   byte-for-byte the pre-fix small-vault rendering (no regression); the
+ *   resolvable read-path + new footer copy are confined to links-first, where
+ *   there is no inline content and the agent MUST resolve a link.
  * - `linksOnly: true` — stage-1 "links-first": a ranked list of links carrying
- *   id, title, type, score, and a single short snippet. The agent expands the
- *   links it wants on demand via `read` (stage 2). Used above the vault-size
- *   threshold to keep large vaults from flooding context.
+ *   id, title, type, score, and a single short snippet, each with a resolvable
+ *   `read <path>`. The agent expands the links it wants on demand (stage 2).
+ *   Used above the vault-size threshold to keep large vaults from flooding context.
+ *
+ * `skillInlineMax` (default `DEFAULT_RECALL_SKILL_INLINE_MAX`) caps how much of a
+ * skill/case body is inlined; 0 disables inlining (pure links-first for those too).
  */
 export function formatRecallContext(
   results: RecallResult[],
-  opts: { linksOnly?: boolean } = {},
+  opts: { linksOnly?: boolean; skillInlineMax?: number } = {},
 ): string {
   if (results.length === 0) return "";
 
+  const skillInlineMax = opts.skillInlineMax ?? DEFAULT_RECALL_SKILL_INLINE_MAX;
   const hasLayered = results.some((r) => r.vaultLabel);
   const label = hasLayered ? " (personal + project)" : "";
   // Salience nudge: when a distilled skill/case matches, tell the agent to
@@ -819,8 +864,8 @@ export function formatRecallContext(
       if (r.path) lines.push(`   ↳ \`read ${r.path}\``);
       // Skills/case carve-out: inline the body so the agent doesn't have to
       // (and often won't) expand the link before acting.
-      const inl = inlineSkillBody(r);
-      if (inl) lines.push("", "   \`\`\`", ...inl.split("\n").map((x) => `   ${x}`), "   \`\`\`");
+      const inl = inlineSkillBody(r, skillInlineMax);
+      if (inl) lines.push(...inlineBlockLines(inl, "   "));
     });
 
     lines.push(
@@ -844,13 +889,15 @@ export function formatRecallContext(
   for (const r of results) {
     const vaultTag = r.vaultLabel ? ` ${r.vaultLabel}` : "";
     lines.push(`- **[[${r.id}]]** — *${r.type}* — ${r.title}${vaultTag}`);
-    // Read-resolvable path so the agent expands in one first-try `read`
-    // instead of guessing the file location from the wikilink id.
-    if (r.path) lines.push(`  ↳ \`read ${r.path}\``);
-    // Skills/case carve-out: inline the body (adherence > context-economy).
-    const inl = inlineSkillBody(r);
+    // Skills/case carve-out: inline the body (adherence > context-economy). Only
+    // here does the default path deviate from the pre-fix small-vault render —
+    // and only when a skill/case matched (i.e. the trajectories feature is on),
+    // so ordinary pages stay byte-for-byte unchanged (#68 no-regression promise).
+    const inl = inlineSkillBody(r, skillInlineMax);
     if (inl) {
-      lines.push("", "  ```", ...inl.split("\n").map((x) => `  ${x}`), "  ```");
+      // Resolvable path so a truncated inline body is one `read` away.
+      if (r.path) lines.push(`  ↳ \`read ${r.path}\``);
+      lines.push(...inlineBlockLines(inl, "  "));
     } else if (r.preview) {
       // Truncate preview to one line
       const preview = r.preview.length > 120 ? `${r.preview.slice(0, 120)}…` : r.preview;
@@ -860,8 +907,7 @@ export function formatRecallContext(
   }
 
   lines.push(
-    "Use `read` on the exact path shown under each link to view its full page." +
-      " Add new findings via wiki_ensure_page or wiki_retro.",
+    "Use `read` to view full pages. Add new findings via wiki_ensure_page or wiki_retro.",
     "",
   );
 

--- a/extensions/llm-wiki/lib/recall.ts
+++ b/extensions/llm-wiki/lib/recall.ts
@@ -743,6 +743,37 @@ function linkSnippet(preview: string): string {
   return oneLine.length > LINKS_SNIPPET_MAX ? `${oneLine.slice(0, LINKS_SNIPPET_MAX)}…` : oneLine;
 }
 
+/** Max chars of a skill/case body inlined directly into the recall block. */
+const SKILL_INLINE_MAX = 1600;
+
+/**
+ * Skills/working-memory carve-out from links-first: short, high-value
+ * procedural pages (`skill`/`case`) are meant to be APPLIED immediately, so we
+ * inline their body directly rather than make the agent expand a link it often
+ * skips (adherence > context-economy for these page types). Returns null for
+ * non-skill pages or when the body can't be read.
+ */
+function isSkillOrCase(r: RecallResult): boolean {
+  return (
+    r.type === "skill" ||
+    r.type === "case" ||
+    r.id.startsWith("skills/") ||
+    r.id.startsWith("cases/")
+  );
+}
+
+function inlineSkillBody(r: RecallResult): string | null {
+  if (!isSkillOrCase(r)) return null;
+  if (!r.path || !existsSync(r.path)) return null;
+  let body = readFileSync(r.path, "utf-8");
+  body = body.replace(/^---\n[\s\S]*?\n---\n/, "").trim(); // strip YAML frontmatter
+  if (!body) return null;
+  if (body.length > SKILL_INLINE_MAX) {
+    body = `${body.slice(0, SKILL_INLINE_MAX)}\n…(truncated — \`read\` the path above for the full page)`;
+  }
+  return body;
+}
+
 /**
  * Format recall results as a compact system-prompt section.
  *
@@ -761,6 +792,11 @@ export function formatRecallContext(
 
   const hasLayered = results.some((r) => r.vaultLabel);
   const label = hasLayered ? " (personal + project)" : "";
+  // Salience nudge: when a distilled skill/case matches, tell the agent to
+  // apply it BEFORE experimenting (the dominant cost is recall non-adherence).
+  const hasSkill = results.some(isSkillOrCase);
+  const skillNudge =
+    "⚠\ufe0f A distilled skill/case below matches this task — read and APPLY it BEFORE experimenting on your own.";
 
   if (opts.linksOnly) {
     const lines: string[] = [
@@ -770,6 +806,7 @@ export function formatRecallContext(
       "",
     ];
 
+    if (hasSkill) lines.splice(1, 0, "", skillNudge);
     results.forEach((r, i) => {
       const vaultTag = r.vaultLabel ? ` ${r.vaultLabel}` : "";
       const snippet = linkSnippet(r.preview);
@@ -777,11 +814,18 @@ export function formatRecallContext(
       lines.push(
         `${i + 1}. **[[${r.id}]]** — *${r.type}* — score ${r.score.toFixed(1)}${vaultTag} — ${r.title}${tail}`,
       );
+      // Surface a read-resolvable path so expansion is a single, first-try
+      // `read` (issue: wikilink ids aren't resolvable by the file read tool).
+      if (r.path) lines.push(`   ↳ \`read ${r.path}\``);
+      // Skills/case carve-out: inline the body so the agent doesn't have to
+      // (and often won't) expand the link before acting.
+      const inl = inlineSkillBody(r);
+      if (inl) lines.push("", "   \`\`\`", ...inl.split("\n").map((x) => `   ${x}`), "   \`\`\`");
     });
 
     lines.push(
       "",
-      "Call `read` on the links you need to pull their full content." +
+      "Call `read` on the exact path shown under each link to pull its full content." +
         " Add new findings via wiki_ensure_page or wiki_retro.",
       "",
     );
@@ -796,10 +840,18 @@ export function formatRecallContext(
     "",
   ];
 
+  if (hasSkill) lines.splice(1, 0, "", skillNudge);
   for (const r of results) {
     const vaultTag = r.vaultLabel ? ` ${r.vaultLabel}` : "";
     lines.push(`- **[[${r.id}]]** — *${r.type}* — ${r.title}${vaultTag}`);
-    if (r.preview) {
+    // Read-resolvable path so the agent expands in one first-try `read`
+    // instead of guessing the file location from the wikilink id.
+    if (r.path) lines.push(`  ↳ \`read ${r.path}\``);
+    // Skills/case carve-out: inline the body (adherence > context-economy).
+    const inl = inlineSkillBody(r);
+    if (inl) {
+      lines.push("", "  ```", ...inl.split("\n").map((x) => `  ${x}`), "  ```");
+    } else if (r.preview) {
       // Truncate preview to one line
       const preview = r.preview.length > 120 ? `${r.preview.slice(0, 120)}…` : r.preview;
       lines.push(`  ${preview}`);
@@ -808,7 +860,8 @@ export function formatRecallContext(
   }
 
   lines.push(
-    "Use `read` to view full pages. Add new findings via wiki_ensure_page or wiki_retro.",
+    "Use `read` on the exact path shown under each link to view its full page." +
+      " Add new findings via wiki_ensure_page or wiki_retro.",
     "",
   );
 

--- a/extensions/llm-wiki/lib/task-config.ts
+++ b/extensions/llm-wiki/lib/task-config.ts
@@ -71,6 +71,19 @@ export interface TaskConfig {
   recallLinksThreshold?: number;
 
   /**
+   * Max characters of a distilled `skill`/`case` body inlined directly into a
+   * recall block before truncation (recall-adherence fix). Skills/cases are
+   * meant to be APPLIED immediately, so links-first recall inlines their short
+   * body instead of a bare link the agent often skips. Set to 0 to DISABLE
+   * inlining entirely — skills/cases then fall back to the normal link/preview
+   * path (pure links-first), and no page body is read at format time. Only
+   * relevant when the trajectories feature is on (skill/case pages exist only
+   * then). Default 1600. Clamped to a non-negative integer. Mirrors the
+   * `recallLinksThreshold` knob — the other context-window lever for recall.
+   */
+  recallSkillInlineMax?: number;
+
+  /**
    * Surface wiki activity in the UI (issue #77). When enabled (the default),
    * the status line reflects recall hits and the periodic observe/retro
    * reminder is shown to the user (`display: true`) instead of being injected
@@ -148,6 +161,11 @@ function readNamespacedConfig(path: string): Partial<TaskConfig> {
     const threshold = section.recallLinksThreshold;
     if (typeof threshold === "number" && Number.isFinite(threshold)) {
       out.recallLinksThreshold = Math.max(0, Math.floor(threshold));
+    }
+
+    const inlineMax = section.recallSkillInlineMax;
+    if (typeof inlineMax === "number" && Number.isFinite(inlineMax)) {
+      out.recallSkillInlineMax = Math.max(0, Math.floor(inlineMax));
     }
 
     if (typeof section.notices === "boolean") {

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -136,6 +136,8 @@ Recall scales with vault size via **two-stage retrieval** (memex-style):
 
 The gate is the `recallLinksThreshold` setting (namespaced `llm-wiki`, default **50** pages). Page count is read from `meta/registry.json` (O(1), no page-body I/O). Set it to `0` to force links-first always, or a large number to always keep previews inline.
 
+**Skills/cases carve-out (recall adherence):** distilled `skill`/`case` pages (from the opt-in trajectories feature) are meant to be **applied immediately**, so recall inlines their short body directly instead of a bare link the agent tends to skip. The `recallSkillInlineMax` setting (namespaced `llm-wiki`, default **1600** chars, clamped to a non-negative integer) caps how much body is inlined; set it to `0` to disable inlining entirely (skills/cases fall back to pure links-first, and no page body is read at format time). Only relevant when `trajectories` is enabled.
+
 ### At End — Save Insights with wiki_retro
 
 After completing any meaningful task, call `wiki_retro` to save key insights:

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -437,14 +437,30 @@ describe("wiki recall", () => {
 
     it("small vault (default opts) renders previews inline, no scores (regression)", () => {
       const out = formatRecallContext(sampleResults());
-      // Byte-for-byte identical to the explicit linksOnly=false path.
-      expect(out).toBe(formatRecallContext(sampleResults(), { linksOnly: false }));
-      // Preview content is present; no score / two-stage directive leaks in.
-      expect(out).toContain("Retrieval augmented generation is a technique");
-      expect(out).toContain("## Relevant Wiki Knowledge\n");
+      // Prior-release guard (NOT a self-comparison): for ordinary non-skill pages
+      // the default path must render byte-for-byte as it did pre-fix — no resolvable
+      // `↳ read <path>` line, the original footer copy. This is the #68 promise that
+      // small vaults below the threshold see zero recall-shape regression.
+      const expected = [
+        "## Relevant Wiki Knowledge",
+        "",
+        "_2 page(s) matched your query (personal + project)._",
+        "",
+        "- **[[concepts/rag]]** — *concept* — RAG",
+        "  Retrieval augmented generation is a technique for grounding LLMs in external knowledge sources.",
+        "",
+        "- **[[entities/openai]]** — *entity* — OpenAI 📓 personal",
+        "  OpenAI is an AI research organization.",
+        "",
+        "Use `read` to view full pages. Add new findings via wiki_ensure_page or wiki_retro.",
+        "",
+      ].join("\n");
+      expect(out).toBe(expected);
+      // Belt-and-suspenders: the links-first-only affordances must not leak here.
+      expect(out).not.toContain("↳");
+      expect(out).not.toContain("on the exact path shown under each link");
       expect(out).not.toContain("links-first");
       expect(out).not.toContain("score ");
-      expect(out).toContain("Use `read` to view full pages.");
     });
 
     it("large vault (linksOnly) renders ranked links: id/title/type/score/snippet, no full preview", () => {
@@ -515,6 +531,32 @@ describe("wiki recall", () => {
       expect(loadTaskConfig(projectDir).recallLinksThreshold).toBeUndefined();
     });
 
+    it("config parsing clamps recallSkillInlineMax to a non-negative integer", async () => {
+      const { loadTaskConfig } = await import("../extensions/llm-wiki/lib/task-config.js");
+      const projectDir = join(tmpDir, "cfg-inline-max");
+      mkdirSync(join(projectDir, ".pi"), { recursive: true });
+      writeFileSync(
+        join(projectDir, ".pi", "settings.json"),
+        JSON.stringify({ "llm-wiki": { recallSkillInlineMax: 800.9 } }),
+        "utf-8",
+      );
+      expect(loadTaskConfig(projectDir).recallSkillInlineMax).toBe(800);
+
+      writeFileSync(
+        join(projectDir, ".pi", "settings.json"),
+        JSON.stringify({ "llm-wiki": { recallSkillInlineMax: -10 } }),
+        "utf-8",
+      );
+      expect(loadTaskConfig(projectDir).recallSkillInlineMax).toBe(0);
+
+      writeFileSync(
+        join(projectDir, ".pi", "settings.json"),
+        JSON.stringify({ "llm-wiki": { recallSkillInlineMax: "nope" } }),
+        "utf-8",
+      );
+      expect(loadTaskConfig(projectDir).recallSkillInlineMax).toBeUndefined();
+    });
+
     it("end-to-end gating: same results below vs above a custom threshold", () => {
       createRegistryPage("alpha", "concept", "Alpha", "Body about caching alpha.");
       createRegistryPage("beta", "concept", "Beta", "Body about caching beta.");
@@ -536,6 +578,233 @@ describe("wiki recall", () => {
       expect(inline).not.toContain("links-first");
       expect(links).toContain("links-first");
       expect(links).toContain("score ");
+    });
+  });
+
+  // ── Recall-adherence rendering: resolvable read-path, salience nudge, and
+  //    the skills/cases inline carve-out (commit ee16fad) ──
+  describe("recall-adherence rendering (read-path + nudge + skills inline)", () => {
+    const NUDGE = "read and APPLY it BEFORE experimenting";
+
+    // Write a real skill fixture on disk so inlineSkillBody can read it; the
+    // returned absolute path is what formatRecallContext renders + inlines.
+    const writeSkillFixture = (name: string, content: string): string => {
+      const dir = join(wikiDir, ".llm-wiki", "wiki", "skills");
+      mkdirSync(dir, { recursive: true });
+      const path = join(dir, `${name}.md`);
+      writeFileSync(path, content, "utf-8");
+      return path;
+    };
+
+    it("surfaces a resolvable `read <path>` under each link in links-first, but NOT in the default small-vault path", () => {
+      const results = [
+        {
+          id: "concepts/rag",
+          title: "RAG",
+          type: "concept",
+          preview: "p",
+          path: "/abs/wiki/concepts/rag.md",
+          score: 5,
+        },
+      ];
+      // Links-first: there is no inline content, so every link gets a resolvable path.
+      expect(formatRecallContext(results, { linksOnly: true })).toContain(
+        "↳ `read /abs/wiki/concepts/rag.md`",
+      );
+      // Default (small-vault) mode: ordinary pages keep the pre-fix render — no read-path line.
+      expect(formatRecallContext(results)).not.toContain("↳");
+    });
+
+    it("omits the read-path line in links-first when a result has no path", () => {
+      const results = [
+        { id: "concepts/x", title: "X", type: "concept", preview: "p", path: "", score: 5 },
+      ];
+      expect(formatRecallContext(results, { linksOnly: true })).not.toContain("↳ `read");
+    });
+
+    it("injects the salience nudge in both modes only when a skill/case matches", () => {
+      const plain = [
+        {
+          id: "concepts/rag",
+          title: "RAG",
+          type: "concept",
+          preview: "p",
+          path: "/x.md",
+          score: 5,
+        },
+      ];
+      expect(formatRecallContext(plain)).not.toContain(NUDGE);
+      expect(formatRecallContext(plain, { linksOnly: true })).not.toContain(NUDGE);
+
+      // Caught by the type check (skill/case) AND by the id-prefix fallback for
+      // pages whose frontmatter type was lost (recall as a generic "page").
+      const skillish = [
+        {
+          id: "skills/debug",
+          title: "Debug",
+          type: "skill",
+          preview: "p",
+          path: "/x.md",
+          score: 9,
+        },
+        {
+          id: "cases/outage",
+          title: "Outage",
+          type: "case",
+          preview: "p",
+          path: "/x.md",
+          score: 9,
+        },
+        { id: "skills/lost", title: "Lost", type: "page", preview: "p", path: "/x.md", score: 9 },
+        { id: "cases/lost", title: "Lost", type: "page", preview: "p", path: "/x.md", score: 9 },
+      ];
+      for (const r of skillish) {
+        expect(formatRecallContext([r])).toContain(NUDGE);
+        expect(formatRecallContext([r], { linksOnly: true })).toContain(NUDGE);
+      }
+    });
+
+    it("inlines a skill body (frontmatter stripped) and suppresses the one-line preview", () => {
+      const path = writeSkillFixture(
+        "kebab-cli",
+        [
+          "---",
+          "type: skill",
+          'title: "Kebab CLI"',
+          "---",
+          "",
+          "# Kebab CLI",
+          "",
+          "Always pass --json.",
+        ].join("\n"),
+      );
+      const results = [
+        {
+          id: "skills/kebab-cli",
+          title: "Kebab CLI",
+          type: "skill",
+          preview: "ONE-LINE-PREVIEW",
+          path,
+          score: 9,
+        },
+      ];
+      const out = formatRecallContext(results);
+      expect(out).toContain("Always pass --json."); // body inlined
+      expect(out).not.toContain("type: skill"); // frontmatter stripped
+      expect(out).not.toContain("ONE-LINE-PREVIEW"); // preview suppressed when inlined
+      // Even in default mode an inlined skill carries its resolvable path (the
+      // body may be truncated) — this is the ONLY default-path read-path line.
+      expect(out).toContain(`↳ \`read ${path}\``);
+    });
+
+    it("skillInlineMax 0 disables inlining (skill falls back to preview/link, zero page-body I/O)", () => {
+      const path = writeSkillFixture(
+        "disabled",
+        ["---", "type: skill", "---", "", "Body that should NOT be inlined."].join("\n"),
+      );
+      const results = [
+        {
+          id: "skills/disabled",
+          title: "Disabled",
+          type: "skill",
+          preview: "PREVIEW-FALLBACK",
+          path,
+          score: 9,
+        },
+      ];
+      // Default mode, inlining off → no body, falls back to preview, no read-path line.
+      const def = formatRecallContext(results, { skillInlineMax: 0 });
+      expect(def).not.toContain("Body that should NOT be inlined.");
+      expect(def).toContain("PREVIEW-FALLBACK");
+      expect(def).not.toContain("↳");
+      // Links-first, inlining off → ranked link only, no inlined body.
+      const links = formatRecallContext(results, { linksOnly: true, skillInlineMax: 0 });
+      expect(links).not.toContain("Body that should NOT be inlined.");
+      expect(links).toContain("[[skills/disabled]]");
+    });
+
+    it("falls back to the preview when the skill file can't be read", () => {
+      const results = [
+        {
+          id: "skills/missing",
+          title: "Missing",
+          type: "skill",
+          preview: "FALLBACK-PREVIEW",
+          path: "/does/not/exist.md",
+          score: 9,
+        },
+      ];
+      const out = formatRecallContext(results);
+      expect(out).toContain("FALLBACK-PREVIEW"); // preview, not an inlined body
+      expect(out).toContain(NUDGE); // still a skill → still nudged
+    });
+
+    it("truncates an over-long skill body with a marker", () => {
+      const huge = "A".repeat(5000);
+      const path = writeSkillFixture("huge", ["---", "type: skill", "---", "", huge].join("\n"));
+      const results = [
+        { id: "skills/huge", title: "Huge", type: "skill", preview: "p", path, score: 9 },
+      ];
+      const out = formatRecallContext(results);
+      expect(out).toContain("…(truncated — `read` the path above for the full page)");
+      expect(out).not.toContain(huge); // full body not dumped
+    });
+
+    it("wraps a fenced skill body in a longer outer fence so it can't terminate early", () => {
+      // Skill body contains its OWN ```bash fence — the wrapper must out-length
+      // it (regression for the code-fence corruption bug).
+      const path = writeSkillFixture(
+        "fenced",
+        [
+          "---",
+          "type: skill",
+          "---",
+          "",
+          "Run this:",
+          "",
+          "```bash",
+          "kebab build --json",
+          "```",
+          "",
+          "Done.",
+        ].join("\n"),
+      );
+      const results = [
+        { id: "skills/fenced", title: "Fenced", type: "skill", preview: "p", path, score: 9 },
+      ];
+      const out = formatRecallContext(results, { linksOnly: true });
+      // Whole body — including the inner fence's contents and trailing prose — is present.
+      expect(out).toContain("kebab build --json");
+      expect(out).toContain("Done.");
+      // Two wrapper fences, each strictly longer than the body's own 3-backtick
+      // fence (which survives as content), prove no early termination.
+      const fenceLens = out
+        .split("\n")
+        .filter((l) => /^\s*`{3,}\s*$/.test(l))
+        .map((l) => l.trim().length);
+      expect(fenceLens).toContain(3); // body's own ``` preserved as content
+      expect(fenceLens.filter((n) => n >= 4).length).toBe(2); // two longer wrappers
+    });
+
+    it("strips CRLF frontmatter so no raw YAML leaks into the prompt", () => {
+      const crlf = [
+        "---",
+        "type: skill",
+        'title: "CRLF"',
+        "---",
+        "",
+        "# CRLF Skill",
+        "",
+        "Body after CRLF frontmatter.",
+      ].join("\r\n");
+      const path = writeSkillFixture("crlf", crlf);
+      const results = [
+        { id: "skills/crlf", title: "CRLF", type: "skill", preview: "p", path, score: 9 },
+      ];
+      const out = formatRecallContext(results);
+      expect(out).toContain("Body after CRLF frontmatter.");
+      expect(out).not.toContain("type: skill"); // frontmatter gone despite CRLF
+      expect(out).not.toContain("---"); // no raw YAML delimiters leaked
     });
   });
 


### PR DESCRIPTION
## Summary

Auto-recall surfaced distilled `skill`/`case` pages (from the trajectory working-memory feature, #79) as **bare `[[wikilink]]`s** under links-first recall (#68). In practice the agent could not act on them: a wikilink id is not resolvable by the `read` tool, so the agent either ignored the one-hop link or hallucinated an answer from the 1-line snippet instead of reading and applying the matched knowledge.

This PR makes recall of `skill`/`case` pages actually *adhere*, while staying inside the two-stage recall design (cheap recall, context economy, no small-vault regression).

Two commits:
- `ee16fad` — the initial carve-out: resolvable `read <path>` under each link, a salience nudge, and inlining of short skill/case bodies.
- `18e62d5` — hardening + scoping so the change respects the links-first design and is verifiable (details below).

## What changed

**1. Resolvable `read <path>` under each link (links-first).** Wikilink ids aren't resolvable by the file-read tool; surfacing the concrete absolute path makes expansion a single first-try `read`. This is the load-bearing correctness fix.

**2. Salience nudge** when a `skill`/`case` matches — "read and APPLY before experimenting" — addressing the observed non-adherence.

**3. Skills/cases inline carve-out.** Short `skill`/`case` bodies are inlined directly (they're meant to be applied immediately), so the agent doesn't have to expand a link it tends to skip. Bounded and configurable:
- Length-adaptive code fence so a skill whose body contains its own fenced code block can't terminate the wrapper early (also makes mid-cap truncation safe).
- CRLF normalized before the frontmatter strip so Windows/autocrlf vaults don't leak raw YAML.
- New **`recallSkillInlineMax`** task-config knob (default `1600`, clamped to a non-negative integer), mirroring `recallLinksThreshold`. **`0` disables inlining** → pure links-first for skills too, and short-circuits before any file read so recall stays page-body-I/O-free when opted out.

## Design alignment (two-stage recall, #68)

- **No small-vault regression.** The resolvable-path line and the reworded footer are confined to **links-first** mode. The default (small-vault) path renders ordinary pages **byte-for-byte as before**; only a matched `skill`/`case` deviates — and those pages exist only when the opt-in `trajectories` feature is enabled. The prior byte-for-byte test was a tautology (it compared the new output to itself); it's replaced with a frozen golden-string assertion.
- **Cheap recall preserved.** The page-count gate still reads only `registry.json`. Inlining reads a bounded set (matched `skill`/`case` results only, top-N, capped), and `recallSkillInlineMax: 0` removes that read entirely.
- **Configurable context-window lever**, consistent with `recallLinksThreshold` / `semanticWeight`.

## Does it actually help? (evaluation)

A controlled, reproducible eval: a **fictional** CLI (`quirktool`) with an un-guessable export rule is distilled into a skill page, then a real `pi` agent runs under five recall-presentation conditions, N times each, scored on whether the final command applies the rule (`QUIRK_SEED=42` + `--codec=ztab`, avoiding the decoy `--format`). Because the rule is fictional, a model that doesn't actually use the skill **cannot** answer correctly — so the score isolates adherence. `fixPathLink`/`fixInline` are rendered by the **shipped** `formatRecallContext`.

| condition | what the agent sees | Sonnet 4.5 (N=10) | Haiku 4.5 (N=8) | avg tool calls |
|---|---|:--:|:--:|:--:|
| `cold` | no recall | 0% | 0% | ~2.2 |
| `prefixLink` | pre-fix bare `[[link]]`, no path | **0%** | **0%** | ~2.0 (flails) |
| `fixPathLink` | resolvable path, no inline (`recallSkillInlineMax: 0`) | **100%** | **100%** | 1.0 |
| `fixInline` | this PR (nudge + path + inline) | **100%** | **100%** | **0.0** |
| `warm` | knowledge pasted in prompt (upper bound) | 100% | 100% | 0.0 |

Findings:
- The pre-fix bare link is **no better than no recall at all** — the agent can't resolve it and confidently emits wrong flags from the snippet (e.g. `quirktool export --seed 0 --format zta …`, using the exact `--format` decoy the skill warns against).
- The **resolvable `read <path>`** is the load-bearing change: 0% → 100%.
- **Inlining** reaches the same 100% with **zero tool calls**, matching the warm upper bound — the efficiency win.

Caveat: one fictional fixture/task, each run bounded to ≤2 tool calls for a fair, terminating comparison. The 0%↔100% gap is stark precisely because the knowledge is fully un-guessable — it isolates the *mechanism*, it is not a forecast of real-world task lift.

<details><summary>Reproduce (standalone harness — not added to the repo, makes paid model calls)</summary>

Requires `pi` on PATH + an authenticated Anthropic provider. `EVAL_MODEL` / `EVAL_N` / `EVAL_CONC` env knobs.

````js
#!/usr/bin/env node
// Recall-adherence eval. node recall-adherence.cjs   (EVAL_MODEL, EVAL_N, EVAL_CONC)
const { mkdirSync, writeFileSync, rmSync, mkdtempSync } = require("node:fs");
const { tmpdir } = require("node:os");
const { join } = require("node:path");
const { spawn } = require("node:child_process");

const ROOT = join(__dirname, "..");
const jiti = require("jiti")(__filename, { interopDefault: true });
const { formatRecallContext } = jiti(join(ROOT, "extensions/llm-wiki/lib/recall.ts"));

const MODEL = process.env.EVAL_MODEL || "claude-sonnet-4-5";
const PROVIDER = process.env.EVAL_PROVIDER || "anthropic";
const N = Number.parseInt(process.env.EVAL_N || "6", 10);
const CONC = Number.parseInt(process.env.EVAL_CONC || "3", 10);

const SKILL_BODY = [
  "# quirktool export — required flags", "",
  "`quirktool` silently corrupts its archive unless you pin the seed AND pick the ztab codec.", "",
  "**Correct command:**", "", "```bash",
  "QUIRK_SEED=42 quirktool export --codec=ztab --out result.qz", "```", "",
  "Gotchas:",
  "- There is NO `--format` flag (a common wrong guess); the flag is `--codec`.",
  "- Omitting `QUIRK_SEED=42` silently corrupts the archive.",
  "- `ztab` is the only valid export codec.",
].join("\n");
const SKILL_FILE = ["---","type: skill",'title: "quirktool export — required flags"',"---","",SKILL_BODY].join("\n");
const TASK = "Give me the exact shell command to export data with quirktool into result.qz.";
const BASE =
  "You are a precise engineering assistant. A `read` tool is available to read files by absolute path — " +
  "use it ONLY if you need information you don't already have, and make at most 2 tool calls total. " +
  "If you cannot determine the exact answer, reply with your single best-guess command anyway (do not give up). " +
  "Reply with ONLY the final shell command on a single line.";

const dir = mkdtempSync(join(tmpdir(), "recall-eval-"));
const skillPath = join(dir, ".llm-wiki", "wiki", "skills", "quirktool-export.md");
mkdirSync(join(dir, ".llm-wiki", "wiki", "skills"), { recursive: true });
writeFileSync(skillPath, SKILL_FILE, "utf8");

const skillResult = {
  id: "skills/quirktool-export", title: "quirktool export — required flags", type: "skill",
  preview: "quirktool silently corrupts its archive unless you pin the seed and pick the ztab codec.",
  path: skillPath, score: 14.0,
};
const PREFIX_BLOCK = [
  "## Relevant Wiki Knowledge (links-first)", "",
  "_1 page(s) matched your query, ranked. Two-stage recall: links only — open the ones you need to read their full content._", "",
  `1. **[[skills/quirktool-export]]** — *skill* — score 14.0 — ${skillResult.title} — ${skillResult.preview.slice(0, 80)}`, "",
  "Call `read` on the links you need to pull their full content. Add new findings via wiki_ensure_page or wiki_retro.",
].join("\n");
const CONDITIONS = {
  cold: BASE,
  prefixLink: `${BASE}\n\n${PREFIX_BLOCK}`,
  fixPathLink: `${BASE}\n\n${formatRecallContext([skillResult], { linksOnly: true, skillInlineMax: 0 })}`,
  fixInline: `${BASE}\n\n${formatRecallContext([skillResult], { linksOnly: true })}`,
  warm: `${BASE}\n\n## Known procedure\n\n${SKILL_BODY}`,
};
function scoreAnswer(text) {
  const cmds = (text || "").split("\n").filter((l) => /quirktool\s+export/i.test(l));
  for (const line of cmds) {
    const t = line.toLowerCase();
    if (/quirk_seed=42/.test(t) && /--codec[ =]ztab/.test(t) && !/--format/.test(t)) return { adherent: true };
  }
  return { adherent: false };
}
function runOnce(systemPrompt) {
  return new Promise((resolve) => {
    const args = ["-p","--mode","json","--no-session","--no-extensions","-ns","-nc",
      "--provider",PROVIDER,"--model",MODEL,"--tools","read","--system-prompt",systemPrompt,TASK];
    const ps = spawn("pi", args, { cwd: dir, stdio: ["ignore","pipe","pipe"] }); // stdin MUST be closed
    const timer = setTimeout(() => ps.kill("SIGKILL"), 120000);
    let out = ""; ps.stdout.on("data",(d)=>out+=d); ps.stderr.on("data",(d)=>out+=d);
    ps.on("close", () => {
      clearTimeout(timer);
      const ev = out.trim().split("\n").map((l)=>{try{return JSON.parse(l)}catch{return null}}).filter(Boolean);
      const tools = []; let finalText = "";
      for (const o of ev) if (o.type==="message_end" && o.message?.role==="assistant")
        for (const c of o.message.content||[]) { if (c.type==="toolCall") tools.push(c.name||c.toolName); if (c.type==="text") finalText=c.text; }
      resolve({ toolCalls: tools.length, reads: tools.filter((n)=>n==="read").length, ...scoreAnswer(finalText) });
    });
  });
}
async function pool(tasks, conc) {
  const r = new Array(tasks.length); let i = 0;
  await Promise.all(Array.from({ length: Math.min(conc, tasks.length) }, async () => { while (i < tasks.length) { const k = i++; r[k] = await tasks[k](); } }));
  return r;
}
(async () => {
  const order = ["cold","prefixLink","fixPathLink","fixInline","warm"];
  const jobs = []; for (const c of order) for (let k=0;k<N;k++) jobs.push({ c, fn: () => runOnce(CONDITIONS[c]) });
  const out = await pool(jobs.map((j)=>j.fn), CONC); jobs.forEach((j,i)=>(j.r=out[i]));
  for (const c of order) { const rs = jobs.filter((j)=>j.c===c).map((j)=>j.r); const a = rs.filter((r)=>r.adherent).length;
    console.log(`${c}\t${a}/${N}\tavgTools=${(rs.reduce((s,r)=>s+r.toolCalls,0)/rs.length).toFixed(2)}`); }
  rmSync(dir, { recursive: true, force: true });
})();
````

</details>

## Verification

- `tsc --noEmit` clean · `biome check .` clean · full suite green (`test/recall.test.ts` adds golden-regression, nudge, skills-inline, per-link read-path, fence-safety, CRLF, truncation, and `recallSkillInlineMax` clamp/disable tests).
- `recallSkillInlineMax` documented in `SKILL.md` beside `recallLinksThreshold`.

## Notes / follow-up

- `wiki_recall` (the explicit tool) renders its own output and doesn't route through `formatRecallContext`, so an explicitly-invoked recall gets a weaker affordance than the auto-injected one. Pre-existing; worth unifying behind one renderer in a follow-up rather than widening scope here.
