### PR TITLE
fix: preserve slug identity during width folding

### DIFF
--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -279,26 +279,33 @@ function nextSequentialId(dir: string, kind: string): string {
 /**
  * Slugify a title to a kebab-case page slug.
  *
- * - NFKC-folds full-width forms (letters/digits/ideographic space) to ASCII
- *   so `ＡＢＣ` and `ABC` produce the same slug.
+ * - Folds full-width ASCII forms and ideographic spaces without changing
+ *   unrelated Unicode compatibility characters.
  * - Collapses whitespace AND existing hyphens into a single `-`.
  * - Trims leading/trailing hyphens.
  * - Prefixes Windows reserved device names (CON, PRN, AUX, NUL, COM1-9,
- *   LPT1-9) with `_` so writing `<slug>.md` never throws on Windows.
+ *   LPT1-9, including superscript 1-3 forms) with `_`.
  * - Appends `-page` to `index`/`log` slugs to avoid colliding with the
  *   special INDEX/LOG wiki pages.
  */
 export function slugify(title: string): string {
   const slug =
     title
-      .toLocaleLowerCase()
-      .normalize("NFKC")
+      .replace(/[\uFF01-\uFF5E]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0xfee0))
+      .replace(/\u3000/g, " ")
+      .toLowerCase()
+      .normalize("NFC")
       .replace(/[^\p{L}\p{N}\s-]/gu, "")
       .trim()
       .replace(/[\s-]+/g, "-")
       .replace(/^-+|-+$/g, "")
-      .replace(/^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i, "_$1")
-      .slice(0, 80) || "untitled";
+      .slice(0, 80)
+      .replace(/[\uD800-\uDBFF]$/, "")
+      .replace(/^-+|-+$/g, "") || "untitled";
+
+  if (/^(?:con|prn|aux|nul|com(?:[1-9¹²³])|lpt(?:[1-9¹²³]))$/.test(slug)) {
+    return `_${slug}`;
+  }
   return slug === "index" || slug === "log" ? `${slug}-page` : slug;
 }
 

--- a/test/ingest-worker.test.ts
+++ b/test/ingest-worker.test.ts
@@ -112,6 +112,33 @@ describe("commitSynthesis", () => {
     expect(readFileSync(existing, "utf-8")).toBe("PRE-EXISTING CONTENT");
   });
 
+  it("uses stable canonical slugs when linking existing pages", () => {
+    const paths = getVaultPaths(wikiDir);
+    writeFileSync(join(paths.wiki, "entities", "①.md"), "NUMBERED ENTITY", "utf-8");
+    writeFileSync(join(paths.wiki, "concepts", "abc.md"), "ASCII CONCEPT", "utf-8");
+
+    const res = commitSynthesis(
+      paths,
+      "SRC-001",
+      MANIFEST,
+      {
+        summary: "s",
+        key_takeaways: [],
+        entities: [{ title: "①", description: "Numbered entity" }],
+        concepts: [{ title: "ＡＢＣ", definition: "Full-width concept" }],
+      },
+      "2026-06-06",
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.entitiesLinked).toEqual(["①"]);
+    expect(res.conceptsLinked).toEqual(["abc"]);
+    expect(res.entitiesCreated).toEqual([]);
+    expect(res.conceptsCreated).toEqual([]);
+    expect(existsSync(join(paths.wiki, "entities", "1.md"))).toBe(false);
+  });
+
   it("appends an ingest event and rebuilds registry on metadata rebuild", () => {
     const paths = getVaultPaths(wikiDir);
     const res = commitSynthesis(paths, "SRC-001", MANIFEST, DATA, "2026-06-06");

--- a/test/slugify.test.ts
+++ b/test/slugify.test.ts
@@ -13,10 +13,13 @@ describe("slugify", () => {
     expect(slugify("   ")).toBe("untitled");
   });
 
-  it("should fold full-width forms to ASCII (NFKC)", () => {
+  it("should fold full-width ASCII forms without changing other Unicode identities", () => {
     expect(slugify("ＡＢＣ")).toBe("abc");
     expect(slugify("１２３")).toBe("123");
     expect(slugify("Ｆｕｌｌ　Ｗｉｄｔｈ")).toBe("full-width");
+    expect(slugify("①")).toBe("①");
+    expect(slugify("ﬁ")).toBe("ﬁ");
+    expect(slugify("™")).toBe("untitled");
   });
 
   it("should collapse whitespace and existing hyphens", () => {
@@ -25,9 +28,11 @@ describe("slugify", () => {
     expect(slugify("中文 - 标题")).toBe("中文-标题");
   });
 
-  it("should trim leading and trailing hyphens", () => {
+  it("should trim edge hyphens after Unicode-safe truncation", () => {
     expect(slugify("- foo -")).toBe("foo");
     expect(slugify("---")).toBe("untitled");
+    expect(slugify(`${"a".repeat(79)}-b`)).toBe("a".repeat(79));
+    expect(slugify(`${"a".repeat(79)}𐐀`)).toBe("a".repeat(79));
   });
 
   it("should guard Windows reserved device names", () => {
@@ -35,6 +40,8 @@ describe("slugify", () => {
     expect(slugify("CON")).toBe("_con");
     expect(slugify("COM1")).toBe("_com1");
     expect(slugify("LPT9")).toBe("_lpt9");
+    expect(slugify("COM¹")).toBe("_com¹");
+    expect(slugify("LPT³")).toBe("_lpt³");
     expect(slugify("NUL")).toBe("_nul");
     expect(slugify("console")).toBe("console");
   });
@@ -44,5 +51,7 @@ describe("slugify", () => {
     expect(slugify("log")).toBe("log-page");
     expect(slugify("Index")).toBe("index-page");
     expect(slugify("index-page")).toBe("index-page");
+    expect(slugify("ᴵndex")).toBe("ᴵndex");
+    expect(slugify("ᴸog")).toBe("ᴸog");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #119. Fixes #120.

- replace broad NFKC with targeted full-width ASCII and ideographic-space folding
- lowercase after width folding while retaining NFC identity
- protect Windows superscript device forms without globally folding superscripts
- truncate on the existing 80 UTF-16-unit boundary without emitting an unpaired surrogate
- trim hyphens again after truncation
- cover production ingestion lookup for preserved and folded page identities

## Verified behavior

- `ＡＢＣ` and `ABC` both resolve to `abc`
- `①` and `ﬁ` retain their pre-#119 page identities
- `ᴵndex` no longer becomes reserved `Index`
- `COM¹` and `LPT³` remain Windows-safe
- truncation cannot leave a dangling high surrogate or edge hyphen

## Checks

- `pnpm test` — 542 passed
- `pnpm typecheck`
- `pnpm lint`
