### PR TITLE
fix: compare physical paths in isPersonalVault (fixes #145)

### DIFF
--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -120,9 +120,29 @@ export function migrateDoubledPersonalVault(
 /**
  * Check if a vault is the personal wiki location.
  * Used in layered recall to avoid double-counting.
+ *
+ * Compares PHYSICAL paths, not strings. On image-based ("atomic") Linux
+ * distributions `/home` is a symlink to `var/home`, so `homedir()` yields the
+ * `$HOME` string (`/home/u`) while `process.cwd()` — and therefore the root
+ * `resolveVaultRoot()` walks up to — yields `/var/home/u`. A string compare
+ * calls the personal vault a project vault, which makes layered recall search
+ * the same vault twice and `vaultPageCount()` double-count it.
+ *
+ * Exact equality, NOT containment: a vault nested under the home directory
+ * (`~/projects/foo/.llm-wiki`) is a project vault and must stay one.
  */
 export function isPersonalVault(paths: VaultPaths): boolean {
-  return paths.root === getPersonalWikiRoot();
+  const personalRoot = getPersonalWikiRoot();
+  // Fast path: identical strings need no filesystem syscalls.
+  if (paths.root === personalRoot) return true;
+  try {
+    return relativePhysicalPath(personalRoot, paths.root) === "";
+  } catch {
+    // Unresolvable path (permissions, symlink cycle): fall back to "not
+    // personal" so layered recall degrades to searching both vaults rather
+    // than silently dropping the personal layer.
+    return false;
+  }
 }
 
 /**

--- a/test/personal-wiki-paths.test.ts
+++ b/test/personal-wiki-paths.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -6,7 +14,9 @@ import {
   getPersonalWikiPaths,
   getPersonalWikiRoot,
   getVaultPaths,
+  isPersonalVault,
   migrateDoubledPersonalVault,
+  resolveVaultPaths,
 } from "../extensions/llm-wiki/lib/utils.js";
 
 /**
@@ -165,5 +175,94 @@ describe("migrateDoubledPersonalVault", () => {
     // And the migrated content is reachable through the standard paths.
     const sources = readdirSync(join(paths.wiki, "sources"));
     expect(sources).toContain("note.md");
+  });
+});
+
+/**
+ * Regression suite for issue #145: `isPersonalVault()` compared root strings,
+ * so on image-based ("atomic") Linux distributions — where `/home` is a
+ * symlink to `var/home` — the personal vault was classified as a project
+ * vault.
+ *
+ * `homedir()` returns the `$HOME` string (`/home/u`), but `process.cwd()`
+ * resolves symlinks, so `resolveVaultRoot()`'s parent walk returns
+ * `/var/home/u`. Both name the same directory; only the strings differ.
+ * The consequences were a doubled layered-recall scan of one vault (every hit
+ * mislabelled "📓 personal") and a doubled `vaultPageCount()`, which tripped
+ * links-first rendering at half the configured threshold.
+ */
+describe("isPersonalVault on a symlinked home (atomic OS layout)", () => {
+  let scratch: string;
+  let physicalHome: string;
+  let symlinkedHome: string;
+  let savedWikiHome: string | undefined;
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    savedWikiHome = process.env.WIKI_HOME;
+    savedHome = process.env.HOME;
+    scratch = join(tmpdir(), `llm-wiki-symlink-${Math.random().toString(36).slice(2)}`);
+
+    // Physical layout: <scratch>/var/home/u, reached via <scratch>/home -> var/home.
+    physicalHome = join(scratch, "var", "home", "u");
+    symlinkedHome = join(scratch, "home", "u");
+    mkdirSync(join(physicalHome, ".llm-wiki"), { recursive: true });
+    writeFileSync(join(physicalHome, ".llm-wiki", "config.json"), "{}");
+    symlinkSync("var/home", join(scratch, "home"));
+  });
+
+  afterEach(() => {
+    if (savedWikiHome === undefined) Reflect.deleteProperty(process.env, "WIKI_HOME");
+    else process.env.WIKI_HOME = savedWikiHome;
+    if (savedHome === undefined) Reflect.deleteProperty(process.env, "HOME");
+    else process.env.HOME = savedHome;
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("recognises the personal vault reached through a symlinked root", () => {
+    // WIKI_HOME points at the symlinked path; the vault root is the physical
+    // one. Before the fix this string compare returned false.
+    process.env.WIKI_HOME = symlinkedHome;
+    expect(isPersonalVault(getVaultPaths(physicalHome))).toBe(true);
+  });
+
+  it("recognises it from the symlinked side too (comparison is symmetric)", () => {
+    process.env.WIKI_HOME = physicalHome;
+    expect(isPersonalVault(getVaultPaths(symlinkedHome))).toBe(true);
+  });
+
+  it("classifies the vault resolved from a physical cwd as personal", () => {
+    // The real atomic-OS path: $HOME uses the symlink, but process.cwd() (and
+    // so resolveVaultRoot's parent walk) yields the physical path. WIKI_HOME
+    // must be unset or it short-circuits the walk.
+    Reflect.deleteProperty(process.env, "WIKI_HOME");
+    process.env.HOME = symlinkedHome;
+    const cwd = join(physicalHome, "proj", "src");
+    mkdirSync(cwd, { recursive: true });
+
+    const paths = resolveVaultPaths(cwd);
+    expect(paths.root).toBe(physicalHome); // walked up to the physical root
+    expect(isPersonalVault(paths)).toBe(true);
+  });
+
+  it("still treats a vault nested under the home directory as a project vault", () => {
+    // Guards against fixing this with containment instead of equality.
+    process.env.WIKI_HOME = symlinkedHome;
+    const nested = join(physicalHome, "projects", "foo");
+    mkdirSync(join(nested, ".llm-wiki"), { recursive: true });
+    expect(isPersonalVault(getVaultPaths(nested))).toBe(false);
+  });
+
+  it("still treats an unrelated vault as a project vault", () => {
+    process.env.WIKI_HOME = symlinkedHome;
+    const unrelated = join(scratch, "var", "srv", "other");
+    mkdirSync(join(unrelated, ".llm-wiki"), { recursive: true });
+    expect(isPersonalVault(getVaultPaths(unrelated))).toBe(false);
+  });
+
+  it("does not throw when the personal root does not exist on disk", () => {
+    process.env.WIKI_HOME = join(scratch, "nonexistent", "home");
+    expect(() => isPersonalVault(getVaultPaths(physicalHome))).not.toThrow();
+    expect(isPersonalVault(getVaultPaths(physicalHome))).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #145.

## The mismatch

`isPersonalVault()` decided whether the resolved vault *is* the personal vault by comparing root strings:

```ts
return paths.root === getPersonalWikiRoot();
```

`getPersonalWikiRoot()` falls back to `homedir()`, which returns the `$HOME` string. `process.cwd()` returns the *physical* path — `getcwd(2)` resolves symlinks — so `resolveVaultRoot()`'s parent walk returns a physical root. Where `$HOME` traverses a symlink, the two never match even though they name the same directory, and the personal vault is classified as a project vault.

That is the default state on every ostree/rpm-ostree system: `/home` is a symlink to `var/home`, because `/home` sits on the immutable ostree-managed root while user data must live under the writable `/var`. It ships in the base image of the Fedora Atomic Desktops (Silverblue, Kinoite, Bazzite, Bluefin, Aurora) and Fedora CoreOS/IoT, so `homedir()` is `/home/u` while the vault root walks up to `/var/home/u`. Users there can't opt out short of rebuilding the image, and it fires in every session started under `$HOME`.

## What it broke

Writes were never affected — both strings address the same directory, so content always landed in the right vault. The damage was confined to the layered-recall bookkeeping this predicate guards:

- **`searchWikiLayered()`** lost its short-circuit and scanned the same vault twice, once as "primary" and once as "personal". Results stayed correct (dedup by page ID), but personal results merge first, so *every* hit was tagged `📓 personal` and the header claimed `(personal + project)` in sessions with no project wiki at all — plus a wasted duplicate lexical/semantic scan on each explicit `wiki_recall`.
- **`vaultPageCount(paths, true)`** added `registryPageCount(personalPaths)` on top of an identical count, exactly doubling it. That feeds `shouldUseLinksFirst()`, so recall flipped to links-first rendering at half the configured `recallLinksThreshold` — a 26-page vault behaving like a 52-page one.

## The fix

Compare physical paths using the existing `relativePhysicalPath()` helper — the same one `isPathWithin()` already uses for this class of problem, and which tolerates a missing tail. No new dependency, no new resolution machinery.

Three deliberate details:

- **Exact equality (`=== ""`), not containment.** `isPathWithin()` would also match `~/projects/foo/.llm-wiki`, which is a project vault and must stay one.
- **String compare kept as a fast path**, so the overwhelmingly common case still costs zero syscalls.
- **Unresolvable paths degrade to `false`** rather than throwing, so a permissions error or symlink cycle makes layered recall search both vaults instead of silently dropping the personal layer.

## Tests

Six cases added to `test/personal-wiki-paths.test.ts`, building a real `<scratch>/home -> var/home` symlink layout in a tmpdir:

- personal vault recognised through a symlinked root, and from the symlinked side too (the comparison is symmetric)
- the end-to-end path: `$HOME` on the symlink, physical cwd, `WIKI_HOME` unset so the parent walk actually runs — asserts both that the walk lands on the physical root and that it is classified as personal
- a vault nested under the home directory stays a *project* vault (guards against a containment-based fix)
- an unrelated vault stays a project vault
- a nonexistent personal root does not throw

The first three fail on `main` and pass with the fix; the last three pass either way, which is their job. `WIKI_HOME`/`HOME` are saved and restored per test, matching the sandboxing pattern already used in this file.

## Checks

Node 22.19.0, `pnpm install --frozen-lockfile`: `pnpm typecheck` and `pnpm lint` clean; `pnpm test` **598 passed (46 files)**.

`biome lint --only=correctness/noUnusedImports` reports 4 pre-existing warnings in `ingest-worker.ts`, `observation.ts`, `source-extractors.ts` and `source-packet.ts` — untouched by this PR, flagged here only because CodeQL tends to surface them in review.
