### PR TITLE
fix(#84): regression test + hardening for the `notices` opt-out

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,32 @@ npm run lint           # biome lint check
 npm run lint:fix       # auto-fix lint issues
 ```
 
+## Pull Request Hygiene
+
+When writing a PR description for a bug fix, separate **"actual bug"** from
+**"defensive cleanup"** so reviewers can audit each claim independently.
+
+Reviewers should be able to mentally substitute pre-fix code into each claim
+and verify that the symptom would still reproduce. If a claim describes a
+reordering or guard-addition that wouldn't have changed observable behavior
+on its own (for example, a flag with a permissive default like
+`noticesEnabled({}) === true`), call it out as **defensive hygiene** rather
+than part of the root cause.
+
+A template for the body:
+
+- **Problem** — the observable symptom, ideally with reproduction steps.
+- **Root cause** — the *one* change that, if reverted, would bring the bug
+  back. Be precise: which line, which missing guard, which order issue,
+  which off-by-one.
+- **Defensive cleanup (optional)** — any other changes in the same PR that
+  harden the code but were not strictly necessary to fix the symptom. These
+  belong in their own section so they don't get confused with the root cause.
+
+When in doubt, also add a **regression test** that fails against the
+pre-fix code — it's the single most reliable way to prove the diagnosis was
+correct and to keep the bug from coming back.
+
 ## Release Process
 
 ```bash

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -2,11 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
-import {
-  MODEL_STATUS_KEY,
-  formatActiveModelLabel,
-  registerWikiModelCommand,
-} from "./lib/model-command.js";
+import { registerWikiModelCommand } from "./lib/model-command.js";
 import {
   buildSessionNotice,
   createReminderState,
@@ -50,6 +46,7 @@ import {
   resolveVaultPaths,
   writeJson,
 } from "./lib/utils.js";
+import { applySessionStartStatus } from "./lib/visible-status.js";
 
 /**
  * @zosmaai/pi-llm-wiki — LLM Wiki extension for Pi
@@ -130,6 +127,10 @@ export default function (pi: ExtensionAPI) {
     try {
       const migration = migrateDoubledPersonalVault();
       if (migration && migration.moved.length > 0) {
+        // INTENTIONALLY NOT gated by `noticesEnabled` (issues #77, #84): this is
+        // a one-shot data-integrity recovery signal, not chat-noise. If the
+        // user has a broken doubled-dotdir layout we want them to see that it
+        // was fixed, even in quiet mode.
         ctx.ui.setStatus(
           "llm-wiki",
           `🧠 Personal wiki layout fixed: flattened ${migration.moved.length} entries out of ${migration.from} (see CHANGELOG)`,
@@ -171,27 +172,24 @@ export default function (pi: ExtensionAPI) {
       writeFileSync(join(vaultPaths.dotWiki, "WIKI_SCHEMA.md"), schema, "utf-8");
 
       needsTopicInference = true;
+      // INTENTIONALLY NOT gated by `noticesEnabled` (issues #77, #84): one-shot
+      // first-run setup signal. The user needs to know the wiki was just
+      // auto-created, regardless of quiet mode.
       ctx.ui.setStatus("llm-wiki", "🧠 Wiki created (inferring topic from first prompt…)");
       return;
     }
 
-    // Surface the active background task model (issue #69). Defaults to the
-    // session model when no taskModel is configured.
+    // Surface the "wiki active" badge and the active background task model
+    // (issue #69), both gated by `llm-wiki.notices` (issue #77, regression
+    // fixed in #83, helper extracted in #84). `ensureConfig` MUST run first so
+    // the gate sees the loaded project settings.
     runtime.ensureConfig(process.cwd());
-
-    if (noticesEnabled(runtime.config)) {
-      ctx.ui.setStatus(
-        "llm-wiki",
-        trajectoriesOn
-          ? "🧠 LLM Wiki (16 tools, trajectory + observe + recall active)"
-          : "🧠 LLM Wiki (13 tools, observe + recall active)",
-      );
-    }
-
-    const modelLabel = formatActiveModelLabel(runtime.config, (ctx.model as { id?: string })?.id);
-    if (noticesEnabled(runtime.config)) {
-      ctx.ui.setStatus(MODEL_STATUS_KEY, `🧠 wiki model: ${modelLabel}`);
-    }
+    applySessionStartStatus({
+      ui: ctx.ui,
+      runtime,
+      trajectoriesOn,
+      sessionModelId: (ctx.model as { id?: string })?.id,
+    });
 
     // One-time, user-visible session notice announcing the full wiki loop
     // (issue #77). Without this, recall/observe/retro are invisible — they

--- a/extensions/llm-wiki/lib/visible-status.ts
+++ b/extensions/llm-wiki/lib/visible-status.ts
@@ -1,0 +1,51 @@
+import { MODEL_STATUS_KEY, formatActiveModelLabel } from "./model-command.js";
+import type { Runtime } from "./runtime.js";
+import { noticesEnabled } from "./task-config.js";
+
+/**
+ * Minimal sink for the two status keys this helper writes. Mirrors the slice
+ * of `ctx.ui` the extension uses; kept narrow so tests don't need to fake the
+ * whole pi UI surface.
+ */
+export interface StatusSink {
+  setStatus(key: string, value: string): void;
+}
+
+/**
+ * Apply the two post-session-start visible status lines (issue #77,
+ * regression-fixed in #83, comments + tests hardened in #84):
+ *
+ *   1. `🧠 LLM Wiki (… tools, … active)`     — the "wiki is loaded" badge
+ *   2. `🧠 wiki model: <label>`              — the active background task model
+ *
+ * Both are user-facing chat noise and are gated by `llm-wiki.notices`
+ * (default `true`). When `notices: false`, neither status is set — that's the
+ * contract the regression in #83 was about.
+ *
+ * Extracted from `index.ts` so the gating contract is unit-testable without
+ * faking the entire pi extension factory; see `test/visible-activity.test.ts`.
+ *
+ * Pure modulo `ui.setStatus`. Callers MUST run `runtime.ensureConfig(...)` for
+ * the current cwd before invoking this so `noticesEnabled(runtime.config)`
+ * sees the loaded project settings.
+ */
+export function applySessionStartStatus(opts: {
+  ui: StatusSink;
+  runtime: Runtime;
+  trajectoriesOn: boolean;
+  sessionModelId: string | undefined;
+}): void {
+  // Single gate for BOTH status lines (#83 added two adjacent guards; #84
+  // collapses them — same condition, same scope).
+  if (!noticesEnabled(opts.runtime.config)) return;
+
+  opts.ui.setStatus(
+    "llm-wiki",
+    opts.trajectoriesOn
+      ? "🧠 LLM Wiki (16 tools, trajectory + observe + recall active)"
+      : "🧠 LLM Wiki (13 tools, observe + recall active)",
+  );
+
+  const modelLabel = formatActiveModelLabel(opts.runtime.config, opts.sessionModelId);
+  opts.ui.setStatus(MODEL_STATUS_KEY, `🧠 wiki model: ${modelLabel}`);
+}

--- a/test/visible-activity.test.ts
+++ b/test/visible-activity.test.ts
@@ -2,9 +2,11 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MODEL_STATUS_KEY } from "../extensions/llm-wiki/lib/model-command.js";
 import { buildReminderText, buildSessionNotice } from "../extensions/llm-wiki/lib/observation.js";
 import { Runtime } from "../extensions/llm-wiki/lib/runtime.js";
 import { loadTaskConfig, noticesEnabled } from "../extensions/llm-wiki/lib/task-config.js";
+import { applySessionStartStatus } from "../extensions/llm-wiki/lib/visible-status.js";
 
 // Issue #77: make wiki activity visible (recall status, observe/retro reminder,
 // session notice) and route mutating actions through background + report.
@@ -146,6 +148,131 @@ describe("Runtime.launchReported (issue #77)", () => {
     rt.pi = pi;
     await rt.launchReported({ hasUI: false }, "label-b", async () => null);
     expect(sent).toHaveLength(0);
+  });
+});
+
+// ─── applySessionStartStatus (issues #77, #83, #84) ─────────────────────────
+//
+// Regression guard for #83: the two `setStatus` calls in `session_start`
+// (`🧠 LLM Wiki (…)` and `🧠 wiki model: …`) MUST be silenced when
+// `notices: false`. The original #77 implementation only gated the reminder
+// and the session-notice message; the status lines slipped through and
+// surfaced even in quiet mode. PR #83 added the guards; PR #84 extracted the
+// gating block into this helper so it's directly testable instead of buried
+// inside the `pi.on("session_start", …)` closure.
+
+interface StatusCall {
+  key: string;
+  value: string;
+}
+
+function fakeUi(): { ui: { setStatus: (k: string, v: string) => void }; calls: StatusCall[] } {
+  const calls: StatusCall[] = [];
+  return {
+    ui: { setStatus: (key, value) => calls.push({ key, value }) },
+    calls,
+  };
+}
+
+describe("applySessionStartStatus (issues #77 + #83 + #84)", () => {
+  it("sets BOTH status lines when notices default (unset) — default-on contract", () => {
+    const rt = new Runtime();
+    // rt.config is `{}` by default — same shape as before ensureConfig runs.
+    // noticesEnabled({}) === true, so the helper must still emit both lines.
+    // This is the case that nudged the original #83 author toward an
+    // "ensureConfig was empty" theory; the test pins down that empty-config
+    // is default-ON and therefore non-silencing.
+    const { ui, calls } = fakeUi();
+    applySessionStartStatus({
+      ui,
+      runtime: rt,
+      trajectoriesOn: false,
+      sessionModelId: "anthropic-sonnet-4",
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual({
+      key: "llm-wiki",
+      value: "🧠 LLM Wiki (13 tools, observe + recall active)",
+    });
+    expect(calls[1]).toEqual({
+      key: MODEL_STATUS_KEY,
+      value: "🧠 wiki model: session model (anthropic-sonnet-4)",
+    });
+  });
+
+  it("sets BOTH status lines when notices: true is explicit", () => {
+    const rt = new Runtime();
+    rt.config = { notices: true };
+    const { ui, calls } = fakeUi();
+    applySessionStartStatus({
+      ui,
+      runtime: rt,
+      trajectoriesOn: false,
+      sessionModelId: undefined,
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0].key).toBe("llm-wiki");
+    expect(calls[1].key).toBe(MODEL_STATUS_KEY);
+  });
+
+  it("emits the 16-tools label when trajectoriesOn is true", () => {
+    const rt = new Runtime();
+    const { ui, calls } = fakeUi();
+    applySessionStartStatus({
+      ui,
+      runtime: rt,
+      trajectoriesOn: true,
+      sessionModelId: undefined,
+    });
+    expect(calls[0].value).toBe("🧠 LLM Wiki (16 tools, trajectory + observe + recall active)");
+  });
+
+  // ↑ Default-on / explicit-on coverage. ↓ The actual #83 regression contract.
+
+  it("emits NEITHER status line when notices: false (regression guard for #83)", () => {
+    const rt = new Runtime();
+    rt.config = { notices: false };
+    const { ui, calls } = fakeUi();
+    applySessionStartStatus({
+      ui,
+      runtime: rt,
+      trajectoriesOn: false,
+      sessionModelId: "anthropic-sonnet-4",
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("emits NEITHER status line when notices: false AND trajectoriesOn (sanity)", () => {
+    const rt = new Runtime();
+    rt.config = { notices: false };
+    const { ui, calls } = fakeUi();
+    applySessionStartStatus({
+      ui,
+      runtime: rt,
+      trajectoriesOn: true,
+      sessionModelId: "anthropic-sonnet-4",
+    });
+    // Both keys must stay silent regardless of which tools-active label would
+    // otherwise have been chosen.
+    expect(calls.some((c) => c.key === "llm-wiki")).toBe(false);
+    expect(calls.some((c) => c.key === MODEL_STATUS_KEY)).toBe(false);
+  });
+
+  it("uses the configured taskModel label when one is set", () => {
+    const rt = new Runtime();
+    rt.config = { taskModel: { provider: "anthropic", id: "claude-sonnet-4" } };
+    const { ui, calls } = fakeUi();
+    applySessionStartStatus({
+      ui,
+      runtime: rt,
+      trajectoriesOn: false,
+      sessionModelId: "some-other-session-id",
+    });
+    // taskModel wins over the session model id (see formatActiveModelLabel).
+    expect(calls[1]).toEqual({
+      key: MODEL_STATUS_KEY,
+      value: "🧠 wiki model: anthropic/claude-sonnet-4",
+    });
   });
 });
 


### PR DESCRIPTION
Closes #84. Follow-up to #83.

## Problem

Three loose ends from PR #83, all flagged in issue #84:

1. **No regression test.** Issue #77's acceptance criteria called for unit tests on the `notices` flag, but the original test suite only covered the reminder + session-notice paths — the two `session_start` `setStatus` calls (which were the regression) were never asserted.
2. **The two intentional exceptions** (migration-recovery `setStatus` and "Wiki created" `setStatus`) are not gated by `noticesEnabled`, but there was no comment explaining why — a future contributor could "complete" the silencing work by mistake.
3. **CONTRIBUTING.md** had no guidance against conflating "actual bug" with "defensive cleanup" in PR descriptions — which is exactly what made #83's framing slightly confusing on review.

## What this PR does

### 1. Regression test for the gating contract

Extracts the gating block from `index.ts` `session_start` into a new helper `lib/visible-status.ts::applySessionStartStatus`. The helper is pure modulo `ui.setStatus`, so the contract — *"notices: false ⇒ no setStatus calls"* — is directly testable without faking the entire pi extension factory.

6 new tests in `test/visible-activity.test.ts`:

- `notices` unset (default) → both status lines fire
- `notices: true` explicit → both status lines fire
- `trajectoriesOn: true` → "16 tools" label is selected
- **`notices: false` → NEITHER status line fires** (the #83 regression guard)
- `notices: false` + `trajectoriesOn: true` → still NEITHER line (sanity)
- `taskModel` set → model label uses `provider/id` instead of session model

### Verifying the regression test would have caught the original bug

I dropped a pre-#83 copy of the helper (no `noticesEnabled` guard, status lines unconditional) into the test file and ran just the `notices: false ⇒ length 0` assertion against it:

```
× PRE-FIX: notices:false should fail the 'emits NEITHER' assertion
AssertionError: expected [ { key: 'llm-wiki', …(1) }, …(1) ] to have a length of +0 but got 2
- Expected  0
+ Received  2
```

i.e. against the buggy pre-#83 code the new test fails with exactly the symptom the user reported — both status lines fire when they shouldn't. This satisfies the acceptance criterion *"Unit tests for #1 land and fail against the pre-#83 code (proving they catch the original regression)."*

### 2. Comments on the intentional exceptions

Both untouched-by-#83 `setStatus` calls in `session_start` now carry a comment:

```ts
// INTENTIONALLY NOT gated by `noticesEnabled` (issues #77, #84): this is
// a one-shot data-integrity recovery signal, not chat-noise. …
ctx.ui.setStatus("llm-wiki", `🧠 Personal wiki layout fixed: …`);
```

```ts
// INTENTIONALLY NOT gated by `noticesEnabled` (issues #77, #84): one-shot
// first-run setup signal. …
ctx.ui.setStatus("llm-wiki", "🧠 Wiki created (inferring topic from first prompt…)");
```

### 3. CONTRIBUTING.md — Pull Request Hygiene

New short section asking bug-fix PRs to separate **Problem / Root cause / Defensive cleanup** so each claim is independently auditable. Motivated by the `ensureConfig` reordering in #83, which is good defensive hygiene but doesn't fix the bug on its own (because `noticesEnabled({}) === true`).

### Stretch (task #4 from the issue) — style cleanup

The two adjacent `if (noticesEnabled(runtime.config)) { … }` blocks #83 added are now collapsed into a single guard inside the new helper.

## Verification

- `npm run typecheck` ✓
- `npm run lint` ✓ on all files this PR touches (CONTRIBUTING.md, index.ts, visible-status.ts, visible-activity.test.ts)
- `npx vitest run test/visible-activity.test.ts` → 14 tests pass (8 existing + 6 new)
- Regression-against-pre-fix experiment described above → fails with the expected diagnostic, confirming the test catches the original #83 bug.

## Files

- `extensions/llm-wiki/index.ts` — call the helper; add the two "intentionally not gated" comments
- `extensions/llm-wiki/lib/visible-status.ts` — new helper + docstring
- `test/visible-activity.test.ts` — 6 new tests in a new `describe` block
- `CONTRIBUTING.md` — "Pull Request Hygiene" section
