### PR TITLE
fix: harden slugify for full-width forms, hyphen runs, and Windows reserved  names

### DIFF
--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -276,15 +276,28 @@ function nextSequentialId(dir: string, kind: string): string {
   return `${prefix}-${String(num + 1).padStart(3, "0")}`;
 }
 
-/** Slugify a title. */
+/**
+ * Slugify a title to a kebab-case page slug.
+ *
+ * - NFKC-folds full-width forms (letters/digits/ideographic space) to ASCII
+ *   so `ＡＢＣ` and `ABC` produce the same slug.
+ * - Collapses whitespace AND existing hyphens into a single `-`.
+ * - Trims leading/trailing hyphens.
+ * - Prefixes Windows reserved device names (CON, PRN, AUX, NUL, COM1-9,
+ *   LPT1-9) with `_` so writing `<slug>.md` never throws on Windows.
+ * - Appends `-page` to `index`/`log` slugs to avoid colliding with the
+ *   special INDEX/LOG wiki pages.
+ */
 export function slugify(title: string): string {
   const slug =
     title
       .toLocaleLowerCase()
-      .normalize("NFC")
+      .normalize("NFKC")
       .replace(/[^\p{L}\p{N}\s-]/gu, "")
       .trim()
-      .replace(/\s+/g, "-")
+      .replace(/[\s-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .replace(/^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i, "_$1")
       .slice(0, 80) || "untitled";
   return slug === "index" || slug === "log" ? `${slug}-page` : slug;
 }

--- a/test/slugify.test.ts
+++ b/test/slugify.test.ts
@@ -12,4 +12,37 @@ describe("slugify", () => {
     expect(slugify("！！！")).toBe("untitled");
     expect(slugify("   ")).toBe("untitled");
   });
+
+  it("should fold full-width forms to ASCII (NFKC)", () => {
+    expect(slugify("ＡＢＣ")).toBe("abc");
+    expect(slugify("１２３")).toBe("123");
+    expect(slugify("Ｆｕｌｌ　Ｗｉｄｔｈ")).toBe("full-width");
+  });
+
+  it("should collapse whitespace and existing hyphens", () => {
+    expect(slugify("A - B")).toBe("a-b");
+    expect(slugify("a--b")).toBe("a-b");
+    expect(slugify("中文 - 标题")).toBe("中文-标题");
+  });
+
+  it("should trim leading and trailing hyphens", () => {
+    expect(slugify("- foo -")).toBe("foo");
+    expect(slugify("---")).toBe("untitled");
+  });
+
+  it("should guard Windows reserved device names", () => {
+    expect(slugify("con")).toBe("_con");
+    expect(slugify("CON")).toBe("_con");
+    expect(slugify("COM1")).toBe("_com1");
+    expect(slugify("LPT9")).toBe("_lpt9");
+    expect(slugify("NUL")).toBe("_nul");
+    expect(slugify("console")).toBe("console");
+  });
+
+  it("should avoid colliding with the special INDEX/LOG pages", () => {
+    expect(slugify("index")).toBe("index-page");
+    expect(slugify("log")).toBe("log-page");
+    expect(slugify("Index")).toBe("index-page");
+    expect(slugify("index-page")).toBe("index-page");
+  });
 });


### PR DESCRIPTION
  ▎ Problem
  ▎ - On Windows, page creation crashes when a title is a reserved device name (CON, PRN, 
  ▎ AUX, NUL, COM1-9, LPT1-9): writeFileSync("<slug>.md") throws EBUSY/EPERM.
  ▎ - Full-width titles (ＡＢＣ vs ABC) produce distinct slugs for the same page.
  ▎ - Titles with surrounding or repeated hyphens (A - B, - foo -) produce a---b / -foo-. 
  ▎
  ▎ Root cause — slugify() in extensions/llm-wiki/lib/utils.ts:
  ▎ - normalize("NFC") (added in #117) does not fold full-width forms — upgraded here to  
  ▎ NFKC, which is a superset and covers NFC's composition;
  ▎ - collapses whitespace only (/\s+/g), not existing hyphens;
  ▎ - never trims leading/trailing hyphens;
  ▎ - no guard for Windows reserved device names.
  ▎
  ▎ Regression tests — test/slugify.test.ts covers each behavior: full-width folding      
  ▎ (ＡＢＣ → abc), hyphen collapse (A - B → a-b), trimming (- foo - → foo, --- →
  ▎ untitled), reserved-name guarding (con → _con, COM1 → _com1; console unaffected), and 
  ▎ the existing index/log collision guard remains covered. Existing tests unchanged, all 
  ▎ passing.

  ▎ 🤖 Generated with Claude Code