### PR TITLE
fix: instant completion toast for background wiki actions (#132)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -223,6 +223,10 @@ Deterministic health check of the wiki. Scans for orphan pages (no inbound links
 (linked but not created), and contradiction markers. Optionally auto-creates stub pages for
 knowledge gaps cited in two or more pages.
 
+Runs **asynchronously**: the tool acknowledges immediately and scans off-thread. On completion a
+UI toast fires instantly (when a UI is available) and the full health report is delivered with
+the next user message.
+
 **Parameters**
 
 | Name | Type | Required | Description |
@@ -277,8 +281,12 @@ Health is `"⚠️ Warning"` when orphan count exceeds 5, `"🔴 Empty"` when th
 
 ## wiki_rebuild_meta
 
-Force a full synchronous rebuild of all generated metadata: `registry.json`, `backlinks.json`,
+Force a full rebuild of all generated metadata: `registry.json`, `backlinks.json`,
 `index.md`, `log.md`. Use when metadata appears out of sync with actual wiki files.
+
+Runs **asynchronously**: the tool acknowledges immediately and rebuilds off-thread. On completion
+a UI toast fires instantly (when a UI is available) and the result is delivered with the next
+user message.
 
 If `meta/events.jsonl` is missing or unreadable, rebuild reports a warning and preserves existing log projections while continuing to rebuild registry, backlinks, and indexes. A present zero-byte event file is an intentional empty history.
 

--- a/extensions/llm-wiki/lib/runtime.ts
+++ b/extensions/llm-wiki/lib/runtime.ts
@@ -214,7 +214,14 @@ export class Runtime {
   launchReported(ctx: LaunchCtx, label: string, work: () => Promise<string | null>): Promise<void> {
     return this.launchTask(ctx, label, async () => {
       const summary = await work();
-      if (summary) this.report(summary);
+      if (summary) {
+        // Instant completion feedback: the nextTurn report below is queued for
+        // the next user prompt, so without a toast a background task looks
+        // stuck. Mirrors the failure notification in launchTask and the
+        // success toast already used by wiki_ingest.
+        if (ctx.hasUI && ctx.ui) ctx.ui.notify(summary.split("\n")[0].replace(/\*\*/g, ""), "info");
+        this.report(summary);
+      }
     });
   }
 

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -821,7 +821,7 @@ export function registerWikiLint(pi: ExtensionAPI, runtime?: Runtime): void {
       return dispatchReported(runtime, ctx as ToolCtx, {
         label: `lint:${paths.root}`,
         started:
-          "\u{1F9F9} LLM Wiki: lint started in the background — the health report will be posted when it completes.",
+          "\u{1F9F9} LLM Wiki: lint started in the background — the health report will be posted with your next message.",
         work: async () => runWikiLint(paths, params.auto_fix === true),
       });
     },
@@ -1106,7 +1106,7 @@ export function registerWikiRebuildMeta(pi: ExtensionAPI, runtime?: Runtime): vo
       return dispatchReported(runtime, ctx as ToolCtx, {
         label: `rebuild_meta:${paths.root}`,
         started:
-          "\u{1F9E0} LLM Wiki: metadata rebuild started in the background — the result will be reported when it completes.",
+          "\u{1F9E0} LLM Wiki: metadata rebuild started in the background — the result will be reported with your next message.",
         work: async () => {
           const result = rebuildMetadata(paths);
           // No rebuild_meta event — rebuild is a projection, not an authoritative mutation
@@ -1187,7 +1187,7 @@ export function registerWikiReindexEmbeddings(pi: ExtensionAPI, runtime?: Runtim
       // report the stats on completion (issue #77).
       return dispatchReported(runtime, ctx as ToolCtx, {
         label: `reindex_embeddings:${paths.root}`,
-        started: `\u{1F9E0} LLM Wiki: embedding reindex started in the background (${embedder.model}) — stats will be reported when it completes.`,
+        started: `\u{1F9E0} LLM Wiki: embedding reindex started in the background (${embedder.model}) — stats will be reported with your next message.`,
         details: { enabled: true, model: embedder.model },
         work: async () => {
           const stats = await reindexEmbeddings(paths, embedder, { force: params.force === true });

--- a/test/background-report.test.ts
+++ b/test/background-report.test.ts
@@ -1,0 +1,104 @@
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { afterEach, expect, it } from "vitest";
+import { Runtime } from "../extensions/llm-wiki/lib/runtime.js";
+import { registerWikiLint, registerWikiRebuildMeta } from "../extensions/llm-wiki/lib/tools.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+
+type TestTool = {
+  execute: (...args: unknown[]) => Promise<{
+    isError?: boolean;
+    content: Array<{ text: string }>;
+  }>;
+};
+
+const root = join(import.meta.dirname, "..", "tmp", `background-report-${Date.now()}`);
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+function register(fn: (api: ExtensionAPI, runtime?: Runtime) => void, runtime: Runtime): TestTool {
+  let tool: TestTool | undefined;
+  fn(
+    {
+      registerTool: (definition: unknown) => {
+        tool = definition as TestTool;
+      },
+    } as unknown as ExtensionAPI,
+    runtime,
+  );
+  if (!tool) throw new Error("tool was not registered");
+  return tool;
+}
+
+it("acknowledges background work, notifies instantly on completion, reports nextTurn", async () => {
+  const paths = getVaultPaths(root);
+  ensureVaultStructure(paths);
+  writeFileSync(join(paths.dotWiki, "config.json"), JSON.stringify({ name: "Background report" }));
+  writeFileSync(join(paths.wiki, "concepts", "valid.md"), "---\ntype: concept\n---\n\nValid.\n");
+
+  const toasts: Array<{ message: string; level: string | undefined }> = [];
+  const sent: Array<{ message: unknown; opts: { deliverAs?: string } }> = [];
+  const runtime = new Runtime();
+  runtime.pi = {
+    sendMessage: (message: unknown, opts: { deliverAs?: string }) => sent.push({ message, opts }),
+  } as unknown as ExtensionAPI;
+  const fakeCtx = {
+    cwd: root,
+    hasUI: true,
+    ui: {
+      notify: (message: string, level?: string) => {
+        toasts.push({ message, level });
+      },
+    },
+  };
+
+  // wiki_lint: background ack + instant toast + nextTurn report.
+  const lint = register(registerWikiLint, runtime);
+  const lintResult = await lint.execute("test", { auto_fix: false }, undefined, undefined, fakeCtx);
+  expect(lintResult.isError).not.toBe(true);
+  expect(lintResult.content[0].text).toContain("started in the background");
+  expect(lintResult.content[0].text).toContain("with your next message");
+
+  await runtime.awaitAll();
+  expect(toasts).toEqual([{ message: "🧹 LLM Wiki lint complete", level: "info" }]);
+  expect(sent).toHaveLength(1);
+  expect(sent[0].opts.deliverAs).toBe("nextTurn");
+
+  // wiki_rebuild_meta: same delivery contract.
+  const rebuild = register(registerWikiRebuildMeta, runtime);
+  const rebuildResult = await rebuild.execute("test", {}, undefined, undefined, fakeCtx);
+  expect(rebuildResult.content[0].text).toContain("started in the background");
+  expect(rebuildResult.content[0].text).toContain("with your next message");
+  await runtime.awaitAll();
+  expect(toasts).toHaveLength(2);
+  expect(sent).toHaveLength(2);
+});
+
+it("skips the toast and nextTurn report when the work has no summary", async () => {
+  const paths = getVaultPaths(root);
+  ensureVaultStructure(paths);
+  writeFileSync(join(paths.dotWiki, "config.json"), JSON.stringify({ name: "Background report" }));
+  writeFileSync(join(paths.wiki, "concepts", "valid.md"), "---\ntype: concept\n---\n\nValid.\n");
+
+  const toasts: Array<{ message: string; level: string | undefined }> = [];
+  const sent: unknown[] = [];
+  const runtime = new Runtime();
+  runtime.pi = {
+    sendMessage: (message: unknown) => sent.push(message),
+  } as unknown as ExtensionAPI;
+  runtime.launchReported(
+    {
+      hasUI: true,
+      ui: {
+        notify: (message: string, level?: string) => {
+          toasts.push({ message, level });
+        },
+      },
+    },
+    "test:noop",
+    async () => null,
+  );
+  await runtime.awaitAll();
+  expect(toasts).toEqual([]);
+  expect(sent).toEqual([]);
+});


### PR DESCRIPTION
Fixes #132

## Problem

Background wiki actions (`wiki_lint`, `wiki_rebuild_meta`, `wiki_reindex_embeddings`) acknowledged immediately but only delivered results via `sendMessage(..., { deliverAs: "nextTurn" })` — queued for the **next user prompt**. Between the acknowledgement and the next prompt the operation is invisible, so it looks stuck.

The failure path already fired an instant `ctx.ui.notify(..., "warning")` toast (runtime.ts `launchTask` catch), and `wiki_ingest` already fired a success toast (tools.ts:434-439) — success for the other background tools was the odd one out.

## Fix

- **`runtime.ts` — `launchReported`**: on completion, when a UI is available, fire an instant `ctx.ui.notify(summaryFirstLine, "info")` toast — mirroring the existing failure toast and the ingest success toast. The full report still goes through `nextTurn` (the safety contract is unchanged).
- **`tools.ts`**: acknowledgement text now says the result arrives *with your next message* instead of the vague "when it completes" (all three background tools).
- **`docs/api.md`**: `wiki_lint` and `wiki_rebuild_meta` now documented as asynchronous (rebuild no longer claims to be synchronous).
- **Tests** (`test/background-report.test.ts`, new): asserts the ack text, the instant toast (`🧹 LLM Wiki lint complete`, `info`), `nextTurn` delivery, and the null-summary no-op path.

## Verification

- `test/background-report.test.ts`: 2/2 pass
- `pnpm typecheck`, biome: clean
- Full suite: 581 passed, 3 pre-existing failures in `vault-format`/`migration-script` (NFC path collisions, unrelated — also failing on clean `main`)

Note: this branch is based on `main` and does not include the (separate, still-open) #133 gap-snapshot fix from PR #137 — both touch `tools.ts` in different regions and should merge cleanly.
