### PR TITLE
fix: remove unused imports flagged by CodeQL

### DIFF
--- a/test/ingest-worker-synthesis-language.test.ts
+++ b/test/ingest-worker-synthesis-language.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -44,7 +44,6 @@ describe("runIngestSynthesis language injection", () => {
 
   it("appends language instruction when synthesisLanguage is set", async () => {
     const { runIngestSynthesis } = await import("../extensions/llm-wiki/lib/ingest-worker.js");
-    const { runSubAgent } = await import("../extensions/llm-wiki/lib/subagent.js");
 
     const spy = vi
       .spyOn(await import("../extensions/llm-wiki/lib/subagent.js"), "runSubAgent")

--- a/test/synthesis-language.test.ts
+++ b/test/synthesis-language.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import {
   loadTaskConfig,
   validateSynthesisLanguage,


### PR DESCRIPTION
- test/ingest-worker-synthesis-language.test.ts: remove writeFileSync import, unused runSubAgent destructuring
- test/synthesis-language.test.ts: remove readFileSync, beforeEach imports