### PR TITLE
fix: capture ctx before await in launchReported so stale proxy cannot break completion (fixes #142)

### DIFF
--- a/extensions/llm-wiki/lib/runtime.ts
+++ b/extensions/llm-wiki/lib/runtime.ts
@@ -213,13 +213,18 @@ export class Runtime {
    */
   launchReported(ctx: LaunchCtx, label: string, work: () => Promise<string | null>): Promise<void> {
     return this.launchTask(ctx, label, async () => {
+      // Capture synchronously — after `await work()` the extension ctx may be
+      // a stale proxy (newSession/fork/switchSession/reload) and accessing
+      // ctx.hasUI or ctx.ui on it throws (see launchTask).
+      const hasUI = ctx.hasUI;
+      const ui = ctx.ui;
       const summary = await work();
       if (summary) {
         // Instant completion feedback: the nextTurn report below is queued for
         // the next user prompt, so without a toast a background task looks
         // stuck. Mirrors the failure notification in launchTask and the
         // success toast already used by wiki_ingest.
-        if (ctx.hasUI && ctx.ui) ctx.ui.notify(summary.split("\n")[0].replace(/\*\*/g, ""), "info");
+        if (hasUI && ui) ui.notify(summary.split("\n")[0].replace(/\*\*/g, ""), "info");
         this.report(summary);
       }
     });

--- a/test/background-report.test.ts
+++ b/test/background-report.test.ts
@@ -102,3 +102,41 @@ it("skips the toast and nextTurn report when the work has no summary", async () 
   expect(toasts).toEqual([]);
   expect(sent).toEqual([]);
 });
+
+it("captures ctx before await so a stale ctx proxy cannot break completion (issue #142)", async () => {
+  const toasts: Array<{ message: string; level: string | undefined }> = [];
+  const sent: Array<{ message: unknown; opts: { deliverAs?: string } }> = [];
+  const runtime = new Runtime();
+  runtime.pi = {
+    sendMessage: (message: unknown, opts: { deliverAs?: string }) => sent.push({ message, opts }),
+  } as unknown as ExtensionAPI;
+
+  // Simulate a stale extension ctx: property access throws once the
+  // background work is running (as after newSession/fork/switchSession/reload).
+  let stale = false;
+  const staleCtx = {
+    get hasUI() {
+      if (stale) throw new Error("stale ctx proxy");
+      return true;
+    },
+    get ui() {
+      if (stale) throw new Error("stale ctx proxy");
+      return {
+        notify: (message: string, level?: string) => {
+          toasts.push({ message, level });
+        },
+      };
+    },
+  };
+
+  await runtime.launchReported(staleCtx, "test:stale", async () => {
+    stale = true; // ctx goes stale while work is in flight
+    return "✅ done";
+  });
+  await runtime.awaitAll();
+
+  // Success toast still fires (captured before await) and no false failure toast.
+  expect(toasts).toEqual([{ message: "✅ done", level: "info" }]);
+  expect(sent).toHaveLength(1);
+  expect(sent[0].opts.deliverAs).toBe("nextTurn");
+});


### PR DESCRIPTION
## Fixes #142

## Problem

`Runtime.launchReported` read `ctx.hasUI`/`ctx.ui` **after** `await work()`. When the session switches/forks/reloads while background work runs, the extension ctx is a stale proxy and property access **throws** → `launchTask`'s catch fires a false `warning` toast (`LLM Wiki: <label> failed: ...`) and `report(summary)` is skipped, losing the `nextTurn` completion report.

## Fix

Capture `hasUI`/`ui` synchronously **before** `await work()`, mirroring the existing pattern in `launchTask`:

```ts
launchReported(ctx: LaunchCtx, label: string, work: () => Promise<string | null>): Promise<void> {
  return this.launchTask(ctx, label, async () => {
    const hasUI = ctx.hasUI; // capture before await
    const ui = ctx.ui;
    const summary = await work();
    if (summary) {
      if (hasUI && ui) ui.notify(summary.split("\n")[0].replace(/\*\*/g, ""), "info");
      this.report(summary);
    }
  });
}
```

## Regression test

`test/background-report.test.ts` — new test simulates a ctx whose `hasUI`/`ui` getters throw once work is in flight (stale proxy). Verified it **fails on the pre-fix code** (asserts the false `failed` toast) and passes with the fix.

## Verification

- `pnpm test`: 592 passed (46 files)
- `pnpm typecheck`: clean
- `pnpm lint` (biome): clean