### PR TITLE
test(#80): validate trajectory opt-in with command-handler + docs tests

### DIFF
--- a/test/package-structure.test.ts
+++ b/test/package-structure.test.ts
@@ -141,6 +141,16 @@ describe("package structure", () => {
     expect(sourceExtractors).toContain("pdfExtractionFailureMessage");
   });
 
+  it("should document opt-in trajectory workflow in docs/api.md (issue #80, criterion #7)", () => {
+    const api = readFile(join(rootDir, "docs", "api.md"));
+    expect(api).toContain("wiki_capture_trajectory");
+    expect(api).toContain("wiki_retro");
+    expect(api).toContain("wiki_observe");
+    expect(api).toContain("opt-in");
+    expect(api).toContain("off by default");
+    expect(api).toContain("working-memory");
+  });
+
   it("should have a comprehensive README with install instructions", () => {
     const readme = readFile(join(rootDir, "README.md"));
     expect(readme).toContain("@zosmaai/pi-llm-wiki");
@@ -169,6 +179,16 @@ describe("skill frontmatter validation", () => {
     expect(name.length).toBeLessThanOrEqual(64);
     expect(name).not.toContain("--");
     expect(name).not.toMatch(/^-|-$/);
+  });
+
+  it("should contain the agent working-memory decision table (issue #80, criterion #7)", () => {
+    const content = readFile(skillPath);
+    expect(content).toContain("When to use which memory tool");
+    expect(content).toContain("wiki_capture_trajectory");
+    expect(content).toContain("wiki_retro");
+    expect(content).toContain("wiki_observe");
+    expect(content).toContain("replayable");
+    expect(content).toContain("prose **insight");
   });
 
   it("should have a description under 1024 characters", () => {

--- a/test/trajectories-command.test.ts
+++ b/test/trajectories-command.test.ts
@@ -1,0 +1,224 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  loadTaskConfig,
+  persistTaskModel,
+  trajectoriesEnabled,
+} from "../extensions/llm-wiki/lib/task-config.js";
+import { registerWikiTrajectoriesCommand } from "../extensions/llm-wiki/lib/trajectories-command.js";
+
+/**
+ * Issue #80: unit tests for the /wiki-trajectories command handler.
+ *
+ * The handler is registered as a pi command closure. These tests capture it
+ * through a minimal fake pi and drive it with a fake ctx.
+ */
+
+interface NotifyCall {
+  message: string;
+  type: string;
+}
+
+type Handler = (args: string, ctx: Record<string, unknown>) => Promise<void>;
+
+function captureHandler(): Handler {
+  let handler: Handler | undefined;
+  const fakePi = {
+    registerCommand: (_name: string, descriptor: { handler: Handler }) => {
+      handler = descriptor.handler;
+    },
+  };
+  registerWikiTrajectoriesCommand(fakePi as never);
+  if (!handler) throw new Error("handler was not registered");
+  return handler;
+}
+
+function fakeCtx(
+  overrides: Partial<{
+    cwd: string;
+    notify: (message: string, type: string) => void;
+    reload: () => Promise<void>;
+  }>,
+): Record<string, unknown> {
+  const notifications: NotifyCall[] = [];
+  let reloadCalled = false;
+  const ctx = {
+    cwd: overrides.cwd ?? process.cwd(),
+    ui: {
+      notify:
+        overrides.notify ??
+        ((message: string, type: string) => notifications.push({ message, type })),
+    },
+    reload:
+      overrides.reload ??
+      (async () => {
+        reloadCalled = true;
+      }),
+    // Expose for test assertions
+    _notifications: notifications,
+    _reloadCalled: () => reloadCalled,
+  };
+  return ctx;
+}
+
+describe("/wiki-trajectories command (issue #80)", () => {
+  let tmpDir: string;
+  let handler: Handler;
+
+  beforeAll(() => {
+    handler = captureHandler();
+  });
+
+  beforeEach(() => {
+    tmpDir = join(import.meta.dirname, "..", "tmp", `trj-cmd-${Date.now()}-${Math.random()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("shows 'OFF' when no args and trajectories are disabled (default)", async () => {
+    const notifications: NotifyCall[] = [];
+    const ctx = fakeCtx({
+      cwd: tmpDir,
+      notify: (m, t) => notifications.push({ message: m, type: t }),
+    });
+    await handler("", ctx);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].message).toMatch(/OFF/i);
+    expect(notifications[0].type).toBe("info");
+  });
+
+  it("shows 'ON' when no args and trajectories are enabled", async () => {
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { trajectories: true } }),
+    );
+    const notifications: NotifyCall[] = [];
+    const ctx = fakeCtx({
+      cwd: tmpDir,
+      notify: (m, t) => notifications.push({ message: m, type: t }),
+    });
+    await handler("", ctx);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].message).toMatch(/ON/i);
+  });
+
+  it("turns on with 'on' arg: persists true and reloads", async () => {
+    let reloadCalled = false;
+    const ctx = fakeCtx({
+      cwd: tmpDir,
+      reload: async () => {
+        reloadCalled = true;
+      },
+    });
+    await handler("on", ctx);
+    expect(trajectoriesEnabled(loadTaskConfig(tmpDir))).toBe(true);
+    expect(reloadCalled).toBe(true);
+  });
+
+  it("turns off with 'off' arg: persists false and reloads", async () => {
+    // Start with it on
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { trajectories: true } }),
+    );
+    let reloadCalled = false;
+    const ctx = fakeCtx({
+      cwd: tmpDir,
+      reload: async () => {
+        reloadCalled = true;
+      },
+    });
+    await handler("off", ctx);
+    expect(trajectoriesEnabled(loadTaskConfig(tmpDir))).toBe(false);
+    expect(reloadCalled).toBe(true);
+  });
+
+  it("does not persist or reload when already in the requested state", async () => {
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { trajectories: true } }),
+    );
+    const notifications: NotifyCall[] = [];
+    let reloadCalled = false;
+    const ctx = fakeCtx({
+      cwd: tmpDir,
+      notify: (m, t) => notifications.push({ message: m, type: t }),
+      reload: async () => {
+        reloadCalled = true;
+      },
+    });
+    await handler("on", ctx);
+    expect(reloadCalled).toBe(false);
+    expect(notifications.some((n) => /already/i.test(n.message))).toBe(true);
+  });
+
+  it("shows error for unrecognized arg, does not persist or reload", async () => {
+    const notifications: NotifyCall[] = [];
+    let reloadCalled = false;
+    const ctx = fakeCtx({
+      cwd: tmpDir,
+      notify: (m, t) => notifications.push({ message: m, type: t }),
+      reload: async () => {
+        reloadCalled = true;
+      },
+    });
+    await handler("banana", ctx);
+    expect(trajectoriesEnabled(loadTaskConfig(tmpDir))).toBe(false);
+    expect(reloadCalled).toBe(false);
+    expect(notifications.some((n) => n.type === "error")).toBe(true);
+  });
+
+  it("preserves other llm-wiki settings when toggling on then off", async () => {
+    // Set a task model first
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    persistTaskModel(tmpDir, { provider: "anthropic", id: "claude-haiku-4-5" });
+
+    // Turn trajectories on
+    const ctxOn = fakeCtx({ cwd: tmpDir });
+    await handler("on", ctxOn);
+    let cfg = loadTaskConfig(tmpDir);
+    expect(cfg.trajectories).toBe(true);
+    expect(cfg.taskModel).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
+
+    // Turn trajectories off — taskModel must survive
+    const ctxOff = fakeCtx({ cwd: tmpDir });
+    await handler("off", ctxOff);
+    cfg = loadTaskConfig(tmpDir);
+    expect(trajectoriesEnabled(cfg)).toBe(false); // key removed → false
+    expect(cfg.taskModel).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
+  });
+
+  it("accepts common synonyms for on and off", async () => {
+    const synonyms = {
+      on: ["true", "enable", "enabled", "yes", "1"],
+      off: ["false", "disable", "disabled", "no", "0"],
+    };
+
+    for (const word of synonyms.on) {
+      const d = join(import.meta.dirname, "..", "tmp", `trj-syn-${Date.now()}-${Math.random()}`);
+      mkdirSync(d, { recursive: true });
+      const ctx = fakeCtx({ cwd: d });
+      await handler(word, ctx);
+      expect(trajectoriesEnabled(loadTaskConfig(d))).toBe(true);
+      rmSync(d, { recursive: true, force: true });
+    }
+
+    for (const word of synonyms.off) {
+      const d = join(import.meta.dirname, "..", "tmp", `trj-syn-${Date.now()}-${Math.random()}`);
+      mkdirSync(d, { recursive: true });
+      const ctx = fakeCtx({ cwd: d });
+      await handler(word, ctx);
+      expect(trajectoriesEnabled(loadTaskConfig(d))).toBe(false);
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds tests that validate all 7 acceptance criteria from issue #80 (trajectory opt-in, off by default). The code changes for #80 were already merged — this PR adds the missing test coverage and docs-content validation.

## Changes

### New: `test/trajectories-command.test.ts` (8 tests)
Unit tests for the `/wiki-trajectories` command handler:
- Shows OFF/ON status on no-arg invocation
- `on` → persists true + reloads
- `off` → persists false + reloads
- Already-in-state → no-op (no reload)
- Unknown arg → error, no side effects
- Synonyms accepted (`true`/`enable`/`yes`/etc.)
- Cross-setting isolation (taskModel survives toggle)

### Updated: `test/package-structure.test.ts` (2 new tests)
Docs-content validation for issue #80 criterion #7:
- SKILL.md contains the decision table comparing the three memory tools
- docs/api.md documents all 3 trajectory tools with opt-in/off-by-default banner

## Verification
- 358 tests pass (27 files, +10 from this PR)
- Existing 348 tests unaffected

Closes #80