### PR TITLE
fix: handle patch-shaped edit guardrails

### DIFF
--- a/extensions/llm-wiki/lib/guardrails.ts
+++ b/extensions/llm-wiki/lib/guardrails.ts
@@ -1,3 +1,4 @@
+import { resolve, sep } from "node:path";
 import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { scheduleReindex } from "./indexing.js";
@@ -10,6 +11,39 @@ import { isProtectedPath, resolveVaultPaths } from "./utils.js";
  */
 
 let pendingRebuild = false;
+
+const PATCH_HEADER = /^\[([^#\r\n]+)#[0-9A-F]{4}\]$/gm;
+
+function collectMutationPaths(input: unknown, seen: WeakSet<object>): string[] {
+  if (typeof input === "string") {
+    return Array.from(input.matchAll(PATCH_HEADER), ([, target]) => target);
+  }
+  if (!input || typeof input !== "object" || seen.has(input)) return [];
+
+  seen.add(input);
+  if (Array.isArray(input)) return input.flatMap((value) => collectMutationPaths(value, seen));
+
+  const { path, ...nested } = input as Record<string, unknown>;
+  if (typeof path === "string" && path.length > 0) return [path];
+
+  return Object.values(nested).flatMap((value) => collectMutationPaths(value, seen));
+}
+
+/** Return every file path targeted by a write or patch-shaped edit input. */
+export function extractMutationPaths(input: unknown): string[] {
+  return [...new Set(collectMutationPaths(input, new WeakSet()))];
+}
+
+/** True when a write or patch-shaped edit targets a page in the wiki directory. */
+export function hasWikiMutation(input: unknown, wikiPath: string): boolean {
+  const resolvedWikiPath = resolve(wikiPath);
+  return extractMutationPaths(input).some((path) => {
+    const resolvedPath = resolve(path);
+    return (
+      resolvedPath === resolvedWikiPath || resolvedPath.startsWith(`${resolvedWikiPath}${sep}`)
+    );
+  });
+}
 
 /** Install guardrails on the extension API. */
 export function installGuardrails(pi: ExtensionAPI, runtime?: Runtime): void {
@@ -25,11 +59,17 @@ export function installGuardrails(pi: ExtensionAPI, runtime?: Runtime): void {
     }
 
     if (isToolCallEventType("edit", event)) {
-      const path = event.input.path as string;
+      const targetPaths = extractMutationPaths(event.input);
+      if (targetPaths.length === 0) {
+        return { block: true, reason: "Cannot determine the files targeted by this edit." };
+      }
+
       const paths = resolveVaultPaths(process.cwd());
-      const check = isProtectedPath(path, paths);
-      if (check.protected) {
-        return { block: true, reason: check.reason };
+      for (const path of targetPaths) {
+        const check = isProtectedPath(path, paths);
+        if (check.protected) {
+          return { block: true, reason: check.reason };
+        }
       }
     }
   });
@@ -37,10 +77,8 @@ export function installGuardrails(pi: ExtensionAPI, runtime?: Runtime): void {
   // Track wiki edits for auto-rebuild
   pi.on("tool_result", async (event) => {
     if (event.toolName === "write" || event.toolName === "edit") {
-      const path = event.input.path as string;
       const paths = resolveVaultPaths(process.cwd());
-      const wikiPath = `${paths.wiki}/`;
-      if (path?.startsWith(wikiPath)) {
+      if (hasWikiMutation(event.input, paths.wiki)) {
         pendingRebuild = true;
       }
     }

--- a/test/guardrails.test.ts
+++ b/test/guardrails.test.ts
@@ -1,0 +1,136 @@
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import {
+  extractMutationPaths,
+  hasWikiMutation,
+  installGuardrails,
+} from "../extensions/llm-wiki/lib/guardrails.js";
+import { resolveVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+
+type ToolCallHandler = (event: { toolName: string; input: unknown }) => Promise<unknown>;
+
+function captureToolCallHandler(): ToolCallHandler {
+  let handler: ToolCallHandler | undefined;
+  const pi = {
+    on: (eventName: string, candidate: unknown) => {
+      if (eventName === "tool_call") handler = candidate as ToolCallHandler;
+    },
+  } as unknown as ExtensionAPI;
+
+  installGuardrails(pi);
+  if (!handler) throw new Error("tool_call handler was not registered");
+  return handler;
+}
+
+const vaultPaths = resolveVaultPaths(process.cwd());
+
+describe("edit guardrails", () => {
+  it("extracts every file target from an Edit patch", () => {
+    const paths = extractMutationPaths({
+      patch: [
+        "[.llm-wiki/wiki/sources/issue-109.md#ABCD]",
+        "SWAP 1.=1:",
+        "+updated",
+        "[.llm-wiki/wiki/concepts/guardrails.md#1234]",
+        "INS.TAIL:",
+        "+linked",
+      ].join("\n"),
+    });
+
+    expect(paths).toEqual([
+      ".llm-wiki/wiki/sources/issue-109.md",
+      ".llm-wiki/wiki/concepts/guardrails.md",
+    ]);
+  });
+
+  it("extracts every file target when Pi passes the patch directly", () => {
+    const paths = extractMutationPaths(
+      "[.llm-wiki/wiki/sources/issue-109.md#ABCD]\nSWAP 1.=1:\n+updated",
+    );
+
+    expect(paths).toEqual([".llm-wiki/wiki/sources/issue-109.md"]);
+  });
+
+  it("extracts every file target from a nested patch payload", () => {
+    const paths = extractMutationPaths({
+      arguments: {
+        patch: "[.llm-wiki/wiki/sources/issue-109.md#ABCD]\nSWAP 1.=1:\n+updated",
+      },
+    });
+
+    expect(paths).toEqual([".llm-wiki/wiki/sources/issue-109.md"]);
+  });
+
+  it("recognizes a wiki target for metadata rebuild", () => {
+    expect(
+      hasWikiMutation(
+        {
+          patch: `[${join(vaultPaths.wiki, "sources", "issue-109.md")}#ABCD]\nSWAP 1.=1:\n+updated`,
+        },
+        vaultPaths.wiki,
+      ),
+    ).toBe(true);
+  });
+
+  it("allows an Edit patch that only changes wiki pages", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: { patch: "[.llm-wiki/wiki/sources/issue-109.md#ABCD]\nSWAP 1.=1:\n+updated" },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("blocks an Edit patch that targets a raw source packet", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        patch: `[${join(
+          vaultPaths.rawSources,
+          "SRC-2026-07-27-001",
+          "extracted.md",
+        )}#ABCD]\nSWAP 1.=1:\n+changed`,
+      },
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason: "Raw sources are immutable. Use wiki_capture_source to add sources.",
+    });
+  });
+
+  it("blocks a mixed Edit patch when any target is protected", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        patch: [
+          "[.llm-wiki/wiki/sources/issue-109.md#ABCD]",
+          "SWAP 1.=1:",
+          "+updated",
+          `[${join(vaultPaths.meta, "registry.json")}#1234]`,
+          "SWAP 1.=1:",
+          "+changed",
+        ].join("\n"),
+      },
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason: "Metadata is auto-generated. Use wiki_rebuild_meta or wiki_log_event instead.",
+    });
+  });
+
+  it("blocks a pathless Edit request with a clear error", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({ toolName: "edit", input: { patch: "invalid patch" } });
+
+    expect(result).toEqual({
+      block: true,
+      reason: "Cannot determine the files targeted by this edit.",
+    });
+  });
+});


### PR DESCRIPTION
Fixes #109

The guardrail reads file targets from Edit patches, including nested payloads. It blocks any patch that targets raw sources or generated metadata. The metadata rebuild hook detects page edits in patch inputs.

Verification passed with `pnpm test`, `pnpm typecheck`, and `pnpm lint`.