### PR TITLE
fix: support OMP segmented system prompts

### DIFF
--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installGuardrails } from "./lib/guardrails.js";
-import { buildAgentStartInjection } from "./lib/inject.js";
+import { buildAgentStartInjection, normalizeSystemPrompt } from "./lib/inject.js";
 import { registerWikiModelCommand } from "./lib/model-command.js";
 import {
   buildSessionNotice,
@@ -303,13 +303,12 @@ Then call wiki_bootstrap with the inferred topic and mode to finalize the setup.
 
     // Split into a cache-stable system prompt (static footer only) and a
     // volatile tail message (issue #92). See lib/inject.ts for the contract.
-    const { systemPrompt, message } = buildAgentStartInjection(event.systemPrompt || "", [
-      dynamicContext,
-    ]);
+    const priorSystemPrompt = normalizeSystemPrompt(event.systemPrompt);
+    const { systemPrompt, message } = buildAgentStartInjection(priorSystemPrompt, [dynamicContext]);
 
     // Only claim a systemPrompt change when the footer actually altered the
     // string (a carry-forward turn already carries it, so this no-ops).
-    const systemPromptChanged = systemPrompt !== event.systemPrompt;
+    const systemPromptChanged = systemPrompt !== priorSystemPrompt;
     if (!systemPromptChanged && !message) return;
     return {
       ...(systemPromptChanged ? { systemPrompt } : {}),

--- a/extensions/llm-wiki/lib/inject.ts
+++ b/extensions/llm-wiki/lib/inject.ts
@@ -33,6 +33,14 @@ export function appendWikiStatus(systemPrompt: string): string {
   return `${base}\n\n${WIKI_STATUS_BLOCK}`;
 }
 
+/** Normalize upstream Pi and OMP system-prompt representations. */
+export function normalizeSystemPrompt(
+  systemPrompt: string | readonly string[] | null | undefined,
+): string {
+  if (Array.isArray(systemPrompt)) return systemPrompt.join("\n\n");
+  return typeof systemPrompt === "string" ? systemPrompt : "";
+}
+
 /** customType of the hidden tail message carrying volatile per-turn context. */
 export const WIKI_RECALL_MESSAGE_TYPE = "wiki-recall-context";
 
@@ -69,10 +77,10 @@ export interface AgentStartInjection {
  * Pure and side-effect free — see test/agent-start-injection.test.ts.
  */
 export function buildAgentStartInjection(
-  baseSystemPrompt: string,
+  baseSystemPrompt: string | readonly string[] | null | undefined,
   dynamicBlocks: Array<string | undefined>,
 ): AgentStartInjection {
-  const systemPrompt = appendWikiStatus(baseSystemPrompt);
+  const systemPrompt = appendWikiStatus(normalizeSystemPrompt(baseSystemPrompt));
   const content = dynamicBlocks
     .map((b) => b?.trim())
     .filter((b): b is string => Boolean(b))

--- a/test/agent-start-injection.test.ts
+++ b/test/agent-start-injection.test.ts
@@ -40,6 +40,11 @@ describe("buildAgentStartInjection (issue #92 cache safety)", () => {
     expect(systemPrompt).toBe(`${BASE}\n\n${WIKI_STATUS_BLOCK}`);
   });
 
+  it("accepts OMP's segmented system prompt", () => {
+    const { systemPrompt } = buildAgentStartInjection([BASE, "Follow project rules."], []);
+    expect(systemPrompt).toBe(`${BASE}\n\nFollow project rules.\n\n${WIKI_STATUS_BLOCK}`);
+  });
+
   it("volatile blocks ride in a hidden tail message, joined in order", () => {
     const topic = "## Wiki Setup Required\ninfer topic";
     const { message } = buildAgentStartInjection(BASE, [topic, RECALL_A]);


### PR DESCRIPTION
## Summary
- normalize OMP `string[]` system prompts before wiki footer injection
- compare normalized prompt for retry-safe idempotency
- cover segmented prompt input

## Test plan
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`

Fixes #107