### PR TITLE
refactor: deduplicate slugify + fix ingest-worker test

### DIFF
--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -26,6 +26,7 @@ import {
   getVaultPaths,
   readJson,
   resolveVaultPaths,
+  slugify,
   writeJson,
 } from "./utils.js";
 
@@ -544,13 +545,7 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
         | "requirement"
         | "skill"
         | "case";
-      const slug =
-        params.title
-          .toLocaleLowerCase()
-          .replace(/[^\p{L}\p{N}\s-]/gu, "")
-          .trim()
-          .replace(/\s+/g, "-")
-          .slice(0, 80) || "untitled";
+      const slug = slugify(params.title);
 
       const folderMap: Record<string, string> = {
         entity: "entities",

--- a/test/ingest-worker.test.ts
+++ b/test/ingest-worker.test.ts
@@ -126,6 +126,7 @@ describe("commitSynthesis", () => {
       },
       "2026-06-06",
     );
-    expect(res.entitiesCreated).toEqual([]);
+    // Non-alphanumeric titles fall back to "untitled" slug.
+    expect(res.entitiesCreated).toEqual(["untitled"]);
   });
 });


### PR DESCRIPTION
## Changes

1. **Deduplicate slugify** — Import `slugify` from utils.ts into tools.ts, replace inline block in `wiki_ensure_page`. Addresses tech-debt issue #113.

2. **Fix broken test** — `test/ingest-worker.test.ts`: punctuation-only entity titles ("!!!") now produce `"untitled"` slug instead of empty string (due to PR #111 fallback). Updated test expectation accordingly.

## Stats

- `-8` lines removed, `+4` added
- All 395 tests pass, lint clean