### PR TITLE
Fix: batch embedding requests and stop silently storing empty vectors

### DIFF
--- a/extensions/llm-wiki/lib/embeddings.ts
+++ b/extensions/llm-wiki/lib/embeddings.ts
@@ -285,14 +285,94 @@ function embeddingsRequestPath(basePath: string): string {
 }
 
 interface EmbeddingApiResponse {
-  data?: Array<{ index: number; embedding: number[] }>;
+  data?: Array<{ index?: number; embedding: number[] }>;
   error?: { message?: string };
+  /** Some OpenAI-compatible gateways (e.g. GSA USAi / Vertex) nest errors here. */
+  detail?: unknown;
+}
+
+/**
+ * Max inputs per embeddings request. Providers cap batch size server-side
+ * (OpenAI 2048, Google Vertex `text-embedding-*` 250, Cohere v3 96); we chunk
+ * under the smallest common limit so a reindex of hundreds of pages never
+ * overruns the cap. Exported so tests and callers can reference the default.
+ */
+export const DEFAULT_MAX_EMBED_BATCH = 96;
+
+/**
+ * Approx per-request character budget. Providers also cap *total tokens* per
+ * request (Google Vertex `text-embedding-*` = 20,000 tokens). Tokenizing here
+ * would add a dependency, so we approximate with a conservative char budget
+ * (~2.8 chars/token observed for wiki prose, with headroom) — the request
+ * stays well under the token cap without counting tokens.
+ */
+export const DEFAULT_MAX_EMBED_BATCH_CHARS = 45_000;
+
+/**
+ * Split `texts` into batches that stay under BOTH a count cap and a total
+ * char budget. A single oversized text is emitted as its own batch rather than
+ * dropped, so every input is always embedded. Pure — unit-testable with no
+ * network.
+ */
+export function chunkByBudget(texts: string[], maxCount: number, maxChars: number): string[][] {
+  const batches: string[][] = [];
+  let batch: string[] = [];
+  let chars = 0;
+  for (const text of texts) {
+    // Close the current batch before adding a text that would exceed either
+    // cap — but never emit an empty batch (an oversized text stands alone).
+    if (batch.length > 0 && (batch.length >= maxCount || chars + text.length > maxChars)) {
+      batches.push(batch);
+      batch = [];
+      chars = 0;
+    }
+    batch.push(text);
+    chars += text.length;
+  }
+  if (batch.length > 0) batches.push(batch);
+  return batches;
+}
+
+/**
+ * Parse an OpenAI-compatible embeddings response into row-ordered vectors,
+ * throwing on any error shape so failures are never silently stored as empty
+ * vectors. Handles gateways that report errors via a nested `detail` field
+ * (GSA USAi / Vertex) or via HTTP status alone, and providers that omit the
+ * per-row `index` (returning rows in request order). Pure — unit-testable.
+ */
+export function parseEmbeddingResponse(
+  status: number,
+  body: EmbeddingApiResponse,
+  expectedCount: number,
+): number[][] {
+  if (body.error || body.detail !== undefined || status < 200 || status >= 300) {
+    const message =
+      body.error?.message ??
+      (typeof body.detail === "string"
+        ? body.detail
+        : body.detail !== undefined
+          ? JSON.stringify(body.detail)
+          : `HTTP ${status}`);
+    throw new Error(`embedding API error: ${message}`);
+  }
+  const rows = body.data ?? [];
+  if (rows.length !== expectedCount) {
+    throw new Error(`embedding API returned ${rows.length} vectors for ${expectedCount} inputs`);
+  }
+  const ordered = rows.every((r) => typeof r.index === "number")
+    ? [...rows].sort((a, b) => (a.index as number) - (b.index as number))
+    : rows;
+  return ordered.map((r) => r.embedding);
 }
 
 /**
  * Create an `EmbedFn` backed by an OpenAI-compatible `/v1/embeddings`
  * endpoint. Uses node's http/https directly (no SDK) so it works against
  * OpenAI, Azure (with an api-key header), or any compatible gateway.
+ *
+ * Inputs are split into batches under both the instance-count and total-char
+ * caps (see `chunkByBudget`) and re-joined in request order, so provider batch
+ * limits never truncate a reindex. Any request error is thrown, not swallowed.
  */
 export function createOpenAIEmbedFn(cfg: {
   apiKey: string;
@@ -306,7 +386,7 @@ export function createOpenAIEmbedFn(cfg: {
   const useHttp = parsed.protocol === "http:";
   const port = parsed.port ? Number(parsed.port) : undefined;
 
-  return (texts) =>
+  const embedBatch = (texts: string[]): Promise<number[][]> =>
     new Promise<number[][]>((resolve, reject) => {
       if (texts.length === 0) {
         resolve([]);
@@ -333,17 +413,17 @@ export function createOpenAIEmbedFn(cfg: {
             data += chunk.toString();
           });
           res.on("end", () => {
+            let parsedBody: EmbeddingApiResponse;
             try {
-              const parsedBody = JSON.parse(data) as EmbeddingApiResponse;
-              if (parsedBody.error) {
-                reject(new Error(`embedding API error: ${parsedBody.error.message ?? "unknown"}`));
-                return;
-              }
-              const rows = parsedBody.data ?? [];
-              const sorted = [...rows].sort((a, b) => a.index - b.index);
-              resolve(sorted.map((d) => d.embedding));
+              parsedBody = JSON.parse(data) as EmbeddingApiResponse;
             } catch (err) {
               reject(new Error(`failed to parse embedding response: ${(err as Error).message}`));
+              return;
+            }
+            try {
+              resolve(parseEmbeddingResponse(res.statusCode ?? 0, parsedBody, texts.length));
+            } catch (err) {
+              reject(err as Error);
             }
           });
         },
@@ -352,6 +432,18 @@ export function createOpenAIEmbedFn(cfg: {
       req.write(body);
       req.end();
     });
+
+  return async (texts) => {
+    const out: number[][] = [];
+    for (const batch of chunkByBudget(
+      texts,
+      DEFAULT_MAX_EMBED_BATCH,
+      DEFAULT_MAX_EMBED_BATCH_CHARS,
+    )) {
+      out.push(...(await embedBatch(batch)));
+    }
+    return out;
+  };
 }
 
 /**

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -4,12 +4,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   type EmbeddingStore,
   buildEmbeddingText,
+  chunkByBudget,
   contentHash,
   cosineSimilarity,
   embedPages,
   embeddingStorePath,
   isStale,
   normalizeVector,
+  parseEmbeddingResponse,
   readEmbeddingStore,
   reindexEmbeddings,
   resolveEmbedder,
@@ -293,5 +295,126 @@ describe("embeddingStorePath", () => {
   it("lives in the meta sidecar dir", () => {
     const paths = getVaultPaths("/tmp/x");
     expect(embeddingStorePath(paths)).toBe(join(paths.meta, "embeddings.json"));
+  });
+});
+
+// ── request batching (chunkByBudget) ──────────────────────
+describe("chunkByBudget", () => {
+  it("returns no batches for an empty input", () => {
+    expect(chunkByBudget([], 96, 1000)).toEqual([]);
+  });
+
+  it("keeps everything in one batch when under both caps", () => {
+    const texts = ["a", "b", "c"];
+    expect(chunkByBudget(texts, 96, 1000)).toEqual([texts]);
+  });
+
+  it("splits on the count cap", () => {
+    const texts = Array.from({ length: 5 }, (_, i) => `t${i}`);
+    expect(chunkByBudget(texts, 2, 10_000)).toEqual([["t0", "t1"], ["t2", "t3"], ["t4"]]);
+  });
+
+  it("splits on the char budget", () => {
+    // Each text is 10 chars; a 25-char budget fits two per batch.
+    const texts = ["x".repeat(10), "y".repeat(10), "z".repeat(10)];
+    expect(chunkByBudget(texts, 96, 25)).toEqual([[texts[0], texts[1]], [texts[2]]]);
+  });
+
+  it("emits an oversized text as its own batch rather than dropping it", () => {
+    const texts = ["small", "x".repeat(100), "small"];
+    expect(chunkByBudget(texts, 96, 10)).toEqual([["small"], ["x".repeat(100)], ["small"]]);
+  });
+
+  it("never loses or reorders inputs across a realistic split", () => {
+    const texts = Array.from({ length: 500 }, (_, i) => "w".repeat((i % 7) + 1));
+    const batches = chunkByBudget(texts, 96, 45_000);
+    expect(batches.flat()).toEqual(texts);
+    for (const b of batches) {
+      expect(b.length).toBeGreaterThan(0);
+      expect(b.length).toBeLessThanOrEqual(96);
+    }
+  });
+});
+
+// ── response parsing (parseEmbeddingResponse) ─────────────
+describe("parseEmbeddingResponse", () => {
+  it("returns row vectors in order for a well-formed OpenAI response", () => {
+    const vectors = parseEmbeddingResponse(
+      200,
+      {
+        data: [
+          { index: 0, embedding: [1, 0] },
+          { index: 1, embedding: [0, 1] },
+        ],
+      },
+      2,
+    );
+    expect(vectors).toEqual([
+      [1, 0],
+      [0, 1],
+    ]);
+  });
+
+  it("reorders by index when the provider returns rows out of order", () => {
+    const vectors = parseEmbeddingResponse(
+      200,
+      {
+        data: [
+          { index: 1, embedding: [0, 1] },
+          { index: 0, embedding: [1, 0] },
+        ],
+      },
+      2,
+    );
+    expect(vectors).toEqual([
+      [1, 0],
+      [0, 1],
+    ]);
+  });
+
+  it("preserves request order when rows omit index (USAi / Cohere)", () => {
+    const vectors = parseEmbeddingResponse(
+      200,
+      { data: [{ embedding: [1, 0] }, { embedding: [0, 1] }] },
+      2,
+    );
+    expect(vectors).toEqual([
+      [1, 0],
+      [0, 1],
+    ]);
+  });
+
+  it("throws on an OpenAI-style top-level error", () => {
+    expect(() => parseEmbeddingResponse(200, { error: { message: "bad key" } }, 1)).toThrow(
+      /bad key/,
+    );
+  });
+
+  it("throws on a gateway error nested under `detail` (GSA USAi / Vertex)", () => {
+    // Regression: this shape previously slipped past the top-level `error`
+    // check and was stored as empty vectors.
+    expect(() =>
+      parseEmbeddingResponse(
+        400,
+        { detail: "400 INVALID_ARGUMENT. 250 instance(s) is allowed per prediction." },
+        462,
+      ),
+    ).toThrow(/250 instance/);
+  });
+
+  it("throws on a non-2xx status even when the body has no error field", () => {
+    expect(() => parseEmbeddingResponse(500, {}, 1)).toThrow(/HTTP 500/);
+  });
+
+  it("stringifies a non-string `detail` payload", () => {
+    expect(() =>
+      parseEmbeddingResponse(400, { detail: { code: 400, status: "INVALID_ARGUMENT" } }, 1),
+    ).toThrow(/INVALID_ARGUMENT/);
+  });
+
+  it("throws when the vector count does not match the request", () => {
+    expect(() =>
+      parseEmbeddingResponse(200, { data: [{ index: 0, embedding: [1, 0] }] }, 2),
+    ).toThrow(/returned 1 vectors for 2 inputs/);
   });
 });


### PR DESCRIPTION
# Fix: batch embedding requests and stop silently storing empty vectors

## What's wrong

`createOpenAIEmbedFn` sends every page's text in a single `/embeddings` request
and only looks for a top-level `error` field in the response. That works against
OpenAI, but breaks against OpenAI-compatible gateways that proxy Google Vertex
(for example, GSA's USAi gateway):

- Vertex's `text-embedding-*` models cap each request at **250 inputs and 20,000
  tokens**. Embedding a few hundred pages exceeds both.
- When the limit is hit, the gateway returns **HTTP 400 with the error message
  under a `detail` field**, not `error`. The current code doesn't check `detail`
  or the status code, so it treats the failure as success, falls back to an
  empty list, and **writes empty vectors (`dim: 0`) for every page** — while
  `wiki_reindex_embeddings` reports success.

The result is a silent failure: semantic recall quietly degrades to keyword-only,
with no error surfaced. I hit this on a ~460-page vault.

## What this changes

- **Chunk requests.** New `chunkByBudget()` splits inputs so each request stays
  under both a count cap (`DEFAULT_MAX_EMBED_BATCH = 96`) and a character budget
  (`DEFAULT_MAX_EMBED_BATCH_CHARS = 45,000`, roughly 16k tokens — safely under
  Vertex's 20k). An oversized single page is sent on its own rather than dropped.
  `96` is safe for OpenAI (2048), Vertex (250), and Cohere v3 (96) alike.
- **Fail loudly.** New `parseEmbeddingResponse()` throws on a top-level `error`,
  a nested `detail`, any non-2xx status, or a vector-count mismatch — so a
  provider error can never again be persisted as empty vectors.
- **Tolerate missing `index`.** Some gateways (USAi, Cohere) omit the per-row
  `index` and return rows in request order; we only re-sort when `index` is
  present.
- Both helpers are pure and exported, matching the module's existing
  "no-network, unit-testable" functions.

## Behavior change (intentional)

A failed batch now **rejects** `embed()` instead of resolving to empty vectors.
Embedding already runs in error-isolated background tasks (`launchEmbedPages` /
`launchReindex`), so a failure now leaves the existing embeddings untouched and
logs the error, instead of overwriting them with empties. This is the safer
default.

## Tests

Adds 14 tests to `test/embeddings.test.ts` covering count/character splitting,
oversized-input handling, order preservation with and without `index`, and every
error shape — including a regression test for the `detail`-nested Vertex/USAi
400. Full suite: **382 passing** (was 368). `biome` and `tsc` are clean.

## Possible follow-up

The character budget is a deliberately dependency-free approximation of the token
limit. If you'd prefer, `DEFAULT_MAX_EMBED_BATCH` and
`DEFAULT_MAX_EMBED_BATCH_CHARS` could become optional `TaskConfig` fields,
consistent with the existing `embeddingModel` / `embeddingBaseUrl` settings. I
kept them as constants to keep this change focused.
