### PR TITLE
fix: close edit guardrail path bypasses

### DIFF
--- a/extensions/llm-wiki/lib/guardrails.ts
+++ b/extensions/llm-wiki/lib/guardrails.ts
@@ -15,6 +15,13 @@ let pendingRebuild = false;
 const APPLY_PATCH_PATH_NOISE =
   /^\*{0,3}\s*(?:(?:update|add|delete|move)[^A-Za-z0-9]*(?:file|to)?[^A-Za-z0-9]*:)?\s*\*{0,3}\s*/i;
 const PATCH_INPUT_KEYS: Record<string, true> = { input: true, _input: true, patch: true };
+const DESTINATION_KEYS: Record<string, true> = {
+  rename: true,
+  move: true,
+  dest: true,
+  destination: true,
+  newPath: true,
+};
 
 interface MutationScan {
   paths: string[];
@@ -41,18 +48,52 @@ function parsePatchHeader(line: string): string | undefined {
   return normalizePatchTarget(rawTarget) || undefined;
 }
 
+function parseMoveDestination(line: string): string | undefined {
+  const rawDestination = line.trim().slice(2).trim();
+  if (!rawDestination) return undefined;
+  const quote = rawDestination[0];
+  if (quote !== '"' && quote !== "'") return rawDestination;
+
+  let cursor = 1;
+  while (cursor < rawDestination.length) {
+    if (rawDestination[cursor] === "\\" && cursor + 1 < rawDestination.length) {
+      cursor += 2;
+      continue;
+    }
+    if (rawDestination[cursor] === quote) {
+      return cursor === rawDestination.length - 1
+        ? rawDestination.slice(1, cursor)
+        : undefined;
+    }
+    cursor++;
+  }
+  return undefined;
+}
+
 function scanPatchString(input: string): MutationScan {
   const paths: string[] = [];
   let sawHeader = false;
+  let sectionHasMove = false;
   let complete = true;
   const stripped = input.startsWith("\uFEFF") ? input.slice(1) : input;
 
   for (const line of stripped.split("\n")) {
-    if (!line.replace(/\r$/, "").trimEnd().startsWith("[")) continue;
-    sawHeader = true;
-    const path = parsePatchHeader(line);
-    if (path) paths.push(path);
-    else complete = false;
+    const trimmed = line.replace(/\r$/, "").trim();
+    if (trimmed.startsWith("[")) {
+      sawHeader = true;
+      sectionHasMove = false;
+      const path = parsePatchHeader(line);
+      if (path) paths.push(path);
+      else complete = false;
+      continue;
+    }
+    if (!/^MV(?:\s|$)/.test(trimmed)) continue;
+    const destination = parseMoveDestination(trimmed);
+    if (!sawHeader || sectionHasMove || !destination) complete = false;
+    else {
+      paths.push(destination);
+      sectionHasMove = true;
+    }
   }
 
   return { paths, complete: sawHeader && complete };
@@ -95,6 +136,11 @@ function collectMutationPaths(
 
   for (const [key, value] of Object.entries(record)) {
     if (key === "path" || key === "paths") continue;
+    if (DESTINATION_KEYS[key] === true) {
+      if (typeof value === "string" && value.length > 0) scan.paths.push(value);
+      else scan.complete = false;
+      continue;
+    }
     const childStringsArePatches = stringsArePatches || PATCH_INPUT_KEYS[key] === true;
     if (typeof value !== "string" && (!value || typeof value !== "object")) continue;
     mergeMutationScans(scan, collectMutationPaths(value, seen, childStringsArePatches));

--- a/extensions/llm-wiki/lib/guardrails.ts
+++ b/extensions/llm-wiki/lib/guardrails.ts
@@ -28,31 +28,36 @@ interface MutationScan {
   complete: boolean;
 }
 
-function normalizePatchTarget(target: string): string {
-  const stripped = target.trim().replace(APPLY_PATCH_PATH_NOISE, "");
-  if (stripped.length < 2) return stripped;
-  const first = stripped[0];
-  const last = stripped[stripped.length - 1];
-  return (first === '"' || first === "'") && first === last ? stripped.slice(1, -1) : stripped;
+function normalizeMutationPath(target: string): string | undefined {
+  const trimmed = target.trim();
+  if (!trimmed) return undefined;
+  const first = trimmed[0];
+  const last = trimmed[trimmed.length - 1];
+  const quoted = first === '"' || first === "'";
+  if (quoted !== (last === '"' || last === "'") || (quoted && first !== last)) {
+    return undefined;
+  }
+  const unquoted = quoted ? trimmed.slice(1, -1) : trimmed;
+  return unquoted.replace(APPLY_PATCH_PATH_NOISE, "") || undefined;
 }
 
 function parsePatchHeader(line: string): string | undefined {
   const trimmed = line.replace(/\r$/, "").trimEnd();
   if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return undefined;
 
-  const body = trimmed.slice(1, -1).trim().replace(APPLY_PATCH_PATH_NOISE, "");
+  const body = trimmed.slice(1, -1).trim();
   const tag = /#[0-9A-Fa-f]{4}\s*$/.exec(body);
   const rawTarget = tag ? body.slice(0, tag.index) : body.replace(/\s+$/, "");
   if (!rawTarget || rawTarget.includes("#")) return undefined;
 
-  return normalizePatchTarget(rawTarget) || undefined;
+  return normalizeMutationPath(rawTarget);
 }
 
 function parseMoveDestination(line: string): string | undefined {
   const rawDestination = line.trim().slice(2).trim();
   if (!rawDestination) return undefined;
   const quote = rawDestination[0];
-  if (quote !== '"' && quote !== "'") return rawDestination;
+  if (quote !== '"' && quote !== "'") return normalizeMutationPath(rawDestination);
 
   let cursor = 1;
   while (cursor < rawDestination.length) {
@@ -62,7 +67,7 @@ function parseMoveDestination(line: string): string | undefined {
     }
     if (rawDestination[cursor] === quote) {
       return cursor === rawDestination.length - 1
-        ? rawDestination.slice(1, cursor)
+        ? normalizeMutationPath(rawDestination)
         : undefined;
     }
     cursor++;
@@ -104,6 +109,12 @@ function mergeMutationScans(target: MutationScan, source: MutationScan): void {
   target.complete &&= source.complete;
 }
 
+function addMutationPath(scan: MutationScan, target: string): void {
+  const path = normalizeMutationPath(target);
+  if (path) scan.paths.push(path);
+  else scan.complete = false;
+}
+
 function collectMutationPaths(
   input: unknown,
   seen: WeakSet<object>,
@@ -127,17 +138,17 @@ function collectMutationPaths(
 
   const record = input as Record<string, unknown>;
   if (typeof record.path === "string" && record.path.length > 0) {
-    scan.paths.push(record.path);
+    addMutationPath(scan, record.path);
   }
   const eventPaths = Array.isArray(record.paths) ? record.paths : [record.paths];
   for (const path of eventPaths) {
-    if (typeof path === "string" && path.length > 0) scan.paths.push(path);
+    if (typeof path === "string" && path.length > 0) addMutationPath(scan, path);
   }
 
   for (const [key, value] of Object.entries(record)) {
     if (key === "path" || key === "paths") continue;
     if (DESTINATION_KEYS[key] === true) {
-      if (typeof value === "string" && value.length > 0) scan.paths.push(value);
+      if (typeof value === "string" && value.length > 0) addMutationPath(scan, value);
       else scan.complete = false;
       continue;
     }

--- a/extensions/llm-wiki/lib/guardrails.ts
+++ b/extensions/llm-wiki/lib/guardrails.ts
@@ -12,26 +12,105 @@ import { isProtectedPath, resolveVaultPaths } from "./utils.js";
 
 let pendingRebuild = false;
 
-const PATCH_HEADER = /^\[([^#\r\n]+)#[0-9A-F]{4}\]$/gm;
+const APPLY_PATCH_PATH_NOISE =
+  /^\*{0,3}\s*(?:(?:update|add|delete|move)[^A-Za-z0-9]*(?:file|to)?[^A-Za-z0-9]*:)?\s*\*{0,3}\s*/i;
+const PATCH_INPUT_KEYS: Record<string, true> = { input: true, _input: true, patch: true };
 
-function collectMutationPaths(input: unknown, seen: WeakSet<object>): string[] {
-  if (typeof input === "string") {
-    return Array.from(input.matchAll(PATCH_HEADER), ([, target]) => target);
+interface MutationScan {
+  paths: string[];
+  complete: boolean;
+}
+
+function normalizePatchTarget(target: string): string {
+  const stripped = target.trim().replace(APPLY_PATCH_PATH_NOISE, "");
+  if (stripped.length < 2) return stripped;
+  const first = stripped[0];
+  const last = stripped[stripped.length - 1];
+  return (first === '"' || first === "'") && first === last ? stripped.slice(1, -1) : stripped;
+}
+
+function parsePatchHeader(line: string): string | undefined {
+  const trimmed = line.replace(/\r$/, "").trimEnd();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return undefined;
+
+  const body = trimmed.slice(1, -1).trim().replace(APPLY_PATCH_PATH_NOISE, "");
+  const tag = /#[0-9A-Fa-f]{4}\s*$/.exec(body);
+  const rawTarget = tag ? body.slice(0, tag.index) : body.replace(/\s+$/, "");
+  if (!rawTarget || rawTarget.includes("#")) return undefined;
+
+  return normalizePatchTarget(rawTarget) || undefined;
+}
+
+function scanPatchString(input: string): MutationScan {
+  const paths: string[] = [];
+  let sawHeader = false;
+  let complete = true;
+  const stripped = input.startsWith("\uFEFF") ? input.slice(1) : input;
+
+  for (const line of stripped.split("\n")) {
+    if (!line.replace(/\r$/, "").trimEnd().startsWith("[")) continue;
+    sawHeader = true;
+    const path = parsePatchHeader(line);
+    if (path) paths.push(path);
+    else complete = false;
   }
-  if (!input || typeof input !== "object" || seen.has(input)) return [];
+
+  return { paths, complete: sawHeader && complete };
+}
+
+function mergeMutationScans(target: MutationScan, source: MutationScan): void {
+  target.paths.push(...source.paths);
+  target.complete &&= source.complete;
+}
+
+function collectMutationPaths(
+  input: unknown,
+  seen: WeakSet<object>,
+  stringsArePatches = false,
+): MutationScan {
+  if (typeof input === "string") {
+    return stringsArePatches ? scanPatchString(input) : { paths: [], complete: true };
+  }
+  if (!input || typeof input !== "object" || seen.has(input)) {
+    return { paths: [], complete: true };
+  }
 
   seen.add(input);
-  if (Array.isArray(input)) return input.flatMap((value) => collectMutationPaths(value, seen));
+  const scan: MutationScan = { paths: [], complete: true };
+  if (Array.isArray(input)) {
+    for (const value of input) {
+      mergeMutationScans(scan, collectMutationPaths(value, seen, stringsArePatches));
+    }
+    return scan;
+  }
 
-  const { path, ...nested } = input as Record<string, unknown>;
-  if (typeof path === "string" && path.length > 0) return [path];
+  const record = input as Record<string, unknown>;
+  if (typeof record.path === "string" && record.path.length > 0) {
+    scan.paths.push(record.path);
+  }
+  const eventPaths = Array.isArray(record.paths) ? record.paths : [record.paths];
+  for (const path of eventPaths) {
+    if (typeof path === "string" && path.length > 0) scan.paths.push(path);
+  }
 
-  return Object.values(nested).flatMap((value) => collectMutationPaths(value, seen));
+  for (const [key, value] of Object.entries(record)) {
+    if (key === "path" || key === "paths") continue;
+    const childStringsArePatches = stringsArePatches || PATCH_INPUT_KEYS[key] === true;
+    if (typeof value !== "string" && (!value || typeof value !== "object")) continue;
+    mergeMutationScans(scan, collectMutationPaths(value, seen, childStringsArePatches));
+  }
+  return scan;
+}
+
+function inspectMutationPaths(input: unknown): MutationScan {
+  const stringsArePatches = typeof input === "string" || Array.isArray(input);
+  const scan = collectMutationPaths(input, new WeakSet(), stringsArePatches);
+  return { paths: [...new Set(scan.paths)], complete: scan.complete };
 }
 
 /** Return every file path targeted by a write or patch-shaped edit input. */
 export function extractMutationPaths(input: unknown): string[] {
-  return [...new Set(collectMutationPaths(input, new WeakSet()))];
+  return inspectMutationPaths(input).paths;
 }
 
 /** True when a write or patch-shaped edit targets a page in the wiki directory. */
@@ -59,8 +138,9 @@ export function installGuardrails(pi: ExtensionAPI, runtime?: Runtime): void {
     }
 
     if (isToolCallEventType("edit", event)) {
-      const targetPaths = extractMutationPaths(event.input);
-      if (targetPaths.length === 0) {
+      const mutation = inspectMutationPaths(event.input);
+      const targetPaths = mutation.paths;
+      if (!mutation.complete || targetPaths.length === 0) {
         return { block: true, reason: "Cannot determine the files targeted by this edit." };
       }
 

--- a/test/guardrails.test.ts
+++ b/test/guardrails.test.ts
@@ -124,6 +124,88 @@ describe("edit guardrails", () => {
     });
   });
 
+  it("checks nested edit input even when a top-level path is present", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        path: join(vaultPaths.wiki, "sources", "issue-109.md"),
+        input: `[${join(
+          vaultPaths.rawSources,
+          "SRC-2026-07-27-001",
+          "extracted.md",
+        )}#ABCD]\nSWAP 1.=1:\n+changed`,
+      },
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason: "Raw sources are immutable. Use wiki_capture_source to add sources.",
+    });
+  });
+
+  it("blocks a mixed edit when a protected target uses a lowercase tag", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        input: [
+          `[${join(vaultPaths.wiki, "sources", "issue-109.md")}#ABCD]`,
+          "SWAP 1.=1:",
+          "+updated",
+          `[${join(vaultPaths.rawSources, "SRC-2026-07-27-001", "extracted.md")}#abcd]`,
+          "SWAP 1.=1:",
+          "+changed",
+        ].join("\n"),
+      },
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason: "Raw sources are immutable. Use wiki_capture_source to add sources.",
+    });
+  });
+
+  it("blocks a protected target recovered from an apply-patch-prefixed header", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        input: `[*** Update File:${join(
+          vaultPaths.meta,
+          "registry.json",
+        )}#ABCD]\nSWAP 1.=1:\n+changed`,
+      },
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason: "Metadata is auto-generated. Use wiki_rebuild_meta or wiki_log_event instead.",
+    });
+  });
+
+  it("fails closed when a mixed edit contains an unparseable header", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        input: [
+          `[${join(vaultPaths.wiki, "sources", "issue-109.md")}#ABCD]`,
+          "SWAP 1.=1:",
+          "+updated",
+          `[${join(vaultPaths.rawSources, "SRC-2026-07-27-001", "extracted.md")}#XYZ]`,
+          "SWAP 1.=1:",
+          "+changed",
+        ].join("\n"),
+      },
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason: "Cannot determine the files targeted by this edit.",
+    });
+  });
+
   it("blocks a pathless Edit request with a clear error", async () => {
     const handler = captureToolCallHandler();
     const result = await handler({ toolName: "edit", input: { patch: "invalid patch" } });

--- a/test/guardrails.test.ts
+++ b/test/guardrails.test.ts
@@ -206,6 +206,76 @@ describe("edit guardrails", () => {
     });
   });
 
+  it.each([
+    ["raw source", join(vaultPaths.rawSources, "moved.md"), "Raw sources are immutable. Use wiki_capture_source to add sources."],
+    ["metadata", join(vaultPaths.meta, "moved.json"), "Metadata is auto-generated. Use wiki_rebuild_meta or wiki_log_event instead."],
+  ])("blocks a hashline move to protected %s", async (_label, destination, reason) => {
+    const handler = captureToolCallHandler();
+    const source = join(vaultPaths.wiki, "sources", "issue-109.md");
+    const result = await handler({
+      toolName: "edit",
+      input: { input: `[${source}#ABCD]\nMV ${destination}` },
+    });
+
+    expect(result).toEqual({ block: true, reason });
+  });
+
+  it.each([
+    ["raw source", join(vaultPaths.rawSources, "renamed.md"), "Raw sources are immutable. Use wiki_capture_source to add sources."],
+    ["metadata", join(vaultPaths.meta, "renamed.json"), "Metadata is auto-generated. Use wiki_rebuild_meta or wiki_log_event instead."],
+  ])("blocks a JSON patch rename to protected %s", async (_label, destination, reason) => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        path: join(vaultPaths.wiki, "sources", "issue-109.md"),
+        edits: [{ op: "update", rename: destination, diff: "@@\n unchanged" }],
+      },
+    });
+
+    expect(result).toEqual({ block: true, reason });
+  });
+
+  it("blocks a mixed ordinary edit and protected move destination", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        input: [
+          `[${join(vaultPaths.wiki, "sources", "issue-109.md")}#ABCD]`,
+          "INS.TAIL:",
+          "+updated",
+          `[${join(vaultPaths.wiki, "sources", "move-source.md")}#1234]`,
+          `MV ${join(vaultPaths.rawSources, "move-destination.md")}`,
+        ].join("\n"),
+      },
+    });
+
+    expect(result).toEqual({
+      block: true,
+      reason: "Raw sources are immutable. Use wiki_capture_source to add sources.",
+    });
+  });
+
+  it("allows an ordinary JSON patch rename", async () => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        path: join(vaultPaths.wiki, "sources", "issue-109.md"),
+        edits: [
+          {
+            op: "update",
+            rename: join(vaultPaths.wiki, "sources", "renamed-issue-109.md"),
+            diff: "@@\n unchanged",
+          },
+        ],
+      },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
   it("blocks a pathless Edit request with a clear error", async () => {
     const handler = captureToolCallHandler();
     const result = await handler({ toolName: "edit", input: { patch: "invalid patch" } });

--- a/test/guardrails.test.ts
+++ b/test/guardrails.test.ts
@@ -276,6 +276,62 @@ describe("edit guardrails", () => {
     expect(result).toBeUndefined();
   });
 
+  it.each([
+    [
+      "raw source",
+      `"*** Update File:${join(vaultPaths.rawSources, "quoted-source.md")}"`,
+      "Raw sources are immutable. Use wiki_capture_source to add sources.",
+    ],
+    [
+      "metadata",
+      `"*** Delete File:${join(vaultPaths.meta, "quoted-source.json")}"`,
+      "Metadata is auto-generated. Use wiki_rebuild_meta or wiki_log_event instead.",
+    ],
+  ])("blocks a quoted recovery-prefixed %s header", async (_label, source, reason) => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: { input: `[${source}#ABCD]\nREM` },
+    });
+
+    expect(result).toEqual({ block: true, reason });
+  });
+
+  it.each([
+    [
+      "raw source",
+      `*** Move to:${join(vaultPaths.rawSources, "prefixed-move.md")}`,
+      "Raw sources are immutable. Use wiki_capture_source to add sources.",
+    ],
+    [
+      "metadata",
+      `"*** Move to:${join(vaultPaths.meta, "prefixed-move.json")}"`,
+      "Metadata is auto-generated. Use wiki_rebuild_meta or wiki_log_event instead.",
+    ],
+  ])("blocks a recovery-prefixed move to protected %s", async (_label, destination, reason) => {
+    const handler = captureToolCallHandler();
+    const result = await handler({
+      toolName: "edit",
+      input: {
+        input: `[${join(vaultPaths.wiki, "sources", "issue-109.md")}#ABCD]\nMV ${destination}`,
+      },
+    });
+
+    expect(result).toEqual({ block: true, reason });
+  });
+
+  it("normalizes ordinary quoted recovery-prefixed sources and destinations", async () => {
+    const source = join(vaultPaths.wiki, "sources", "quoted-source.md");
+    const destination = join(vaultPaths.wiki, "sources", "quoted-destination.md");
+    const input = {
+      input: `["*** Update File:${source}"#ABCD]\nMV "*** Move to:${destination}"`,
+    };
+
+    expect(extractMutationPaths(input)).toEqual([source, destination]);
+    const handler = captureToolCallHandler();
+    expect(await handler({ toolName: "edit", input })).toBeUndefined();
+  });
+
   it("blocks a pathless Edit request with a clear error", async () => {
     const handler = captureToolCallHandler();
     const result = await handler({ toolName: "edit", input: { patch: "invalid patch" } });


### PR DESCRIPTION
## Summary
- collect nested edit targets even when an extra top-level `path` is present
- normalize lowercase, quoted, and apply-patch-prefixed hashline headers before authorization
- fail closed when any patch header cannot be accounted for
- honor OMP-enriched `paths` arrays without weakening raw/meta protection

## Verification
- `pnpm exec vitest run test/guardrails.test.ts` (12 passed)
- `pnpm exec vitest run test/guardrails.test.ts test/e2e-guardrails.test.ts test/agent-start-injection.test.ts` (29 passed)

The regression cases cover top-level safe `path` plus nested protected `input`, mixed exact-safe plus lowercase protected headers, recovered `*** Update File:` protected headers, and mixed malformed headers failing closed.