### PR TITLE
fix(obs): prevent reminder resurrection after session_compact

### DIFF
--- a/extensions/llm-wiki/lib/observation.ts
+++ b/extensions/llm-wiki/lib/observation.ts
@@ -348,10 +348,11 @@ export function registerObservationReminder(
     reminderState.observeDoneThisSession = false;
   });
 
-  // After compaction, reset the reminder state so reminders resume
+  // After compaction, reset turn counter so reminders resume
+  // BUT preserve observeDoneThisSession — if the model already called
+  // wiki_observe this session, compaction should not resurrect the nag.
   pi.on("session_compact", async () => {
     turnsSinceLastReminder = 0;
-    reminderState.observeDoneThisSession = false;
   });
 
   pi.on("agent_end", async (event, _ctx) => {

--- a/test/observation.test.ts
+++ b/test/observation.test.ts
@@ -312,7 +312,7 @@ describe("registerObservationReminder — retry deduplication", () => {
     expect(messages).toHaveLength(2);
   });
 
-  it("resets state on session_compact", async () => {
+  it("resets turn counter on session_compact but preserves observeDoneThisSession", async () => {
     const { pi, emit, messages } = createMockPi();
     const state = createReminderState();
     registerObservationReminder(pi, state, { turnsBetweenReminders: 1 });
@@ -322,7 +322,24 @@ describe("registerObservationReminder — retry deduplication", () => {
 
     await emit("session_compact");
 
-    // State reset — reminder fires again
+    // Compaction must NOT resurrect the nag — observeDoneThisSession preserved
+    await emit("agent_end", {});
+    expect(messages).toHaveLength(1);
+  });
+
+  it("allows reminder to resume after session_compact when observe not done", async () => {
+    const { pi, emit, messages } = createMockPi();
+    const state = createReminderState();
+    registerObservationReminder(pi, state, { turnsBetweenReminders: 1 });
+
+    // 1 turn fires reminder
+    await emit("agent_end", {});
+    expect(messages).toHaveLength(1);
+
+    // Counter stays at 1, compact resets it
+    await emit("session_compact");
+
+    // Counter = 0, next turn = 1 → fires again
     await emit("agent_end", {});
     expect(messages).toHaveLength(2);
   });


### PR DESCRIPTION
## Summary

- Preserve `observeDoneThisSession` across `session_compact` so a
  completed `wiki_observe` call in the same session is not re-nagged
  after context is compacted.
- Reset turn counter to keep long-session reminders working.
- Split existing session_compact test into two focused cases.

## Changes

- `extensions/llm-wiki/lib/observation.ts`
- `test/observation.test.ts`

## Impact

- Fixes annoying double-reminder after compaction.
- No change in public API; internal reminder behavior only.