### PR TITLE
fix(mcp): make llm-wiki MCP server bootable

### DIFF
--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -14,8 +14,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { McpServer } from "@modelcontextprotocol/server";
-import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { McpServer, StdioServerTransport } from "@modelcontextprotocol/server";
 import * as z from "zod/v4";
 
 // ─── Wiki Vault Detection ──────────────────────────────

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "prompts": ["./prompts"],
     "image": "https://raw.githubusercontent.com/zosmaai/pi-llm-wiki/main/assets/screenshot.png",
     "mcpservers": {
-      "llm-wiki": "node ./mcp/index.js"
+      "llm-wiki": "node ./mcp/index.ts"
     }
   },
   "peerDependencies": {
@@ -77,8 +77,10 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
     "@modelcontextprotocol/server": "^2.0.0-alpha.2",
-    "node-html-markdown": "^2.0.0"
+    "node-html-markdown": "^2.0.0",
+    "zod": "^4.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@cfworker/json-schema':
+        specifier: ^4.1.1
+        version: 4.1.1
       '@modelcontextprotocol/server':
         specifier: ^2.0.0-alpha.2
-        version: 2.0.0-alpha.2
+        version: 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
       node-html-markdown:
         specifier: ^2.0.0
         version: 2.0.0
+      zod:
+        specifier: ^4.0
+        version: 4.4.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -252,6 +258,9 @@ packages:
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
@@ -2821,6 +2830,8 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@cfworker/json-schema@4.1.1': {}
+
   '@chevrotain/types@11.1.2': {}
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -3192,9 +3203,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/server@2.0.0-alpha.2':
+  '@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1)':
     dependencies:
       zod: 4.4.3
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
 
   '@napi-rs/canvas-android-arm64@0.1.100':
     optional: true


### PR DESCRIPTION
## Problem
The `llm-wiki` MCP server declared in `package.json` (`pi.mcpservers`) could not start. Three independent breakages:

1. **Missing runtime deps.** `mcp/index.ts` / the MCP SDK import packages that aren't declared:
   - `@cfworker/json-schema` — an *optional* peer of `@modelcontextprotocol/server`, but the SDK imports it **unconditionally** at boot → `ERR_MODULE_NOT_FOUND`.
   - `zod` — the server imports `zod/v4` directly but only had it transitively.
2. **Wrong import path.** `StdioServerTransport` was imported from `@modelcontextprotocol/server/stdio`, but `2.0.0-alpha.2` does not export that subpath — it exports `StdioServerTransport` from the package **root**.
3. **Entrypoint pointed at a non-existent `.js`.** `mcpservers` ran `node ./mcp/index.js`, but the package is TS-native (only `mcp/index.ts` exists, no build step). Pointed it at `mcp/index.ts`.

## Fix
- Add `@cfworker/json-schema` and `zod` to `dependencies`.
- Import `McpServer, StdioServerTransport` from the package root.
- `mcpservers.llm-wiki` → `node ./mcp/index.ts`.

## Verification
- `pnpm run typecheck` — clean
- `pnpm run lint` (biome) — clean
- `pnpm test` — **348 tests pass**
- MCP server boots over stdio and lists all 5 tools: `wiki_recall, wiki_search, wiki_status, wiki_retro, wiki_capture_source`