### PR TITLE
fix(ci): publish with --no-git-checks so releases stop aborting on dirty tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Publish to npm
-        run: pnpm publish --provenance --access public
+        run: pnpm publish --provenance --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Symptom
The **Release** workflow for tag `v0.10.0` failed at the publish step ([run 28472873311](https://github.com/zosmaai/pi-llm-wiki/actions/runs/28472873311)). The tag is pushed but npm is still stuck at `0.9.3`.

## Root cause
```
ERR_PNPM_GIT_UNCLEAN  Unclean working tree. Commit or stash changes first.
```
The `Update package.json version` step rewrites `package.json` (and runs `biome check --fix`) right before publishing, **intentionally without committing** — the git tag is the release source of truth. That leaves the working tree dirty, so `pnpm publish`'s default git-clean check aborts.

## Fix
Add `--no-git-checks` to the publish step — pnpm's documented escape hatch, literally suggested in the error message. The version is already pinned from the tag, so the git-clean guard buys nothing here.

```diff
- run: pnpm publish --provenance --access public
+ run: pnpm publish --provenance --access public --no-git-checks
```

## After merge — to actually publish 0.10.0
The `v0.10.0` tag points at the pre-fix commit, so re-running the old run won't pick up this change. Move the tag to the fixed commit (npm never received 0.10.0, and the failed run never created a GitHub Release, so this is clean):
```bash
git tag -f v0.10.0 origin/main   # after this merges
git push origin v0.10.0 --force
```
Or just cut `v0.10.1`.