### PR TITLE
fix: realpath personal-vault fallback in resolveVaultRoot

### DIFF
--- a/extensions/llm-wiki/lib/utils.ts
+++ b/extensions/llm-wiki/lib/utils.ts
@@ -191,7 +191,11 @@ export function resolveProjectVaultRoot(cwd: string): string | null {
  *    holds a vault, so first-run bootstrap has somewhere to write.
  */
 export function resolveVaultRoot(cwd: string): string {
-  return resolveProjectVaultRoot(cwd) ?? getPersonalWikiRoot();
+  // Realpath the personal fallback so a symlinked `$HOME` (atomic-OS layouts)
+  // yields the PHYSICAL root the ancestor walk used to return — the #145
+  // regression guard pins that. `realpathWithMissingTail` also covers first-run
+  // bootstrap, where the personal root does not exist on disk yet.
+  return resolveProjectVaultRoot(cwd) ?? realpathWithMissingTail(getPersonalWikiRoot());
 }
 
 /** Get all vault paths for the new (.llm-wiki) layout. */


### PR DESCRIPTION
## Problem

Follow-up to #150. The ancestor walk in `resolveProjectVaultRoot()` now skips the personal vault so the ambient gate can answer "does *this* project have a wiki". When no project vault exists, `resolveVaultRoot()` falls back to `getPersonalWikiRoot()` — which returns the **raw `$HOME` string**.

On atomic-OS layouts where `/home` is a symlink to `var/home`, the old walk returned the *physical* root (`/var/home/u`); the fallback now returns the *symlinked* string (`/home/u`). Same directory, different string — which trips `test/personal-wiki-paths.test.ts` (the #145 regression guard), the one failing CI check on #150.

## Fix

Realpath the fallback using the existing `realpathWithMissingTail` helper (utils.ts) — it resolves the longest existing prefix and appends the missing tail, so it also covers first-run bootstrap where the personal root does not exist on disk yet.

`WIKI_HOME` short-circuits inside `resolveProjectVaultRoot`, so an explicit `WIKI_HOME` is returned untouched.

## Verification

- `test/personal-wiki-paths.test.ts` + `test/ambient-gate.test.ts`: 32/32 pass (symlink regression guard restored)
- Full suite: **632/632 pass**, typecheck clean, biome clean