### PR TITLE
fix: harden slugify for full-width forms, hyphen runs, and Windows reserved names

### DIFF
--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -368,14 +368,26 @@ export function extractWikilinks(content: string): string[] {
   return links;
 }
 
-/** Slugify a title. */
+/**
+ * Slugify a title to a kebab-case page slug.
+ *
+ * - NFKC-folds full-width forms (letters/digits/ideographic space) to ASCII
+ *   so `ＡＢＣ` and `ABC` produce the same slug.
+ * - Collapses whitespace AND existing hyphens into a single `-`.
+ * - Trims leading/trailing hyphens.
+ * - Prefixes Windows reserved device names (CON, PRN, AUX, NUL, COM1-9,
+ *   LPT1-9) with `_` so writing `<slug>.md` never throws on Windows.
+ */
 export function slugify(title: string): string {
   return (
     title
       .toLocaleLowerCase()
+      .normalize("NFKC")
       .replace(/[^\p{L}\p{N}\s-]/gu, "")
       .trim()
-      .replace(/\s+/g, "-")
+      .replace(/[\s-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .replace(/^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i, "_$1")
       .slice(0, 80) || "untitled"
   );
 }

--- a/test/slugify.test.ts
+++ b/test/slugify.test.ts
@@ -12,4 +12,30 @@ describe("slugify", () => {
     expect(slugify("！！！")).toBe("untitled");
     expect(slugify("   ")).toBe("untitled");
   });
+
+  it("should fold full-width forms to ASCII (NFKC)", () => {
+    expect(slugify("ＡＢＣ")).toBe("abc");
+    expect(slugify("１２３")).toBe("123");
+    expect(slugify("Ｆｕｌｌ　Ｗｉｄｔｈ")).toBe("full-width");
+  });
+
+  it("should collapse whitespace and existing hyphens", () => {
+    expect(slugify("A - B")).toBe("a-b");
+    expect(slugify("a--b")).toBe("a-b");
+    expect(slugify("中文 - 标题")).toBe("中文-标题");
+  });
+
+  it("should trim leading and trailing hyphens", () => {
+    expect(slugify("- foo -")).toBe("foo");
+    expect(slugify("---")).toBe("untitled");
+  });
+
+  it("should guard Windows reserved device names", () => {
+    expect(slugify("con")).toBe("_con");
+    expect(slugify("CON")).toBe("_con");
+    expect(slugify("COM1")).toBe("_com1");
+    expect(slugify("LPT9")).toBe("_lpt9");
+    expect(slugify("NUL")).toBe("_nul");
+    expect(slugify("console")).toBe("console");
+  });
 });


### PR DESCRIPTION
Problem
- On Windows, wiki_ensure_page / ingest crash when a page title is a reserved device name (CON, PRN, AUX, NUL, COM1-9, LPT1-9): writeFileSync("<slug>.md") throws EBUSY/EPERM.
- Full-width titles produce slugs that differ from their ASCII equivalents (ＡＢＣ vs ABC), so the same page gets two distinct slugs.
- Titles with surrounding or repeated hyphens (A - B, - foo -) produce a---b / -foo- instead of clean kebab-case.

Root cause — slugify() in extensions/llm-wiki/lib/utils.ts:
- no NFKC normalization before the character filter;
- collapses whitespace only (/\s+/g), not existing hyphens;
- never trims leading/trailing hyphens;
- no guard for Windows reserved device names.

Regression tests — added in test/slugify.test.ts covering each behavior: full-width folding, hyphen collapse (A - B → a-b), hyphen trimming (- foo - → foo, --- → untitled), and reserved-name guarding (con → _con, COM1 → _com1; console unaffected). All existing    
tests unchanged and passing.

🤖 Generated with Claude Code