### PR TITLE
fix(#92): stop breaking the LLM provider prompt cache

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
-import { appendWikiStatus } from "./lib/inject.js";
+import { buildAgentStartInjection } from "./lib/inject.js";
 import { registerWikiModelCommand } from "./lib/model-command.js";
 import {
   buildSessionNotice,
@@ -216,7 +216,14 @@ export default function (pi: ExtensionAPI) {
     }
 
     const prompt = event.prompt || "";
-    let injectedContext = event.systemPrompt || "";
+    // Volatile, per-turn content (recall results + one-time topic-inference
+    // directive) MUST NOT go into the system prompt (issue #92). The system
+    // prompt is the provider's primary cache prefix; rewriting it every turn
+    // (recall is keyed on event.prompt, so it differs each turn) invalidates
+    // the whole prompt cache, forcing a full re-prompt-fill every turn. Collect
+    // it here and deliver it as a tail conversation message instead, which
+    // leaves the cached system-prompt prefix stable.
+    let dynamicContext = "";
 
     // Topic inference on first turn after auto-creation
     if (needsTopicInference && prompt.trim()) {
@@ -238,7 +245,7 @@ export default function (pi: ExtensionAPI) {
         // ignore
       }
 
-      injectedContext += `
+      dynamicContext += `
 
 ## Wiki Setup Required
 The LLM Wiki was just auto-created but needs its topic and mode configured. Before responding to the user, analyze their prompt and this project's context to infer:
@@ -279,7 +286,7 @@ Then call wiki_bootstrap with the inferred topic and mode to finalize the setup.
           skillInlineMax: runtime.config?.recallSkillInlineMax,
         });
         if (recallContext) {
-          injectedContext += `\n\n${recallContext}`;
+          dynamicContext += `\n\n${recallContext}`;
         }
         // Recall-aware status line (issue #77): make it visible that recall
         // actually fired and how many pages matched. Purely a UI signal — no
@@ -294,11 +301,19 @@ Then call wiki_bootstrap with the inferred topic and mode to finalize the setup.
       }
     }
 
-    // Always inject a visible wiki status footer, even when empty
-    // This ensures the model knows the wiki is active and can use it
-    injectedContext = appendWikiStatus(injectedContext);
+    // Split into a cache-stable system prompt (static footer only) and a
+    // volatile tail message (issue #92). See lib/inject.ts for the contract.
+    const { systemPrompt, message } = buildAgentStartInjection(event.systemPrompt || "", [
+      dynamicContext,
+    ]);
 
-    if (injectedContext === event.systemPrompt) return;
-    return { systemPrompt: injectedContext };
+    // Only claim a systemPrompt change when the footer actually altered the
+    // string (a carry-forward turn already carries it, so this no-ops).
+    const systemPromptChanged = systemPrompt !== event.systemPrompt;
+    if (!systemPromptChanged && !message) return;
+    return {
+      ...(systemPromptChanged ? { systemPrompt } : {}),
+      ...(message ? { message } : {}),
+    };
   });
 }

--- a/extensions/llm-wiki/lib/inject.ts
+++ b/extensions/llm-wiki/lib/inject.ts
@@ -1,11 +1,18 @@
 /**
- * System-prompt context injection primitives (issue #87).
+ * System-prompt context injection primitives (issues #87, #92).
  *
  * The `before_agent_start` hook augments the chained system prompt with a
  * visible wiki-status footer. This module isolates that append so it can be
  * unit-tested for idempotency — a turn that aborts (network error / ESC) and is
  * retried can carry the prior injection forward, and a naive append stacks the
  * footer 2x, 3x, ...
+ *
+ * It also owns the cache-safety split (issue #92): VOLATILE per-turn context
+ * (recall results, one-time topic-inference directive) must never enter the
+ * system prompt — that is the provider's primary cache prefix, so per-turn
+ * variation there forces a full cache miss every turn. Volatile content is
+ * routed into a tail conversation message instead. `buildAgentStartInjection`
+ * is the single, pure decision point for that split.
  */
 
 /** The always-injected wiki-status footer (sans surrounding whitespace). */
@@ -24,4 +31,55 @@ export const WIKI_STATUS_BLOCK =
 export function appendWikiStatus(systemPrompt: string): string {
   const base = systemPrompt.split(`\n\n${WIKI_STATUS_BLOCK}`).join("");
   return `${base}\n\n${WIKI_STATUS_BLOCK}`;
+}
+
+/** customType of the hidden tail message carrying volatile per-turn context. */
+export const WIKI_RECALL_MESSAGE_TYPE = "wiki-recall-context";
+
+/** A hidden, LLM-visible tail message carrying volatile per-turn wiki context. */
+export interface WikiRecallMessage {
+  customType: typeof WIKI_RECALL_MESSAGE_TYPE;
+  content: string;
+  display: false;
+}
+
+/** Result of the cache-safe split for one `before_agent_start` turn. */
+export interface AgentStartInjection {
+  /**
+   * The system prompt to return. ONLY ever the base plus the static footer —
+   * never any volatile content — so it is byte-identical turn over turn and
+   * the provider's prompt cache stays warm (issue #92).
+   */
+  systemPrompt: string;
+  /** Volatile blocks, delivered as a tail message. Omitted when empty. */
+  message?: WikiRecallMessage;
+}
+
+/**
+ * Split a turn's injection into a cache-stable system prompt and a volatile
+ * tail message (issue #92).
+ *
+ * - `systemPrompt` is always `appendWikiStatus(baseSystemPrompt)` — the static
+ *   footer only. It carries NONE of `dynamicBlocks`, so it does not vary with
+ *   recall results and never breaks the provider cache prefix.
+ * - `dynamicBlocks` (recall context, topic-inference directive, ...) are
+ *   trimmed, emptied entries dropped, and joined with a blank line into the
+ *   message body. When nothing survives, no message is emitted.
+ *
+ * Pure and side-effect free — see test/agent-start-injection.test.ts.
+ */
+export function buildAgentStartInjection(
+  baseSystemPrompt: string,
+  dynamicBlocks: Array<string | undefined>,
+): AgentStartInjection {
+  const systemPrompt = appendWikiStatus(baseSystemPrompt);
+  const content = dynamicBlocks
+    .map((b) => b?.trim())
+    .filter((b): b is string => Boolean(b))
+    .join("\n\n");
+  if (!content) return { systemPrompt };
+  return {
+    systemPrompt,
+    message: { customType: WIKI_RECALL_MESSAGE_TYPE, content, display: false },
+  };
 }

--- a/test/agent-start-injection.test.ts
+++ b/test/agent-start-injection.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  WIKI_RECALL_MESSAGE_TYPE,
+  WIKI_STATUS_BLOCK,
+  buildAgentStartInjection,
+} from "../extensions/llm-wiki/lib/inject.js";
+
+/**
+ * Cache-safety contract for the `before_agent_start` injection (issue #92).
+ *
+ * The system prompt is the LLM provider's primary cache prefix. Any per-turn
+ * variation in it forces a full cache miss (re-prompt-fill) every turn. The
+ * extension's recall results are keyed on the user's prompt, so they differ
+ * every turn — they MUST NOT land in the system prompt. They ride in a tail
+ * conversation message instead, which never invalidates the cached prefix.
+ *
+ * These tests pin that contract so the regression can never silently return.
+ */
+describe("buildAgentStartInjection (issue #92 cache safety)", () => {
+  const BASE = "You are a helpful agent.";
+  const RECALL_A = "## Relevant Wiki Knowledge\n1. [[page-a]] — score 99";
+  const RECALL_B = "## Relevant Wiki Knowledge\n1. [[page-b]] — score 42";
+
+  it("the returned systemPrompt is INVARIANT across different volatile content", () => {
+    // The core regression guard: whatever the recall result is, the system
+    // prompt the provider caches must be byte-identical turn over turn.
+    const a = buildAgentStartInjection(BASE, [RECALL_A]);
+    const b = buildAgentStartInjection(BASE, [RECALL_B]);
+    expect(a.systemPrompt).toBe(b.systemPrompt);
+  });
+
+  it("the systemPrompt never contains the volatile recall content", () => {
+    const { systemPrompt } = buildAgentStartInjection(BASE, [RECALL_A]);
+    expect(systemPrompt).not.toContain("Relevant Wiki Knowledge");
+    expect(systemPrompt).not.toContain("page-a");
+  });
+
+  it("the systemPrompt is exactly the base plus the static footer", () => {
+    const { systemPrompt } = buildAgentStartInjection(BASE, [RECALL_A]);
+    expect(systemPrompt).toBe(`${BASE}\n\n${WIKI_STATUS_BLOCK}`);
+  });
+
+  it("volatile blocks ride in a hidden tail message, joined in order", () => {
+    const topic = "## Wiki Setup Required\ninfer topic";
+    const { message } = buildAgentStartInjection(BASE, [topic, RECALL_A]);
+    expect(message).toBeDefined();
+    expect(message?.customType).toBe(WIKI_RECALL_MESSAGE_TYPE);
+    expect(message?.display).toBe(false);
+    expect(message?.content).toBe(`${topic}\n\n${RECALL_A}`);
+  });
+
+  it("emits no message when there is no volatile content", () => {
+    expect(buildAgentStartInjection(BASE, []).message).toBeUndefined();
+    expect(buildAgentStartInjection(BASE, [undefined, "", "   "]).message).toBeUndefined();
+  });
+
+  it("does not stack the footer on carry-forward (retry-safe)", () => {
+    // A turn that aborts can carry the prior (footer-bearing) system prompt
+    // back in; re-running must still yield exactly one footer.
+    const once = buildAgentStartInjection(BASE, []).systemPrompt;
+    const twice = buildAgentStartInjection(once, []).systemPrompt;
+    expect(twice).toBe(once);
+    expect(twice.split(WIKI_STATUS_BLOCK)).toHaveLength(2); // appears exactly once
+  });
+});

--- a/test/model-selection.test.ts
+++ b/test/model-selection.test.ts
@@ -65,6 +65,7 @@ describe("parseModelRef", () => {
 // ── persistTaskModel (round-trips through loadTaskConfig) ──
 describe("persistTaskModel", () => {
   let tmpDir: string;
+  let priorAgentDir: string | undefined;
   beforeEach(() => {
     tmpDir = join(
       import.meta.dirname,
@@ -73,8 +74,18 @@ describe("persistTaskModel", () => {
       `modelsel-${Date.now()}-${Math.random().toString(36).slice(2)}`,
     );
     mkdirSync(tmpDir, { recursive: true });
+    // Hermetic isolation: loadTaskConfig merges the global agent-dir settings,
+    // so point it at an empty dir to keep a developer's real
+    // ~/.pi/agent/settings.json from leaking a taskModel (issue #92 follow-up).
+    priorAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(tmpDir, "agent-home");
   });
-  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+  afterEach(() => {
+    // biome-ignore lint/performance/noDelete: must truly unset; assigning undefined sets the string "undefined" in Node
+    if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
 
   it("writes taskModel to project .pi/settings.json and loadTaskConfig reads it back", () => {
     persistTaskModel(tmpDir, { provider: "anthropic", id: "claude-haiku" });

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -47,6 +47,7 @@ function makeRegistry(opts: {
 // ── task-config ───────────────────────────────────────────
 describe("loadTaskConfig", () => {
   let tmpDir: string;
+  let priorAgentDir: string | undefined;
 
   beforeEach(() => {
     tmpDir = join(
@@ -56,8 +57,19 @@ describe("loadTaskConfig", () => {
       `taskcfg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
     );
     mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    // Hermetic isolation: loadTaskConfig merges the global agent-dir
+    // settings (getAgentDir()/settings.json). Point it at an empty dir so a
+    // developer's real ~/.pi/agent/settings.json can't leak a taskModel into
+    // these assertions (issue #92 follow-up).
+    priorAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(tmpDir, "agent-home");
   });
-  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+  afterEach(() => {
+    // biome-ignore lint/performance/noDelete: must truly unset; assigning undefined sets the string "undefined" in Node
+    if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
 
   it("returns empty config (no taskModel) when nothing is set", () => {
     const cfg = loadTaskConfig(tmpDir);


### PR DESCRIPTION
Fixes #92.

## Symptom
With the extension active, every LLM request had to be prompt-filled from scratch — provider prompt caching never hit. @tiberiuichim uninstalled the extension because of it.

## Root cause
The `before_agent_start` hook rewrote `event.systemPrompt` **every turn**, appending recall results that are keyed on the user's prompt (`searchWikiHybrid(paths, prompt, …)`), so the injected block differs every turn.

The system prompt is the provider's **primary cache prefix** — Anthropic/OpenAI key prompt caching on an exact prefix match. The framework applies the hook's result via `agent.state.systemPrompt = result.systemPrompt` each turn, so a per-turn-varying system prompt means the cached prefix changes every turn → guaranteed 100% cache miss → full re-prompt-fill on every request.

## Fix
Split the injection into a **cache-stable system prompt** and a **volatile tail message**.

New pure function `buildAgentStartInjection` (`lib/inject.ts`):
- System prompt gets **only** the static `WIKI_STATUS_BLOCK` footer → byte-identical turn over turn → cached once, never breaks the prefix.
- All volatile content (recall context + one-time topic-inference directive) is routed into a hidden `role: "custom"` message. The framework's `convertToLlm` turns that into a `role: "user"` message at the conversation tail, so the model still sees recall, and the cached prefix grows monotonically and stays warm.

This is the standard place for per-turn context — tail messages, not the cached system prefix.

## Tests (TDD, red → green)
`test/agent-start-injection.test.ts` pins the cache-safety contract:
- returned `systemPrompt` is **invariant** across different recall content (the core regression guard),
- `systemPrompt` never contains volatile content and equals `base + footer`,
- volatile blocks ride in the message (joined in order, `display: false`),
- footer stays idempotent on retry/carry-forward.

## Drive-by: hermetic config tests
`loadTaskConfig`/`persistTaskModel` tests merged the developer's real global `~/.pi/agent/settings.json` (via `getAgentDir()`), so a locally configured `taskModel` leaked into assertions and failed them on a real machine. They now isolate `PI_CODING_AGENT_DIR`.

## Verification
- `npm run typecheck` — clean
- `npm run lint` (biome, 58 files) — clean
- `npm test` — **348 passing** (was 342 + 6 new)