### PR TITLE
fix(#87): make context injection idempotent (wiki_status no longer duplicates)

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
+import { appendWikiStatus } from "./lib/inject.js";
 import { registerWikiModelCommand } from "./lib/model-command.js";
 import {
   buildSessionNotice,
@@ -295,8 +296,7 @@ Then call wiki_bootstrap with the inferred topic and mode to finalize the setup.
 
     // Always inject a visible wiki status footer, even when empty
     // This ensures the model knows the wiki is active and can use it
-    injectedContext +=
-      "\n\n<wiki_status>LLM Wiki active — use wiki_recall for deeper search, wiki_observe to record observations, wiki_retro to save insights.</wiki_status>";
+    injectedContext = appendWikiStatus(injectedContext);
 
     if (injectedContext === event.systemPrompt) return;
     return { systemPrompt: injectedContext };

--- a/extensions/llm-wiki/lib/inject.ts
+++ b/extensions/llm-wiki/lib/inject.ts
@@ -1,0 +1,25 @@
+/**
+ * System-prompt context injection primitives (issue #87).
+ *
+ * The `before_agent_start` hook augments the chained system prompt with a
+ * visible wiki-status footer. This module isolates that append so it can be
+ * unit-tested for idempotency — a turn that aborts (network error / ESC) and is
+ * retried can carry the prior injection forward, and a naive append stacks the
+ * footer 2x, 3x, ...
+ */
+
+/** The always-injected wiki-status footer (sans surrounding whitespace). */
+export const WIKI_STATUS_BLOCK =
+  "<wiki_status>LLM Wiki active — use wiki_recall for deeper search, wiki_observe to record observations, wiki_retro to save insights.</wiki_status>";
+
+/**
+ * Append the wiki-status footer to a system prompt.
+ *
+ * KNOWN BUG (#87): this is NOT idempotent. It re-appends on every call, so when
+ * an aborted/retried agent start carries the prior injection forward, the footer
+ * stacks (2x, 3x, ...). The fix is to skip appending when the block is already
+ * present. See test/inject-idempotent.test.ts.
+ */
+export function appendWikiStatus(systemPrompt: string): string {
+  return `${systemPrompt}\n\n${WIKI_STATUS_BLOCK}`;
+}

--- a/extensions/llm-wiki/lib/inject.ts
+++ b/extensions/llm-wiki/lib/inject.ts
@@ -21,5 +21,6 @@ export const WIKI_STATUS_BLOCK =
  * present. See test/inject-idempotent.test.ts.
  */
 export function appendWikiStatus(systemPrompt: string): string {
-  return `${systemPrompt}\n\n${WIKI_STATUS_BLOCK}`;
+  const base = systemPrompt.split(`\n\n${WIKI_STATUS_BLOCK}`).join("");
+  return `${base}\n\n${WIKI_STATUS_BLOCK}`;
 }

--- a/extensions/llm-wiki/lib/inject.ts
+++ b/extensions/llm-wiki/lib/inject.ts
@@ -13,12 +13,13 @@ export const WIKI_STATUS_BLOCK =
   "<wiki_status>LLM Wiki active — use wiki_recall for deeper search, wiki_observe to record observations, wiki_retro to save insights.</wiki_status>";
 
 /**
- * Append the wiki-status footer to a system prompt.
+ * Append the wiki-status footer to a system prompt — idempotently (issue #87).
  *
- * KNOWN BUG (#87): this is NOT idempotent. It re-appends on every call, so when
- * an aborted/retried agent start carries the prior injection forward, the footer
- * stacks (2x, 3x, ...). The fix is to skip appending when the block is already
- * present. See test/inject-idempotent.test.ts.
+ * Strips any already-present footer (with its leading blank line) before
+ * appending exactly one. This makes the injection safe across aborted/retried
+ * agent starts that carry the prior injection forward in the chained system
+ * prompt, so the footer never stacks (2x, 3x, ...).
+ * See test/inject-idempotent.test.ts.
  */
 export function appendWikiStatus(systemPrompt: string): string {
   const base = systemPrompt.split(`\n\n${WIKI_STATUS_BLOCK}`).join("");

--- a/test/inject-idempotent.test.ts
+++ b/test/inject-idempotent.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  WIKI_STATUS_BLOCK,
+  appendWikiStatus,
+} from "../extensions/llm-wiki/lib/inject.js";
+
+// Regression test for issue #87: context injection must be idempotent.
+//
+// When an agent turn aborts (network error / user presses ESC) and is retried,
+// the chained system prompt can carry the prior injection forward. The append
+// must therefore be a no-op when the wiki-status footer is already present —
+// otherwise the footer stacks 2x, 3x, ... and pollutes the context window.
+describe("appendWikiStatus — issue #87 idempotency", () => {
+  const countBlocks = (s: string): number =>
+    s.split(WIKI_STATUS_BLOCK).length - 1;
+
+  it("appends the footer to a clean prompt", () => {
+    const out = appendWikiStatus("BASE SYSTEM PROMPT");
+    expect(countBlocks(out)).toBe(1);
+    expect(out).toContain("BASE SYSTEM PROMPT");
+  });
+
+  it("is idempotent across repeated (aborted-retry) injections", () => {
+    let sp = "BASE SYSTEM PROMPT";
+    // Three submissions where the prior two starts aborted and carried the
+    // injected prompt forward.
+    sp = appendWikiStatus(sp);
+    sp = appendWikiStatus(sp);
+    sp = appendWikiStatus(sp);
+    expect(countBlocks(sp)).toBe(1);
+  });
+
+  it("does not re-append when the block is already present mid-prompt", () => {
+    const seeded = `head\n\n${WIKI_STATUS_BLOCK}\n\ntail`;
+    expect(countBlocks(appendWikiStatus(seeded))).toBe(1);
+  });
+});

--- a/test/inject-idempotent.test.ts
+++ b/test/inject-idempotent.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  WIKI_STATUS_BLOCK,
-  appendWikiStatus,
-} from "../extensions/llm-wiki/lib/inject.js";
+import { WIKI_STATUS_BLOCK, appendWikiStatus } from "../extensions/llm-wiki/lib/inject.js";
 
 // Regression test for issue #87: context injection must be idempotent.
 //
@@ -11,8 +8,7 @@ import {
 // must therefore be a no-op when the wiki-status footer is already present —
 // otherwise the footer stacks 2x, 3x, ... and pollutes the context window.
 describe("appendWikiStatus — issue #87 idempotency", () => {
-  const countBlocks = (s: string): number =>
-    s.split(WIKI_STATUS_BLOCK).length - 1;
+  const countBlocks = (s: string): number => s.split(WIKI_STATUS_BLOCK).length - 1;
 
   it("appends the footer to a clean prompt", () => {
     const out = appendWikiStatus("BASE SYSTEM PROMPT");


### PR DESCRIPTION
## Summary

Fixes #87 — the `<wiki_status>` footer (and the `[wiki-session-notice]` banner it accompanies) duplicated 2x/3x/… on aborted or retried agent starts because context injection was not idempotent.

The `before_agent_start` hook appended the wiki-status footer **unconditionally**. When a turn fails to start (network error) or the user presses ESC and re-submits, the chained system prompt carries the prior injection forward — and the naive append stacks the same block on every retry.

## Change

- Extract the append into `extensions/llm-wiki/lib/inject.ts` (`appendWikiStatus` + exported `WIKI_STATUS_BLOCK`) so it is unit-testable in isolation.
- Make it **idempotent**: strip any already-present footer (with its leading blank line) before appending exactly one. The footer now appears exactly once regardless of how many aborted retries preceded the turn.
- `index.ts` calls `appendWikiStatus(injectedContext)` instead of the inline `+=`.

## Tests

`test/inject-idempotent.test.ts` (3 cases):
- appends to a clean prompt → exactly 1 block
- repeated (aborted-retry) injections → still exactly 1 block
- block already present mid-prompt → not re-appended

```
✓ test/inject-idempotent.test.ts (3 tests)
```

`tsc --noEmit` and `biome check` clean on the touched files.

> Note: 4 pre-existing failures in `test/runtime.test.ts` / `test/model-selection.test.ts` are unrelated to this change (config-reading tests sensitive to local `taskModel` config) and reproduce on `main`.

## Repro (before)

1. Open a session in a wiki-enabled project.
2. Submit a prompt; while the agent is starting, kill the network or press ESC.
3. Re-submit → `<wiki_status>` / session-notice now appears twice. Repeat → 3x, 4x…

After this change the footer is injected exactly once.

Refs #87