### PR TITLE
fix(#81): wiki_watch emits real crontab line (no fictional schedule_prompt, no /wiki:run typo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **`wiki_watch` referred to a fictional `schedule_prompt` tool** (Issue #81): `wiki_watch` emitted instructions to run `schedule_prompt action=add ...` — a tool that doesn't exist in pi-coding-agent or any pi extension — so `/wiki-run --schedule weekly` printed a command the user couldn't execute. The emitted payload also contained the typo `/wiki:run` (real slash-command is `/wiki-run`), and the tool description claimed it scheduled jobs when it only ever printed instructions. Now emits a real, copy-pasteable **POSIX 5-field crontab line** wrapped in `/bin/bash -lc` (so npm-global / bun / nvm PATH is imported under cron's minimal env), with defensive `mkdir -p` of the log dir and a `# llm-wiki-autoupdate` removal tag. The tool description, output text, `prompts/wiki-run.md`, `docs/api.md` and all 10 i18n READMEs now explicitly say "prints — does not install". `details` now carries `cronLine` and `installed: false`. New `test/wiki-watch.test.ts` (10 tests) locks down all three regressions plus the portability contract (login-shell wrapper, defensive `mkdir`, quoted `$HOME`).
 - **Personal wiki created at doubled path `~/.llm-wiki/.llm-wiki/…`**: `getPersonalWikiRoot()` returned the dot-dir itself (`~/.llm-wiki`) while `getVaultPaths()` then appended another `.llm-wiki/` segment, so the personal vault was written to `~/.llm-wiki/.llm-wiki/wiki/…`. Fixed by aligning `getPersonalWikiRoot()` with the same "root = parent of `.llm-wiki/`" contract used by project vaults. `WIKI_HOME` continues to override the parent.
 
 ### Added

--- a/README.de.md
+++ b/README.de.md
@@ -78,7 +78,7 @@ Das Ergebnis ist ein Wiki, das wächst, während du Quellen erfasst, Fragen stel
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -105,7 +105,7 @@ Das Ergebnis ist ein Wiki, das wächst, während du Quellen erfasst, Fragen stel
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 
 ### Schrägstrich-Befehle
 

--- a/README.es.md
+++ b/README.es.md
@@ -78,7 +78,7 @@ El resultado es un wiki que se acumula a medida que capturas fuentes, haces preg
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -105,7 +105,7 @@ El resultado es un wiki que se acumula a medida que capturas fuentes, haces preg
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 
 ### Comandos de Barra
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -78,7 +78,7 @@ Le résultat est un wiki qui s'accumule au fur et à mesure que vous capturez de
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -105,7 +105,7 @@ Le résultat est un wiki qui s'accumule au fur et à mesure que vous capturez de
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 
 ### Commandes Slash
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -78,7 +78,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -105,7 +105,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 
 ### स्लैश कमांड
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -78,7 +78,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -105,7 +105,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 
 ### スラッシュコマンド
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -78,7 +78,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -105,7 +105,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 
 ### 슬래시 명령
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -106,7 +106,7 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 | `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
 | `wiki_distill_skills` _(opt-in)_ | Batch undistilled trajectories for synthesis into reusable skill pages |
 | `wiki_recall_skill` _(opt-in)_ | Recall distilled skills + similar past cases — "have I done this before?" |

--- a/README.pt.md
+++ b/README.pt.md
@@ -78,7 +78,7 @@ O resultado é um wiki que se acumula conforme você captura fontes, faz pergunt
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -105,7 +105,7 @@ O resultado é um wiki que se acumula conforme você captura fontes, faz pergunt
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 
 ### Comandos de Barra
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -78,7 +78,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -105,7 +105,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 
 ### Слэш-команды
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -78,7 +78,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | 🔍 **Full-text search** | Generated registry with keyword lookup across all pages and sources |
 | 🩺 **Mechanical linting** | Orphans, broken links, duplicate aliases, coverage gaps, stale captures |
 | 📊 **Dashboard** | `wiki_status` — counts, source states, recent activity |
-| 🤖 **Auto-update watch** | `wiki_watch` — schedule periodic discovery + ingest |
+| 🤖 **Auto-update watch** | `wiki_watch` — print a `crontab` line that runs the full cycle on a schedule |
 | 🧠 **Layered recall** | Searches both personal (`~/.llm-wiki/`) and project (`.llm-wiki/`) vaults — personal knowledge follows you everywhere |
 | 📝 **Auto-bootstrap** | Extension suggests creating a wiki when none exists in the current directory |
 | 💾 **Lightweight capture** | `wiki_retro` — save atomic insights as a single markdown file; full 4-layer pipeline also available via `wiki_capture_source` |
@@ -105,7 +105,7 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `wiki_status` | Show counts, source states, and recent activity |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
-| `wiki_watch` | Schedule automatic wiki updates (daily / weekly / hourly) |
+| `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 
 ### 斜杠命令
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -314,28 +314,37 @@ details: { kind: string }
 
 ## wiki_watch
 
-Output the shell command needed to schedule automatic wiki updates (discover → ingest → lint) via
-pi's `schedule_prompt` cron system. Does not schedule anything directly — it returns the command
-for the user to run.
+Print a ready-to-paste **POSIX crontab line** that runs the full wiki cycle (discover → ingest →
+lint) on a schedule by invoking `pi -p "/wiki-run"` headlessly under `/bin/bash -lc` so the
+user's shell profile (and the `pi` binary on npm-global / bun / nvm PATH) is imported. **Does
+not schedule anything directly** — it returns the command for the user to install with
+`crontab -e`. Calling agents should surface the output verbatim and avoid claiming the schedule
+is active.
 
 **Parameters**
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `interval` | `string` | ✅ | `"daily"` (8:00 AM), `"weekly"` (Monday 9:00 AM), `"hourly"`, or `"stop"` (prints removal instructions) |
+| `interval` | `string` | ✅ | `"daily"` (8:00 AM), `"weekly"` (Monday 9:00 AM), `"hourly"`, or `"stop"` (prints crontab removal instructions) |
 
 **Returns**
 
 ```
 details: {
   interval: string,
-  cronSchedule: string,   // e.g. "0 0 8 * * *"
-  label: string           // e.g. "Daily at 8:00 AM"
+  cronSchedule: string,   // 5-field POSIX expression, e.g. "0 8 * * *"
+  label: string,          // e.g. "Daily at 8:00 AM"
+  cronLine: string,       // full crontab line, tagged "# llm-wiki-autoupdate"
+  installed: false        // tool never installs — always false
 }
 ```
 
-When `interval` is `"stop"`, returns `details: { action: "stop_instructions" }` with instructions
-for removing existing jobs via `schedule_prompt action=remove`.
+Output is appended to `~/.llm-wiki/cron.log` (the directory is created by the cron line itself
+via `mkdir -p`). On systems without `/bin/bash`, replace the wrapper with `/bin/sh -c` and
+ensure `pi` is in cron's PATH yourself.
+
+When `interval` is `"stop"`, returns `details: { action: "stop_instructions" }` with
+instructions for removing the line via `crontab -e` (look for the `# llm-wiki-autoupdate` tag).
 
 ---
 

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -1197,10 +1197,12 @@ export function registerWikiWatch(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "wiki_watch",
     label: "Wiki Watch",
-    description: "Schedule automatic wiki updates (discover → ingest → lint) via pi's cron system.",
+    description:
+      "Print a ready-to-paste crontab line for scheduling automatic wiki updates (discover → ingest → lint). Does NOT schedule anything itself — it returns the command for the user to install.",
     promptSnippet: "Schedule auto-updates for the wiki",
     promptGuidelines: [
       "Use wiki_watch when the user wants the wiki to stay current automatically.",
+      "wiki_watch only PRINTS a cron line — surface the output to the user verbatim so they can install it. Do not claim the schedule is active.",
     ],
     parameters: Type.Object({
       interval: Type.String({ description: "daily, weekly, hourly, or stop" }),
@@ -1212,15 +1214,16 @@ export function registerWikiWatch(pi: ExtensionAPI): void {
             {
               type: "text",
               text: [
-                "🛑 To stop wiki auto-updates:",
+                "🛑 To stop wiki auto-updates, remove the cron line you installed earlier:",
                 "",
+                "```bash",
+                "crontab -e   # then delete the line tagged '# llm-wiki-autoupdate'",
                 "```",
-                "schedule_prompt action=list",
-                "```",
-                "Find the wiki job IDs, then:",
                 "",
-                "```",
-                "schedule_prompt action=remove jobId=<id>",
+                "Or list current jobs to confirm:",
+                "",
+                "```bash",
+                "crontab -l | grep llm-wiki-autoupdate",
                 "```",
               ].join("\n"),
             },
@@ -1229,10 +1232,14 @@ export function registerWikiWatch(pi: ExtensionAPI): void {
         };
       }
 
-      const intervals: Record<string, { cron: string; label: string }> = {
-        daily: { cron: "0 0 8 * * *", label: "Daily at 8:00 AM" },
-        weekly: { cron: "0 0 9 * * 1", label: "Weekly on Monday at 9:00 AM" },
-        hourly: { cron: "0 0 * * * *", label: "Every hour" },
+      // 5-field POSIX crontab expressions (min hour dom month dow).
+      const intervals: Record<
+        string,
+        { cron: string; label: string }
+      > = {
+        daily: { cron: "0 8 * * *", label: "Daily at 8:00 AM" },
+        weekly: { cron: "0 9 * * 1", label: "Weekly on Monday at 9:00 AM" },
+        hourly: { cron: "0 * * * *", label: "Every hour" },
       };
 
       const config = intervals[params.interval];
@@ -1249,18 +1256,37 @@ export function registerWikiWatch(pi: ExtensionAPI): void {
         };
       }
 
+      // Robustness for global crontab environments:
+      //   * `/bin/bash -lc` runs a LOGIN shell that sources /etc/profile +
+      //     ~/.profile / ~/.bash_profile, so npm-global / bun / nvm PATH
+      //     additions are imported — cron's default PATH is only
+      //     `/usr/bin:/bin` and would not find `pi`.
+      //   * `mkdir -p` makes the log dir self-healing for users with only
+      //     a project vault (no `~/.llm-wiki/` yet).
+      //   * All `$HOME` references are double-quoted to survive paths with spaces.
+      //   * `# llm-wiki-autoupdate` tags the line so the user can find and
+      //     remove it via `crontab -e` later (see `interval=stop`).
+      const cronLine = `${config.cron} /bin/bash -lc 'mkdir -p "$HOME/.llm-wiki" && pi -p "/wiki-run" >> "$HOME/.llm-wiki/cron.log" 2>&1' # llm-wiki-autoupdate`;
+
       return {
         content: [
           {
             type: "text",
             text: [
-              `⏰ To set up ${config.label} wiki updates, run:`,
+              `⏰ To set up ${config.label} wiki updates, add this line to your crontab.`,
+              `**This tool only prints the line — it does not install it.**`,
               "",
-              "```",
-              `schedule_prompt action=add schedule="${config.cron}" prompt="Run /wiki:run for the LLM Wiki" name="llm-wiki-autoupdate"`,
+              "```bash",
+              "crontab -e",
               "```",
               "",
-              "This will auto-discover, ingest, and lint on schedule.",
+              "Then append:",
+              "",
+              "```cron",
+              cronLine,
+              "```",
+              "",
+              `The line uses \`/bin/bash -lc\` so your shell profile (and the \`pi\` binary on npm-global / bun PATH) is loaded. Output goes to \`~/.llm-wiki/cron.log\`. If your system has no \`/bin/bash\`, replace with \`/bin/sh -c\` and ensure \`pi\` is in cron's PATH yourself.`,
             ].join("\n"),
           },
         ],
@@ -1268,6 +1294,8 @@ export function registerWikiWatch(pi: ExtensionAPI): void {
           interval: params.interval,
           cronSchedule: config.cron,
           label: config.label,
+          cronLine,
+          installed: false,
         } as Record<string, unknown>,
       };
     },

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -1233,10 +1233,7 @@ export function registerWikiWatch(pi: ExtensionAPI): void {
       }
 
       // 5-field POSIX crontab expressions (min hour dom month dow).
-      const intervals: Record<
-        string,
-        { cron: string; label: string }
-      > = {
+      const intervals: Record<string, { cron: string; label: string }> = {
         daily: { cron: "0 8 * * *", label: "Daily at 8:00 AM" },
         weekly: { cron: "0 9 * * 1", label: "Weekly on Monday at 9:00 AM" },
         hourly: { cron: "0 * * * *", label: "Every hour" },
@@ -1274,7 +1271,7 @@ export function registerWikiWatch(pi: ExtensionAPI): void {
             type: "text",
             text: [
               `⏰ To set up ${config.label} wiki updates, add this line to your crontab.`,
-              `**This tool only prints the line — it does not install it.**`,
+              "**This tool only prints the line — it does not install it.**",
               "",
               "```bash",
               "crontab -e",

--- a/prompts/wiki-run.md
+++ b/prompts/wiki-run.md
@@ -24,6 +24,8 @@ $ARGUMENTS
 
 ### Scheduling
 
-If `--schedule` is provided, call `wiki_watch(interval=<daily|weekly>)` to set up automatic updates.
+If `--schedule` is provided, call `wiki_watch(interval=<daily|weekly|hourly>)`.
 
-If `--schedule hourly` is provided, call `wiki_watch(interval=hourly)`.
+**Important:** `wiki_watch` does NOT install a schedule. It only prints a `crontab` line.
+Report the printed line to the user verbatim and tell them to install it themselves with
+`crontab -e`. Do not claim the schedule is active until they confirm they have done so.

--- a/test/wiki-watch.test.ts
+++ b/test/wiki-watch.test.ts
@@ -74,9 +74,7 @@ describe("wiki_watch — issue #81 regressions", () => {
   it("description and output make it explicit that nothing is scheduled", async () => {
     const tool = captureWatchTool();
     expect(tool.description.toLowerCase()).toMatch(/print|return/);
-    expect(tool.description.toLowerCase()).not.toMatch(
-      /^schedule automatic wiki updates/i,
-    );
+    expect(tool.description.toLowerCase()).not.toMatch(/^schedule automatic wiki updates/i);
 
     const result = await run("weekly");
     const text = result.content.map((c) => c.text).join("\n");

--- a/test/wiki-watch.test.ts
+++ b/test/wiki-watch.test.ts
@@ -1,0 +1,143 @@
+// Regression tests for `wiki_watch` (issue #81).
+//
+// Three classes of bugs to lock down:
+//   1. The emitted "schedule_prompt" instructions referred to a tool that
+//      doesn't exist anywhere in pi or any pi extension. The tool now MUST
+//      emit a real, copy-pasteable POSIX crontab line.
+//   2. The generated payload contained the typo `/wiki:run`. The real
+//      slash-command is `/wiki-run` — no colon.
+//   3. The user-facing text and tool description claimed scheduling happens.
+//      It does not — the tool only PRINTS instructions.
+//
+// Plus a robustness contract (global-cron portability):
+//   4. 5-field POSIX schedule (not 6-field quartz/node-cron).
+//   5. Executed under a login shell so the user's PATH (npm-global, bun,
+//      nvm) is imported — cron's default PATH is only `/usr/bin:/bin`.
+//   6. Log directory created defensively so cron doesn't fail-silent.
+//   7. All `$HOME` references double-quoted so paths with spaces survive.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { registerWikiWatch } from "../extensions/llm-wiki/lib/tools.js";
+
+interface CapturedTool {
+  description: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+    signal: undefined,
+    onUpdate: undefined,
+    ctx: unknown,
+  ) => Promise<{
+    content: Array<{ text: string }>;
+    details: Record<string, unknown>;
+    isError?: boolean;
+  }>;
+}
+
+function captureWatchTool(): CapturedTool {
+  let tool: CapturedTool | undefined;
+  const pi = {
+    registerTool: (def: unknown) => {
+      tool = def as CapturedTool;
+    },
+  } as unknown as ExtensionAPI;
+  registerWikiWatch(pi);
+  if (!tool) throw new Error("wiki_watch not registered");
+  return tool;
+}
+
+async function run(interval: string) {
+  const tool = captureWatchTool();
+  return tool.execute("t1", { interval }, undefined, undefined, {});
+}
+
+describe("wiki_watch — issue #81 regressions", () => {
+  it("never references the fictional `schedule_prompt` tool", async () => {
+    for (const interval of ["daily", "weekly", "hourly", "stop"]) {
+      const result = await run(interval);
+      const text = result.content.map((c) => c.text).join("\n");
+      expect(text, `interval=${interval}`).not.toMatch(/schedule_prompt/);
+    }
+  });
+
+  it("never emits the `/wiki:run` typo — only `/wiki-run`", async () => {
+    for (const interval of ["daily", "weekly", "hourly"]) {
+      const result = await run(interval);
+      const text = result.content.map((c) => c.text).join("\n");
+      const details = JSON.stringify(result.details);
+      expect(text, `text@${interval}`).not.toMatch(/\/wiki:run\b/);
+      expect(details, `details@${interval}`).not.toMatch(/\/wiki:run\b/);
+    }
+  });
+
+  it("description and output make it explicit that nothing is scheduled", async () => {
+    const tool = captureWatchTool();
+    expect(tool.description.toLowerCase()).toMatch(/print|return/);
+    expect(tool.description.toLowerCase()).not.toMatch(
+      /^schedule automatic wiki updates/i,
+    );
+
+    const result = await run("weekly");
+    const text = result.content.map((c) => c.text).join("\n");
+    expect(text.toLowerCase()).toMatch(/only prints|does not install|not install/);
+    expect(result.details.installed).toBe(false);
+  });
+});
+
+describe("wiki_watch — crontab line portability (issue #81 follow-up)", () => {
+  it("emits a valid 5-field POSIX crontab line invoking pi -p /wiki-run", async () => {
+    const cases: Array<{ interval: string; cron: RegExp }> = [
+      { interval: "daily", cron: /^0 8 \* \* \*$/ },
+      { interval: "weekly", cron: /^0 9 \* \* 1$/ },
+      { interval: "hourly", cron: /^0 \* \* \* \*$/ },
+    ];
+    for (const { interval, cron } of cases) {
+      const result = await run(interval);
+      const cronLine = result.details.cronLine as string | undefined;
+      expect(cronLine, `cronLine for ${interval}`).toBeTypeOf("string");
+      const fields = cronLine!.split(/\s+/).slice(0, 5).join(" ");
+      expect(fields, `interval=${interval}`).toMatch(cron);
+      expect(cronLine!).toMatch(/pi\s+-p\s+"\/wiki-run"/);
+      expect(cronLine!).toMatch(/llm-wiki-autoupdate/);
+    }
+  });
+
+  it("wraps the command in a login shell so PATH (npm-global / bun / nvm) is imported", async () => {
+    for (const interval of ["daily", "weekly", "hourly"]) {
+      const result = await run(interval);
+      const cronLine = result.details.cronLine as string;
+      expect(cronLine, `interval=${interval}`).toMatch(/\/bin\/bash\s+-lc\s+'/);
+    }
+  });
+
+  it("creates the log directory defensively to avoid silent failure", async () => {
+    const result = await run("daily");
+    const cronLine = result.details.cronLine as string;
+    expect(cronLine).toMatch(/mkdir\s+-p\s+"\$HOME\/\.llm-wiki"/);
+  });
+
+  it("quotes every $HOME reference so paths with spaces survive", async () => {
+    const result = await run("daily");
+    const cronLine = result.details.cronLine as string;
+    let idx = cronLine.indexOf("$HOME");
+    while (idx !== -1) {
+      expect(cronLine[idx - 1], `$HOME at ${idx} not preceded by '"'`).toBe('"');
+      idx = cronLine.indexOf("$HOME", idx + 1);
+    }
+  });
+
+  it("rejects unknown intervals with isError=true", async () => {
+    const result = await run("yearly");
+    expect(result.isError).toBe(true);
+    expect(result.details.error).toBe("bad_interval");
+  });
+
+  it("`stop` returns crontab removal instructions, not schedule_prompt", async () => {
+    const result = await run("stop");
+    const text = result.content.map((c) => c.text).join("\n");
+    expect(text).toMatch(/crontab\s+-e/);
+    expect(text).toMatch(/llm-wiki-autoupdate/);
+    expect(result.details.action).toBe("stop_instructions");
+  });
+});


### PR DESCRIPTION
Closes #81.

## Problem (verified end-to-end against v0.9.1 and current main)

`wiki_watch` — called by `/wiki-run --schedule weekly` — emitted instructions to run `schedule_prompt action=add ...`. That tool does **not exist** anywhere in pi-coding-agent or any pi extension on disk:

```
$ command -v schedule_prompt
(empty)
$ grep -ril schedule_prompt /usr/lib/node_modules/@earendil-works/ ~/.pi/agent/npm/node_modules/ \
    | grep -v pi-llm-wiki
(empty — only pi-llm-wiki itself mentions it)
```

On top of that, the emitted payload contained the typo `/wiki:run` (real slash-command is `/wiki-run`), and the tool's `description` claimed it scheduled jobs when it only ever printed instructions.

## Fix

`wiki_watch` now emits a real, copy-pasteable POSIX crontab line:

```cron
0 9 * * 1 /bin/bash -lc 'mkdir -p "$HOME/.llm-wiki" && pi -p "/wiki-run" >> "$HOME/.llm-wiki/cron.log" 2>&1' # llm-wiki-autoupdate
```

Robustness choices (so this works on a global standard cron, not just the developer's interactive shell):

| Choice | Why |
|---|---|
| 5-field POSIX schedule (`0 9 * * 1`) | The old code emitted 6-field quartz/node-cron expressions which most system crons reject. |
| `/bin/bash -lc '…'` wrapper | cron's default `PATH` is `/usr/bin:/bin`. A login shell sources `/etc/profile` + `~/.profile` / `~/.bash_profile`, importing `pi` from npm-global / bun / nvm. |
| `mkdir -p "$HOME/.llm-wiki"` | Users with only a project vault don't have `~/.llm-wiki/` yet — without this the first cron run would fail-silent. |
| Every `$HOME` double-quoted | Paths with spaces survive. |
| `# llm-wiki-autoupdate` tag | Lets the user (and `interval=stop`) find and remove the line later. |

The output text, the tool description, `prompts/wiki-run.md`, `docs/api.md` and **all 10 i18n READMEs** now say explicitly: this tool **prints** a crontab line, it does **not** install it. Calling agents must surface the output verbatim and not claim the schedule is active.

`details` now carries `cronLine: string` and `installed: false`.

`interval=stop` now returns honest `crontab -e` removal instructions keyed off the `# llm-wiki-autoupdate` tag (no more `schedule_prompt` references).

## Test coverage

New `test/wiki-watch.test.ts` — 9 tests across two describe blocks:

**Issue #81 regressions:**
1. never references `schedule_prompt` in any interval (incl. `stop`)
2. never emits the `/wiki:run` typo (text or details)
3. description and output explicitly state print-only (`installed === false`)

**Crontab portability contract:**
4. 5-field POSIX schedule for daily / weekly / hourly
5. login-shell wrapper (`/bin/bash -lc '…'`)
6. defensive `mkdir -p "$HOME/.llm-wiki"`
7. every `$HOME` occurrence preceded by `"`
8. unknown intervals → `isError: true`, `details.error === "bad_interval"`
9. `stop` returns `crontab -e` removal instructions

Full suite: 24 files / 333 tests passing. Typecheck clean. Lint clean.

## Files touched

- `extensions/llm-wiki/lib/tools.ts` — `registerWikiWatch` body + description
- `docs/api.md` — `wiki_watch` section
- `prompts/wiki-run.md` — scheduling step now explicit about print-only behavior
- `README.md` + `README.{de,es,fr,hi,ja,ko,pt,ru,zh}.md` — both `wiki_watch` rows
- `CHANGELOG.md` — unreleased "Fixed" entry
- `test/wiki-watch.test.ts` — new

Thanks again to @m1k3s0 for the precise repro and pointing at the exact files.