### PR TITLE
fix: replace broken star-history.com embed with self-generated SVG chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,37 @@
+# Generates a star history chart SVG from GitHub stargazer data.
+# Uses GITHUB_TOKEN (authenticated) to bypass the stargazers API restriction.
+# The resulting SVG is committed to assets/star-history.svg so it never breaks.
+name: Star History
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # weekly on Sunday
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/generate-star-history.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add assets/star-history.svg
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update star history chart"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -16,19 +16,7 @@
 
 <br/>
 
-<div align="center">
-  <a href="https://github.com/zosmaai/pi-llm-wiki/stargazers">
-    <img src="./assets/thank-you-for-the-star.png" alt="Thank you for starring pi-llm-wiki!" width="100%" />
-  </a>
-  <br/>
-  <sub>
-    If you find pi-llm-wiki useful,
-    <a href="https://github.com/zosmaai/pi-llm-wiki">⭐ star the repo</a> —
-    it lets us know we're building something that matters.
-  </sub>
-</div>
 
-<br/>
 
 **Self-maintaining, Obsidian-compatible knowledge base for [pi](https://pi.dev).**
 Follows Andrej Karpathy's [LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
@@ -402,9 +390,25 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, test patterns, and
 
 ---
 
+<div align="center">
+  <a href="https://github.com/zosmaai/pi-llm-wiki/stargazers">
+    <img src="./assets/thank-you-for-the-star.png" alt="Thank you for starring pi-llm-wiki!" width="100%" />
+  </a>
+  <br/>
+  <sub>
+    If you find pi-llm-wiki useful,
+    <a href="https://github.com/zosmaai/pi-llm-wiki">⭐ star the repo</a> —
+    it lets us know we're building something that matters.
+  </sub>
+</div>
+
+<br/>
+
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zosmaai/pi-llm-wiki&type=Date)](https://star-history.com/#zosmaai/pi-llm-wiki&Date)
+<img src="./assets/star-history.svg" alt="Star History Chart" width="100%" />
+
+_Chart auto-updates weekly via [GitHub Action](./.github/workflows/star-history.yml)._
 
 ## Contributors
 

--- a/assets/star-history.svg
+++ b/assets/star-history.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 280" width="800" height="280">
+  <defs>
+    <linearGradient id="gradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="280" fill="#ffffff" rx="8"/>
+  <text x="55" y="18" fill="#0f172a" font-size="13" font-weight="600" font-family="system-ui,sans-serif">★ Star History — zosmaai/pi-llm-wiki</text>
+  <text x="770" y="18" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">181 stars total</text>
+  <line x1="55" y1="230" x2="770" y2="230" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="47" y="234" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">0</text>
+  <line x1="55" y1="174.75138121546962" x2="770" y2="174.75138121546962" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="47" y="178.75138121546962" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">50</text>
+  <line x1="55" y1="119.50276243093921" x2="770" y2="119.50276243093921" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="47" y="123.50276243093921" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">100</text>
+  <line x1="55" y1="64.25414364640883" x2="770" y2="64.25414364640883" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="47" y="68.25414364640883" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">150</text>
+  <line x1="55" y1="30" x2="770" y2="30" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="47" y="34" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">181</text>
+  <text x="55" y="248" text-anchor="end" fill="#64748b" font-size="10" font-family="system-ui,sans-serif" transform="rotate(-30,55,248)">Apr 26</text>
+  <text x="293.3333333333333" y="248" text-anchor="end" fill="#64748b" font-size="10" font-family="system-ui,sans-serif" transform="rotate(-30,293.3333333333333,248)">May 26</text>
+  <text x="531.6666666666666" y="248" text-anchor="end" fill="#64748b" font-size="10" font-family="system-ui,sans-serif" transform="rotate(-30,531.6666666666666,248)">Jun 26</text>
+  <text x="770" y="248" text-anchor="end" fill="#64748b" font-size="10" font-family="system-ui,sans-serif" transform="rotate(-30,770,248)">Jul 26</text>
+  <polygon points="55,227.79005524861878 293.3333333333333,185.8011049723757 531.6666666666666,45.469613259668506 770,30 770,230 55,230" fill="url(#gradient)" opacity="0.15"/>
+  <polyline points="55,227.79005524861878 293.3333333333333,185.8011049723757 531.6666666666666,45.469613259668506 770,30" fill="none" stroke="#3b82f6" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+  <circle cx="55" cy="227.79005524861878" r="2.5" fill="#3b82f6"/>
+  <circle cx="293.3333333333333" cy="185.8011049723757" r="2.5" fill="#3b82f6"/>
+  <circle cx="531.6666666666666" cy="45.469613259668506" r="2.5" fill="#3b82f6"/>
+  <circle cx="770" cy="30" r="2.5" fill="#3b82f6"/>
+</svg>

--- a/scripts/generate-star-history.mjs
+++ b/scripts/generate-star-history.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Generate a star history SVG chart for a GitHub repo.
+ * Uses GITHUB_TOKEN from env (falls back to unauthenticated).
+ *
+ * Usage:
+ *   GITHUB_TOKEN=ghp_xxx node scripts/generate-star-history.mjs <owner/repo> [output.svg]
+ *
+ * Default output: assets/star-history.svg (relative to repo root, via GITHUB_WORKSPACE)
+ */
+
+const OWNER_REPO = process.argv[2] || (process.env.GITHUB_REPOSITORY || 'zosmaai/zosma-cowork');
+const OUTPUT = process.argv[3]
+  || `${process.env.GITHUB_WORKSPACE || '.'}/assets/star-history.svg`;
+const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+const WIDTH = 800;
+const HEIGHT = 280;
+const PAD = { top: 30, right: 30, bottom: 50, left: 55 };
+const CHART_W = WIDTH - PAD.left - PAD.right;
+const CHART_H = HEIGHT - PAD.top - PAD.bottom;
+
+async function fetchPaginated(url) {
+  const items = [];
+  let next = url;
+  while (next) {
+    const res = await fetch(next, {
+      headers: {
+        'Accept': 'application/vnd.github.v3.star+json',
+        ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+        'User-Agent': 'star-history-generator',
+      },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`HTTP ${res.status} ${res.statusText}: ${body.slice(0, 200)}`);
+    }
+    const data = await res.json();
+    items.push(...data);
+    const link = res.headers.get('link') || '';
+    const m = link.match(/<([^>]+)>;\s*rel="next"/);
+    next = m ? m[1] : null;
+  }
+  return items;
+}
+
+function aggregateByMonth(stargazers) {
+  const map = {};
+  for (const s of stargazers) {
+    const key = s.starred_at ? s.starred_at.slice(0, 7) : 'unknown';
+    map[key] = (map[key] || 0) + 1;
+  }
+  const sorted = Object.entries(map).sort(([a], [b]) => a.localeCompare(b));
+  let cumulative = 0;
+  return sorted.map(([month, count]) => {
+    cumulative += count;
+    return { month, count, cumulative };
+  });
+}
+
+function svgChart(data, repo) {
+  const n = data.length;
+  const cumulativeTotal = n > 0 ? data[n - 1].cumulative : 0;
+
+  // X axis: show a subset of labels
+  const maxLabels = Math.min(n, 12);
+  const labelStep = Math.max(1, Math.floor(n / maxLabels));
+
+  // Y axis ticks
+  const yMax = Math.max(...data.map(d => d.cumulative), 1);
+  const yStep = yMax <= 5 ? 1 : yMax <= 20 ? 5 : yMax <= 100 ? 10 : yMax <= 500 ? 50 : yMax <= 1000 ? 100 : 500;
+  const yTicks = [];
+  for (let v = 0; v <= yMax; v += yStep) yTicks.push(v);
+  if (yTicks[yTicks.length - 1] < yMax) yTicks.push(yMax);
+
+  const xScale = (i) => PAD.left + (i / Math.max(n - 1, 1)) * CHART_W;
+  const yScale = (v) => PAD.top + CHART_H - (v / yMax) * CHART_H;
+
+  const points = data.map((d, i) => `${xScale(i)},${yScale(d.cumulative)}`).join(' ');
+
+  const lines = [];
+
+  // Y axis grid lines + labels
+  for (const v of yTicks) {
+    const y = yScale(v);
+    lines.push(`<line x1="${PAD.left}" y1="${y}" x2="${WIDTH - PAD.right}" y2="${y}" stroke="#e2e8f0" stroke-width="1"/>`);
+    lines.push(`<text x="${PAD.left - 8}" y="${y + 4}" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">${v}</text>`);
+  }
+
+  // X axis labels
+  for (let i = 0; i < n; i++) {
+    if (i % labelStep !== 0 && i !== n - 1) continue;
+    const x = xScale(i);
+    // Short label: "Jan '24"
+    const d = new Date(data[i].month + '-01');
+    const label = d.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+    lines.push(`<text x="${x}" y="${HEIGHT - PAD.bottom + 18}" text-anchor="end" fill="#64748b" font-size="10" font-family="system-ui,sans-serif" transform="rotate(-30,${x},${HEIGHT - PAD.bottom + 18})">${label}</text>`);
+  }
+
+  // Fill area under line
+  const fillPoints = points + ` ${xScale(n - 1)},${yScale(0)} ${xScale(0)},${yScale(0)}`;
+  lines.push(`<polygon points="${fillPoints}" fill="url(#gradient)" opacity="0.15"/>`);
+
+  // Line
+  lines.push(`<polyline points="${points}" fill="none" stroke="#3b82f6" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>`);
+
+  // Dots
+  if (n <= 36) {
+    for (let i = 0; i < n; i++) {
+      lines.push(`<circle cx="${xScale(i)}" cy="${yScale(data[i].cumulative)}" r="2.5" fill="#3b82f6"/>`);
+    }
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="${WIDTH}" height="${HEIGHT}">
+  <defs>
+    <linearGradient id="gradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="#ffffff" rx="8"/>
+  <text x="${PAD.left}" y="18" fill="#0f172a" font-size="13" font-weight="600" font-family="system-ui,sans-serif">★ Star History — ${repo}</text>
+  <text x="${WIDTH - PAD.right}" y="18" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">${cumulativeTotal} stars total</text>
+  ${lines.join('\n  ')}
+</svg>`;
+}
+
+async function main() {
+  try {
+    const stargazers = await fetchPaginated(
+      `https://api.github.com/repos/${OWNER_REPO}/stargazers?per_page=100`
+    );
+    const data = aggregateByMonth(stargazers);
+    if (data.length === 0) throw new Error('No stargazer data returned');
+
+    const svg = svgChart(data, OWNER_REPO);
+
+    // Ensure output directory exists
+    const fs = await import('fs');
+    const path = await import('path');
+    fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+    fs.writeFileSync(OUTPUT, svg, 'utf-8');
+
+    console.log(`✅ Star history chart saved to ${OUTPUT}`);
+    console.log(`   Repo: ${OWNER_REPO}, Total stars: ${data[data.length - 1].cumulative}, Months: ${data.length}`);
+  } catch (err) {
+    console.error(`❌ Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/generate-star-history.mjs
+++ b/scripts/generate-star-history.mjs
@@ -9,9 +9,8 @@
  * Default output: assets/star-history.svg (relative to repo root, via GITHUB_WORKSPACE)
  */
 
-const OWNER_REPO = process.argv[2] || (process.env.GITHUB_REPOSITORY || 'zosmaai/zosma-cowork');
-const OUTPUT = process.argv[3]
-  || `${process.env.GITHUB_WORKSPACE || '.'}/assets/star-history.svg`;
+const OWNER_REPO = process.argv[2] || process.env.GITHUB_REPOSITORY || "zosmaai/zosma-cowork";
+const OUTPUT = process.argv[3] || `${process.env.GITHUB_WORKSPACE || "."}/assets/star-history.svg`;
 const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 
 const WIDTH = 800;
@@ -26,9 +25,9 @@ async function fetchPaginated(url) {
   while (next) {
     const res = await fetch(next, {
       headers: {
-        'Accept': 'application/vnd.github.v3.star+json',
+        Accept: "application/vnd.github.v3.star+json",
         ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
-        'User-Agent': 'star-history-generator',
+        "User-Agent": "star-history-generator",
       },
     });
     if (!res.ok) {
@@ -37,7 +36,7 @@ async function fetchPaginated(url) {
     }
     const data = await res.json();
     items.push(...data);
-    const link = res.headers.get('link') || '';
+    const link = res.headers.get("link") || "";
     const m = link.match(/<([^>]+)>;\s*rel="next"/);
     next = m ? m[1] : null;
   }
@@ -47,7 +46,7 @@ async function fetchPaginated(url) {
 function aggregateByMonth(stargazers) {
   const map = {};
   for (const s of stargazers) {
-    const key = s.starred_at ? s.starred_at.slice(0, 7) : 'unknown';
+    const key = s.starred_at ? s.starred_at.slice(0, 7) : "unknown";
     map[key] = (map[key] || 0) + 1;
   }
   const sorted = Object.entries(map).sort(([a], [b]) => a.localeCompare(b));
@@ -67,8 +66,9 @@ function svgChart(data, repo) {
   const labelStep = Math.max(1, Math.floor(n / maxLabels));
 
   // Y axis ticks
-  const yMax = Math.max(...data.map(d => d.cumulative), 1);
-  const yStep = yMax <= 5 ? 1 : yMax <= 20 ? 5 : yMax <= 100 ? 10 : yMax <= 500 ? 50 : yMax <= 1000 ? 100 : 500;
+  const yMax = Math.max(...data.map((d) => d.cumulative), 1);
+  const yStep =
+    yMax <= 5 ? 1 : yMax <= 20 ? 5 : yMax <= 100 ? 10 : yMax <= 500 ? 50 : yMax <= 1000 ? 100 : 500;
   const yTicks = [];
   for (let v = 0; v <= yMax; v += yStep) yTicks.push(v);
   if (yTicks[yTicks.length - 1] < yMax) yTicks.push(yMax);
@@ -76,15 +76,19 @@ function svgChart(data, repo) {
   const xScale = (i) => PAD.left + (i / Math.max(n - 1, 1)) * CHART_W;
   const yScale = (v) => PAD.top + CHART_H - (v / yMax) * CHART_H;
 
-  const points = data.map((d, i) => `${xScale(i)},${yScale(d.cumulative)}`).join(' ');
+  const points = data.map((d, i) => `${xScale(i)},${yScale(d.cumulative)}`).join(" ");
 
   const lines = [];
 
   // Y axis grid lines + labels
   for (const v of yTicks) {
     const y = yScale(v);
-    lines.push(`<line x1="${PAD.left}" y1="${y}" x2="${WIDTH - PAD.right}" y2="${y}" stroke="#e2e8f0" stroke-width="1"/>`);
-    lines.push(`<text x="${PAD.left - 8}" y="${y + 4}" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">${v}</text>`);
+    lines.push(
+      `<line x1="${PAD.left}" y1="${y}" x2="${WIDTH - PAD.right}" y2="${y}" stroke="#e2e8f0" stroke-width="1"/>`,
+    );
+    lines.push(
+      `<text x="${PAD.left - 8}" y="${y + 4}" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">${v}</text>`,
+    );
   }
 
   // X axis labels
@@ -92,22 +96,28 @@ function svgChart(data, repo) {
     if (i % labelStep !== 0 && i !== n - 1) continue;
     const x = xScale(i);
     // Short label: "Jan '24"
-    const d = new Date(data[i].month + '-01');
-    const label = d.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
-    lines.push(`<text x="${x}" y="${HEIGHT - PAD.bottom + 18}" text-anchor="end" fill="#64748b" font-size="10" font-family="system-ui,sans-serif" transform="rotate(-30,${x},${HEIGHT - PAD.bottom + 18})">${label}</text>`);
+    const d = new Date(`${data[i].month}-01`);
+    const label = d.toLocaleDateString("en-US", { month: "short", year: "2-digit" });
+    lines.push(
+      `<text x="${x}" y="${HEIGHT - PAD.bottom + 18}" text-anchor="end" fill="#64748b" font-size="10" font-family="system-ui,sans-serif" transform="rotate(-30,${x},${HEIGHT - PAD.bottom + 18})">${label}</text>`,
+    );
   }
 
   // Fill area under line
-  const fillPoints = points + ` ${xScale(n - 1)},${yScale(0)} ${xScale(0)},${yScale(0)}`;
+  const fillPoints = `${points} ${xScale(n - 1)},${yScale(0)} ${xScale(0)},${yScale(0)}`;
   lines.push(`<polygon points="${fillPoints}" fill="url(#gradient)" opacity="0.15"/>`);
 
   // Line
-  lines.push(`<polyline points="${points}" fill="none" stroke="#3b82f6" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>`);
+  lines.push(
+    `<polyline points="${points}" fill="none" stroke="#3b82f6" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>`,
+  );
 
   // Dots
   if (n <= 36) {
     for (let i = 0; i < n; i++) {
-      lines.push(`<circle cx="${xScale(i)}" cy="${yScale(data[i].cumulative)}" r="2.5" fill="#3b82f6"/>`);
+      lines.push(
+        `<circle cx="${xScale(i)}" cy="${yScale(data[i].cumulative)}" r="2.5" fill="#3b82f6"/>`,
+      );
     }
   }
 
@@ -121,28 +131,30 @@ function svgChart(data, repo) {
   <rect width="${WIDTH}" height="${HEIGHT}" fill="#ffffff" rx="8"/>
   <text x="${PAD.left}" y="18" fill="#0f172a" font-size="13" font-weight="600" font-family="system-ui,sans-serif">★ Star History — ${repo}</text>
   <text x="${WIDTH - PAD.right}" y="18" text-anchor="end" fill="#64748b" font-size="11" font-family="system-ui,sans-serif">${cumulativeTotal} stars total</text>
-  ${lines.join('\n  ')}
+  ${lines.join("\n  ")}
 </svg>`;
 }
 
 async function main() {
   try {
     const stargazers = await fetchPaginated(
-      `https://api.github.com/repos/${OWNER_REPO}/stargazers?per_page=100`
+      `https://api.github.com/repos/${OWNER_REPO}/stargazers?per_page=100`,
     );
     const data = aggregateByMonth(stargazers);
-    if (data.length === 0) throw new Error('No stargazer data returned');
+    if (data.length === 0) throw new Error("No stargazer data returned");
 
     const svg = svgChart(data, OWNER_REPO);
 
     // Ensure output directory exists
-    const fs = await import('fs');
-    const path = await import('path');
+    const fs = await import("node:fs");
+    const path = await import("node:path");
     fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
-    fs.writeFileSync(OUTPUT, svg, 'utf-8');
+    fs.writeFileSync(OUTPUT, svg, "utf-8");
 
     console.log(`✅ Star history chart saved to ${OUTPUT}`);
-    console.log(`   Repo: ${OWNER_REPO}, Total stars: ${data[data.length - 1].cumulative}, Months: ${data.length}`);
+    console.log(
+      `   Repo: ${OWNER_REPO}, Total stars: ${data[data.length - 1].cumulative}, Months: ${data.length}`,
+    );
   } catch (err) {
     console.error(`❌ Error: ${err.message}`);
     process.exit(1);


### PR DESCRIPTION
## Why

The `api.star-history.com` endpoint is broken for most repos (returns 503: _All GitHub API tokens are rate-limited_). GitHub restricted the stargazers API for unauthenticated requests, so free star-history service can't keep up.

## What

1. **New `scripts/generate-star-history.mjs`** — fetches stargazer data via the GitHub API (using `GITHUB_TOKEN`, authenticated requests bypass the restriction) and generates a clean SVG line chart
2. **New `.github/workflows/star-history.yml`** — runs weekly (Sunday) and on pushes to main to regenerate `assets/star-history.svg` and commit it. The chart is a static asset in the repo, **never depends on a third-party service**, and can't break.
3. **README updates**:
   - Replaced the broken star-history.com embed with `<img src="./assets/star-history.svg" />`
   - Moved the "thank you for the star" banner + CTA from the top to just before the Star History section at the bottom

## Why this works

The GITHUB_TOKEN in a workflow has access to its own repo's stargazers data — the restriction only affects **unauthenticated** requests. No external API, no rate limits, always loads.

## Preview

The generated chart is a clean SVG with gradient fill, grid lines, and per-month data points.