### PR TITLE
fix: remove 5 unused imports flagged by CodeQL

### DIFF
--- a/extensions/llm-wiki/lib/ingest-worker.ts
+++ b/extensions/llm-wiki/lib/ingest-worker.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import type { Api, Model } from "@mariozechner/pi-ai";

--- a/extensions/llm-wiki/lib/metadata.ts
+++ b/extensions/llm-wiki/lib/metadata.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   type VaultPaths,
   extractWikilinks,
@@ -7,7 +7,6 @@ import {
   fmtDate,
   parseFrontmatter,
   readJson,
-  readText,
   writeJson,
 } from "./utils.js";
 

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {


### PR DESCRIPTION
## Summary

Removes 5 unused imports flagged by CodeQL code scanning (all note-level). Zero behavioral change.

| File | Removed |
|------|---------|
| `extensions/llm-wiki/lib/metadata.ts` | `statSync`, `resolve`, `readText` |
| `extensions/llm-wiki/lib/ingest-worker.ts` | `readFileSync` |
| `test/embeddings.test.ts` | `readFileSync` |

## Remaining open alerts

These are harder to fix cleanly:

- **`embeddings.ts`** (2 warnings): file data in outbound network request — intentional (sending content to OpenAI embedding API). Would need path validation upstream.
- **`ingest-worker.ts`** (2 warnings): file-system race conditions — standard check-then-use. Fix requires restructuring into read-unless-error pattern.
- **`metadata.ts` / `tools.ts` / `utils.ts` / `scripts/release.js`** (4 warnings): same race-condition pattern. Common in file I/O code.
- **`scripts/release.js`** (1 warning): release script, pre-existing.