### PR TITLE
Fix: Unicode slugify + untitled fallback

### DIFF
--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -544,12 +544,13 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
         | "requirement"
         | "skill"
         | "case";
-      const slug = params.title
-        .toLowerCase()
-        .replace(/[^a-z0-9\s-]/g, "")
-        .trim()
-        .replace(/\s+/g, "-")
-        .slice(0, 80);
+      const slug =
+        params.title
+          .toLocaleLowerCase()
+          .replace(/[^\p{L}\p{N}\s-]/gu, "")
+          .trim()
+          .replace(/\s+/g, "-")
+          .slice(0, 80) || "untitled";
 
       const folderMap: Record<string, string> = {
         entity: "entities",

--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -370,12 +370,14 @@ export function extractWikilinks(content: string): string[] {
 
 /** Slugify a title. */
 export function slugify(title: string): string {
-  return title
-    .toLocaleLowerCase()
-    .replace(/[^\p{L}\p{N}\s-]/gu, "")
-    .trim()
-    .replace(/\s+/g, "-")
-    .slice(0, 80) || "untitled";
+  return (
+    title
+      .toLocaleLowerCase()
+      .replace(/[^\p{L}\p{N}\s-]/gu, "")
+      .trim()
+      .replace(/\s+/g, "-")
+      .slice(0, 80) || "untitled"
+  );
 }
 
 /** Format date as YYYY-MM-DD. */

--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -371,11 +371,11 @@ export function extractWikilinks(content: string): string[] {
 /** Slugify a title. */
 export function slugify(title: string): string {
   return title
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, "")
     .trim()
     .replace(/\s+/g, "-")
-    .slice(0, 80);
+    .slice(0, 80) || "untitled";
 }
 
 /** Format date as YYYY-MM-DD. */

--- a/test/slugify.test.ts
+++ b/test/slugify.test.ts
@@ -13,4 +13,3 @@ describe("slugify", () => {
     expect(slugify("   ")).toBe("untitled");
   });
 });
-

--- a/test/slugify.test.ts
+++ b/test/slugify.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { slugify } from "../extensions/llm-wiki/lib/utils.js";
+
+describe("slugify", () => {
+  it("should keep Unicode letters and numbers", () => {
+    expect(slugify("中文标题")).toBe("中文标题");
+    expect(slugify("Hello 世界")).toBe("hello-世界");
+    expect(slugify("中文 标题")).toBe("中文-标题");
+  });
+
+  it("should fall back when slug is empty", () => {
+    expect(slugify("！！！")).toBe("untitled");
+    expect(slugify("   ")).toBe("untitled");
+  });
+});
+


### PR DESCRIPTION
- Problem — When the page title contains Chinese (or mostly non a-z0-9 characters), the current ASCII-only slug generation strips everything and produces an empty slug ( "" ). As a result, wiki_ensure_page writes to .../entities/.md or .../concepts/.md , and all subsequent Chinese entity/concept pages map to the same .md file (often returning “Page already exists” without creating the intended page).
- Root cause — The slugify logic only allows ASCII [a-z0-9\s-] , so non-ASCII titles are fully filtered out and the slug becomes empty.
- Defensive cleanup (optional) — Switch slug generation to a Unicode-aware regex (preserving \p{L} / \p{N} ), and add a || "untitled" fallback to prevent empty filenames. Add a regression test to cover Unicode titles and the empty-slug fallback.