### PR TITLE
fix(#101): use vault-relative paths in ingest so read tool resolves correctly

### DIFF
--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import { launchEmbedPages, reindexEmbeddings, resolveEmbedder } from "./embeddings.js";
@@ -390,7 +390,11 @@ export function registerWikiIngest(pi: ExtensionAPI, runtime?: Runtime): void {
         const manifestPath = join(paths.rawSources, id, "manifest.json");
         const extracted = existsSync(extractedPath) ? readFileSync(extractedPath, "utf-8") : "";
         const manifest = readJson<Record<string, unknown>>(manifestPath, {});
-        return { id, extracted, manifest };
+        // Vault-relative path used in tool messages so the read tool can open
+        // the file from the vault root (fix #101: agent previously got
+        // "raw/sources/..." and failed on new-layout vaults).
+        const relRaw = relative(paths.root, paths.rawSources);
+        return { id, extracted, manifest, relRaw };
       });
 
       // ── Background synthesis (issue #65) ──────────────────
@@ -474,7 +478,7 @@ export function registerWikiIngest(pi: ExtensionAPI, runtime?: Runtime): void {
                 [
                   `- **${s.id}**: ${s.manifest.title || s.id}`,
                   `  - Extracted: ${s.extracted.length} chars`,
-                  `  - Read: \`raw/sources/${s.id}/extracted.md\``,
+                  `  - Read: \`${s.relRaw}/${s.id}/extracted.md\``,
                 ].join("\n"),
               ),
               "",

--- a/prompts/wiki-ingest.md
+++ b/prompts/wiki-ingest.md
@@ -19,7 +19,7 @@ $ARGUMENTS
 2. If the tool reports "All sources ingested", inform the user and stop.
 3. **If the tool reports it is ingesting in the background**, the synthesis sub-agent is handling those sources on the configured task model. Do NOT synthesize them yourself — just report which sources were dispatched and stop. (You'll be notified as each completes.)
 4. **Otherwise** (the tool returned extracted content — background unavailable or `background=false`), for each source in the returned batch:
-   a. Read the extracted text from `raw/sources/<SOURCE_ID>/extracted.md`
+   a. Read the extracted text from `.llm-wiki/raw/sources/<SOURCE_ID>/extracted.md`
    b. Update the skeleton source page in `wiki/sources/` with a proper summary, key entities, and concepts
    c. Use `wiki_ensure_page(type=entity, title=<name>)` for each new entity (people, orgs, tools, products)
    d. Use `wiki_ensure_page(type=concept, title=<name>)` for each new concept (ideas, patterns, frameworks)

--- a/test/ingest-tool.test.ts
+++ b/test/ingest-tool.test.ts
@@ -143,4 +143,18 @@ describe("wiki_ingest background dispatch", () => {
     const res = await tool.execute("id", { background: true }, undefined, undefined, ctx);
     expect(res.content[0].text as string).toContain("Next steps");
   });
+
+  it("returns a vault-relative path that works for the read tool (#101)", async () => {
+    const tool = captureIngestTool(undefined);
+    const { ctx } = makeCtx(wikiDir);
+    const res = await tool.execute("id", { background: false }, undefined, undefined, ctx);
+    const text = res.content[0].text as string;
+
+    // Must include .llm-wiki/raw/sources (new layout) so agent can run:
+    // read `.llm-wiki/raw/sources/SRC-001/extracted.md` from the vault root. Previously it
+    // returned only `raw/sources/SRC-001/extracted.md`, which failed on new-layout vaults (#101).
+    expect(text).toContain(".llm-wiki/raw/sources/SRC-001/extracted.md");
+    // Must not use the bare, ambiguous prefix.
+    expect(text).not.toContain("`raw/sources/SRC-001/extracted.md`");
+  });
 });


### PR DESCRIPTION
## Summary

The agent fails to read source files during /wiki-ingest because returned paths are hardcoded as relative to project root, but vaults can use either new (.llm-wiki/) or legacy (raw/) layouts.

Example (from #101):
- Agent runs: read sources/SRC-2026-07-23-001
- Actual file: D:\wikis\test\.llm-wiki\raw\sources\SRC-2026-07-23-001
- Result: ENOENT

This PR ensures:
- The wiki_ingest tool returns a vault-relative path (e.g. .llm-wiki/raw/sources/SRC-001/extracted.md) that works when read from the vault root.
- The /wiki-ingest prompt template reflects the actual layout.
- Both new and legacy vault layouts are supported via paths.rawSources.

## Changes

- extensions/llm-wiki/lib/tools.ts:
  - Compute relRaw from paths.rawSources relative to paths.root.
  - Use that in the synchronous ingest response instead of raw hardcoded raw/sources/.
- prompts/wiki-ingest.md:
  - Update example path to use .llm-wiki/raw/sources/.
- test/ingest-tool.test.ts:
  - Add TDD test asserting returned path includes .llm-wiki/raw/sources/ for new-layout vaults.

## Verification

- All 369 tests pass (including the new test).
- biome and tsc are clean.