### PR TITLE
fix: harden wikilinks and directory indexes

### DIFF
--- a/commands/wiki-ingest.md
+++ b/commands/wiki-ingest.md
@@ -33,4 +33,5 @@ $ARGUMENTS
 **Rules:**
 - Never modify files in `raw/` — source packets are immutable after capture.
 - Never fabricate information — always cite sources with `[[sources/SRC-...]]`.
+- Inside Markdown table cells, write aliased wikilinks as `[[target\|alias]]`, never `[[target|alias]]`.
 - The extension auto-updates metadata — you do NOT need to manually edit `meta/` files.

--- a/commands/wiki-req.md
+++ b/commands/wiki-req.md
@@ -53,3 +53,4 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand th
 - Use status values: `draft` → `clarified` → `active` → `implemented` → `deferred` → `rejected`
 - Use priority values: `p0` (blocking), `p1` (critical), `p2` (important), `p3` (nice-to-have)
 - Do not create requirements in `raw/` — that layer is for external source artifacts only
+- Inside Markdown table cells, write aliased wikilinks as `[[target\|alias]]`, never `[[target|alias]]`.

--- a/commands/wiki-retro.md
+++ b/commands/wiki-retro.md
@@ -32,3 +32,4 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand th
 - One atomic insight per `wiki_retro` call. Use multiple calls for multiple insights.
 - Don't save obvious things. Save non-obvious patterns, tradeoffs, and design decisions.
 - Always add `[[wikilinks]]` to connect the new insight with existing wiki knowledge.
+- Inside Markdown table cells, write aliased wikilinks as `[[target\|alias]]`, never `[[target|alias]]`.

--- a/docs/superpowers/plans/2026-08-09-qmd-retrieval-phase-1-quality-baseline-and-compatibility.md
+++ b/docs/superpowers/plans/2026-08-09-qmd-retrieval-phase-1-quality-baseline-and-compatibility.md
@@ -1,0 +1,1520 @@
+# QMD Retrieval Phase 1: Quality Baseline and Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use /skill:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish a reproducible current-retrieval benchmark and prove the published QMD 2.5.3 dependency/runtime contract without changing active recall behavior.
+
+**Architecture:** Keep production recall on the existing `searchWiki` path throughout this phase. Add a deterministic fixture-driven benchmark around that path, pin QMD as an unused runtime dependency, and exercise QMD's public SDK through isolated contract tests. Ordinary CI validates native installation and model-free lexical behavior; a separate cached workflow validates model-backed calls.
+
+**Tech Stack:** TypeScript 5.9, Node.js 22+, Vitest 3, QMD 2.5.3, pnpm 9, GitHub Actions, Markdown fixtures.
+
+**Roadmap:** [`docs/superpowers/roadmaps/2026-08-09-qmd-retrieval-roadmap.md`](../roadmaps/2026-08-09-qmd-retrieval-roadmap.md)
+
+**Phase:** Phase 1: Quality Baseline and QMD Compatibility
+
+---
+
+## Phase Boundary
+
+This plan intentionally does not create persistent QMD vault indexes or route any Pi/MCP/automatic recall through QMD. At completion, current recall remains active and unchanged; QMD is pinned, installable, contract-tested, and ready for Phase 2.
+
+## File Map
+
+**Create:**
+
+- `test/fixtures/retrieval-benchmark/fixture.ts` — sanitized, versioned benchmark pages and 60 graded queries.
+- `test/retrieval-benchmark-fixture.test.ts` — fixture completeness, split, category, identity, and privacy checks.
+- `test/helpers/retrieval-metrics.ts` — pure information-retrieval metric functions.
+- `test/retrieval-metrics.test.ts` — exact metric behavior tests.
+- `test/retrieval-benchmark.test.ts` — materializes the fixture, runs current `searchWiki`, and compares the committed baseline.
+- `scripts/update-retrieval-baseline.mjs` — cross-platform baseline regeneration entry point.
+- `docs/superpowers/benchmarks/phase-1-current-baseline.json` — generated deterministic baseline artifact.
+- `test/qmd-contract.test.ts` — QMD SDK type contract, native lexical smoke, and opt-in model smoke.
+- `.github/workflows/qmd-model-smoke.yml` — scheduled/manual cached model-backed compatibility check.
+- `docs/retrieval-benchmark.md` — benchmark schema, commands, privacy rules, and interpretation.
+- `docs/qmd-compatibility.md` — pinned package/runtime/native/model support contract.
+
+**Modify:**
+
+- `package.json` — Node floor, exact QMD dependency, TypeScript peer-compatible version, benchmark scripts.
+- `pnpm-lock.yaml` — generated dependency lock update.
+- `test/package-structure.test.ts` — package/runtime assertions.
+- `.github/workflows/ci.yml` — supported Node matrix and cross-platform QMD native-install job.
+
+**Explicitly unchanged:**
+
+- `extensions/llm-wiki/lib/recall.ts` — remains the active retrieval implementation and benchmark subject.
+- `extensions/llm-wiki/index.ts` — automatic recall behavior stays unchanged.
+- `mcp/operations.ts` — MCP recall behavior stays unchanged.
+
+---
+
+### Task 1: Pin the next-major runtime and QMD dependency contract
+
+**Files:**
+- Modify: `test/package-structure.test.ts`
+- Modify: `package.json`
+- Modify: `pnpm-lock.yaml`
+
+- [ ] **Step 1: Add the failing package-contract assertions**
+
+Add these assertions inside `it("should have a valid package.json with pi manifest", ...)`, immediately after parsing `pkg`:
+
+```ts
+expect(pkg.engines.node).toBe(">=22.0.0");
+expect(pkg.dependencies["@tobilu/qmd"]).toBe("2.5.3");
+expect(pkg.devDependencies.typescript).toBe("^5.9.3");
+expect(pkg.pnpm.onlyBuiltDependencies).toEqual([
+  "better-sqlite3",
+  "node-llama-cpp",
+  "sqlite-vec",
+]);
+```
+
+- [ ] **Step 2: Run the targeted test and verify the old package contract fails**
+
+Run:
+
+```bash
+pnpm exec vitest run test/package-structure.test.ts --reporter=verbose
+```
+
+Expected: FAIL because the current engine is `>=18`, QMD and the native-build whitelist are absent, and TypeScript is still `^5.7.0`.
+
+- [ ] **Step 3: Install the exact published QMD package and compatible TypeScript**
+
+Run:
+
+```bash
+pnpm add --save-exact @tobilu/qmd@2.5.3
+pnpm add --save-dev typescript@^5.9.3
+```
+
+Expected: `package.json` contains exact QMD `2.5.3`, TypeScript `^5.9.3`, and `pnpm-lock.yaml` records QMD's native dependencies.
+
+- [ ] **Step 4: Raise the Node.js engine floor and whitelist QMD native builds**
+
+Change only the `engines` block in `package.json` to:
+
+```json
+"engines": {
+  "node": ">=22.0.0"
+}
+```
+
+Add a top-level `pnpm` key so pnpm 10+ still runs QMD's native dependency build scripts (QMD's own `pnpm.onlyBuiltDependencies` does not propagate to consumers):
+
+```json
+"pnpm": {
+  "onlyBuiltDependencies": ["better-sqlite3", "node-llama-cpp", "sqlite-vec"]
+}
+```
+
+Do not edit `package.json.version`; release versioning belongs to Phase 7 and must use the release script.
+
+- [ ] **Step 5: Run package, type, and package-build checks**
+
+Run:
+
+```bash
+pnpm exec vitest run test/package-structure.test.ts --reporter=verbose
+pnpm typecheck
+pnpm build:mcp
+```
+
+Expected: all commands exit 0; QMD remains unused by production code. If the TypeScript 5.9 bump surfaces new diagnostics in existing files, commit those fixes separately before the Task 1 commit.
+
+- [ ] **Step 6: Commit the runtime contract**
+
+```bash
+git add package.json pnpm-lock.yaml test/package-structure.test.ts
+git commit -m "build: require Node 22 and pin QMD"
+```
+
+---
+
+### Task 2: Add the sanitized 60-query benchmark fixture
+
+**Files:**
+- Create: `test/fixtures/retrieval-benchmark/fixture.ts`
+- Create: `test/retrieval-benchmark-fixture.test.ts`
+
+- [ ] **Step 1: Write the failing fixture-contract test**
+
+Create `test/retrieval-benchmark-fixture.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  BENCHMARK_VERSION,
+  benchmarkPages,
+  benchmarkQueries,
+} from "./fixtures/retrieval-benchmark/fixture.js";
+
+describe("retrieval benchmark fixture", () => {
+  it("contains the approved versioned 60-query train/held-out corpus", () => {
+    expect(BENCHMARK_VERSION).toBe(1);
+    expect(benchmarkPages).toHaveLength(22);
+    expect(benchmarkQueries).toHaveLength(60);
+    expect(benchmarkQueries.filter((query) => query.split === "train")).toHaveLength(45);
+    expect(benchmarkQueries.filter((query) => query.split === "heldout")).toHaveLength(15);
+  });
+
+  it("covers every Phase 1 query category", () => {
+    expect(new Set(benchmarkQueries.map((query) => query.category))).toEqual(
+      new Set([
+        "exact_lookup",
+        "entity_alias",
+        "paraphrase",
+        "vague_recollection",
+        "conceptual",
+        "graph_scope",
+        "evidence_request",
+        "temporal",
+        "contradiction",
+        "conclusion",
+        "synthesis",
+        "negative",
+      ]),
+    );
+  });
+
+  it("uses unique stable ids and judgments that reference fixture pages", () => {
+    const pageIds = new Set(benchmarkPages.map((page) => page.id));
+    const queryIds = benchmarkQueries.map((query) => query.id);
+    expect(new Set(queryIds).size).toBe(queryIds.length);
+
+    for (const query of benchmarkQueries) {
+      expect(query.judgments.length > 0 || query.autoExpectation === "none").toBe(true);
+      for (const judgment of query.judgments) expect(pageIds.has(judgment.pageId)).toBe(true);
+      for (const pageId of query.expectedConflicts ?? []) expect(pageIds.has(pageId)).toBe(true);
+    }
+  });
+
+  it("contains no raw home paths, email addresses, or token-shaped secrets", () => {
+    const serialized = JSON.stringify({ benchmarkPages, benchmarkQueries });
+    expect(serialized).not.toMatch(/\/home\//i);
+    expect(serialized).not.toMatch(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+    expect(serialized).not.toMatch(/\b(?:sk|ghp|github_pat)_[A-Za-z0-9_-]{16,}\b/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the fixture test and verify the module is missing**
+
+Run:
+
+```bash
+pnpm exec vitest run test/retrieval-benchmark-fixture.test.ts --reporter=verbose
+```
+
+Expected: FAIL with a module-resolution error for `fixtures/retrieval-benchmark/fixture.js`.
+
+- [ ] **Step 3: Create the complete benchmark fixture**
+
+Create `test/fixtures/retrieval-benchmark/fixture.ts`:
+
+```ts
+export const BENCHMARK_VERSION = 1;
+
+export type BenchmarkRole = "canonical" | "evidence";
+export type BenchmarkSplit = "train" | "heldout";
+export type AutoExpectation = "hit" | "none";
+
+export interface BenchmarkPage {
+  id: string;
+  type: string;
+  title: string;
+  body: string;
+  aliases?: string[];
+  tags?: string[];
+  status?: "draft" | "stable" | "deprecated";
+}
+
+export interface BenchmarkJudgment {
+  pageId: string;
+  grade: 1 | 2 | 3;
+  role: BenchmarkRole;
+}
+
+export interface BenchmarkQuery {
+  id: string;
+  text: string;
+  category:
+    | "exact_lookup"
+    | "entity_alias"
+    | "paraphrase"
+    | "vague_recollection"
+    | "conceptual"
+    | "graph_scope"
+    | "evidence_request"
+    | "temporal"
+    | "contradiction"
+    | "conclusion"
+    | "synthesis"
+    | "negative";
+  split: BenchmarkSplit;
+  judgments: BenchmarkJudgment[];
+  autoExpectation: AutoExpectation;
+  expectedConflicts?: string[];
+}
+
+export const benchmarkPages: BenchmarkPage[] = [
+  {
+    id: "entities/qmd",
+    type: "entity",
+    title: "QMD",
+    aliases: ["Query Markup Documents"],
+    tags: ["retrieval", "markdown"],
+    status: "stable",
+    body: "QMD is an on-device Markdown search engine combining BM25, vector retrieval, reciprocal-rank fusion, and local reranking.",
+  },
+  {
+    id: "concepts/reciprocal-rank-fusion",
+    type: "concept",
+    title: "Reciprocal Rank Fusion",
+    aliases: ["RRF"],
+    tags: ["retrieval", "ranking"],
+    body: "Reciprocal Rank Fusion combines independently ranked lists by rank instead of adding incomparable BM25 and cosine scores.",
+  },
+  {
+    id: "concepts/hybrid-retrieval",
+    type: "concept",
+    title: "Hybrid Retrieval",
+    tags: ["bm25", "embeddings"],
+    body: "Hybrid retrieval joins lexical matching for exact terms with dense semantic retrieval for paraphrases and vague recollection.",
+  },
+  {
+    id: "concepts/canonical-memory-cards",
+    type: "concept",
+    title: "Canonical Memory Cards",
+    tags: ["zettelkasten", "memory"],
+    body: "A reviewed canonical card should be returned before raw observations, with source evidence preserved behind the card.",
+  },
+  {
+    id: "concepts/zettelkasten",
+    type: "concept",
+    title: "Zettelkasten",
+    aliases: ["card box method", "卡片盒笔记法"],
+    body: "Zettelkasten organizes atomic permanent notes and meaningful links. It is a knowledge model, not a search ranking algorithm.",
+  },
+  {
+    id: "concepts/obsidian-graph-view",
+    type: "concept",
+    title: "Obsidian Graph View",
+    body: "Obsidian Graph View helps people inspect links, clusters, and orphan notes. It visualizes existing links but does not improve machine search relevance by itself.",
+  },
+  {
+    id: "concepts/wiki-reindex",
+    type: "concept",
+    title: "Wiki Reindexing",
+    aliases: ["wiki_reindex"],
+    body: "Reindexing rescans valid Markdown, refreshes lexical state, embeds stale chunks, removes deleted pages, and keeps the last usable index if rebuilding fails.",
+  },
+  {
+    id: "concepts/node-runtime-policy",
+    type: "concept",
+    title: "Node Runtime Policy",
+    body: "The QMD-backed major requires Node.js 22 or newer. Users requiring Node.js 18 remain on the previous package major.",
+  },
+  {
+    id: "concepts/conflict-preservation",
+    type: "concept",
+    title: "Memory Conflict Preservation",
+    body: "Conflicting claims remain stored with their evidence. Recall shows both and asks the user which scope or claim applies instead of silently choosing.",
+  },
+  {
+    id: "concepts/retrieval-feedback",
+    type: "concept",
+    title: "Retrieval Feedback",
+    body: "Explicit corrections are strong signals. Opened, cited, and shown-only events are weaker, bounded, decaying signals and never rewrite facts.",
+  },
+  {
+    id: "concepts/query-expansion",
+    type: "concept",
+    title: "Query Expansion",
+    body: "Query expansion may improve broad questions but can drift. Adaptive retrieval escalates only uncertain results while exact identifiers bypass expansion.",
+  },
+  {
+    id: "concepts/validated-index-mirror",
+    type: "concept",
+    title: "Validated Index Mirror",
+    body: "QMD indexes a generated mirror containing only pages accepted by the shared Markdown parser, so malformed pages cannot influence candidate generation.",
+  },
+  {
+    id: "syntheses/second-brain-retrieval",
+    type: "synthesis",
+    title: "Second-Brain Retrieval Architecture",
+    body: "The strongest second-brain design combines QMD candidate retrieval with canonical-card prioritization, source evidence, contradiction assembly, bounded feedback, and measured evaluation.",
+  },
+  {
+    id: "analyses/qmd-adoption-decision",
+    type: "analysis",
+    title: "QMD Adoption Decision",
+    body: "The project chose QMD as the first-class retrieval engine rather than rebuilding BM25, vector search, RRF, and local reranking.",
+  },
+  {
+    id: "sources/qmd-2-5-3-release",
+    type: "source",
+    title: "QMD 2.5.3 Release Evidence",
+    body: "The published QMD 2.5.3 package requires Node.js 22, exposes a TypeScript SDK, and supports model-free searchLex plus model-backed vector and reranking calls.",
+  },
+  {
+    id: "sources/vault-audit",
+    type: "source",
+    title: "Vault Retrieval Audit",
+    body: "The audited vault had hundreds of source observations, few canonical concepts, almost no retrieval metadata, and no active embedding sidecar.",
+  },
+  {
+    id: "sources/user-card-first-decision",
+    type: "source",
+    title: "Card-First User Decision",
+    body: "The user selected canonical atomic cards first, with observations retained as evidence rather than mixed equally in recall.",
+  },
+  {
+    id: "sources/reindex-failure-recovery",
+    type: "source",
+    title: "Reindex Recovery Requirement",
+    body: "A failed full rebuild must preserve the previous closed database artifact and report stale derived state instead of deleting the usable index.",
+  },
+  {
+    id: "sources/node-22-decision",
+    type: "source",
+    title: "Node 22 Major-Version Decision",
+    body: "The user approved a clean major-version break to Node.js 22 so QMD can be a first-class dependency.",
+  },
+  {
+    id: "sources/old-conflicting-claim",
+    type: "source",
+    title: "Older Conflicting Claim",
+    body: "An older note says raw observations should always outrank synthesized cards because they are closer to original evidence.",
+  },
+  {
+    id: "sources/new-conflicting-claim",
+    type: "source",
+    title: "Newer Conflicting Claim",
+    body: "A newer reviewed decision says canonical cards should rank first while raw observations remain attached evidence.",
+  },
+  {
+    id: "sources/feedback-evaluation",
+    type: "source",
+    title: "Feedback Evaluation Evidence",
+    body: "Click and open behavior is position-biased, so implicit engagement must remain a tiny supplementary signal rather than factual ground truth.",
+  },
+];
+
+interface QueryGroup {
+  key: string;
+  category: BenchmarkQuery["category"];
+  split: BenchmarkSplit;
+  texts: [string, string, string, string, string];
+  judgments: BenchmarkJudgment[];
+  autoExpectation?: AutoExpectation;
+  expectedConflicts?: string[];
+}
+
+const canonical = (pageId: string, grade: 1 | 2 | 3 = 3): BenchmarkJudgment => ({
+  pageId,
+  grade,
+  role: "canonical",
+});
+
+const evidence = (pageId: string, grade: 1 | 2 | 3 = 2): BenchmarkJudgment => ({
+  pageId,
+  grade,
+  role: "evidence",
+});
+
+const groups: QueryGroup[] = [
+  {
+    key: "qmd-exact",
+    category: "exact_lookup",
+    split: "train",
+    texts: [
+      "QMD",
+      "Query Markup Documents",
+      "QMD Markdown search engine",
+      "find the QMD note",
+      "QMD BM25 vector reranker",
+    ],
+    judgments: [canonical("entities/qmd"), evidence("sources/qmd-2-5-3-release")],
+  },
+  {
+    key: "qmd-entity",
+    category: "entity_alias",
+    split: "train",
+    texts: [
+      "what tool is abbreviated QMD",
+      "the local document search tool",
+      "which entity provides local Markdown retrieval",
+      "QMD full name",
+      "on-device search for Markdown notes",
+    ],
+    judgments: [canonical("entities/qmd"), canonical("analyses/qmd-adoption-decision", 2)],
+  },
+  {
+    key: "hybrid-paraphrase",
+    category: "paraphrase",
+    split: "heldout",
+    texts: [
+      "combine exact words with meaning based search",
+      "find notes when I remember different wording",
+      "keyword plus semantic document lookup",
+      "search using both literal terms and concepts",
+      "mix sparse and dense retrieval",
+    ],
+    judgments: [canonical("concepts/hybrid-retrieval"), canonical("concepts/reciprocal-rank-fusion", 1)],
+  },
+  {
+    key: "cards-vague",
+    category: "vague_recollection",
+    split: "train",
+    texts: [
+      "the decision about useful memory before noisy notes",
+      "what should the AI remember first",
+      "reviewed conclusion with proof behind it",
+      "stop raw observations drowning good knowledge",
+      "card first memory organization",
+    ],
+    judgments: [canonical("concepts/canonical-memory-cards"), evidence("sources/user-card-first-decision")],
+  },
+  {
+    key: "zettelkasten-concept",
+    category: "conceptual",
+    split: "train",
+    texts: [
+      "what is Zettelkasten",
+      "is Zettelkasten a search algorithm",
+      "atomic permanent notes and meaningful links",
+      "什么是卡片盒笔记法",
+      "zettelkasten 是搜索算法吗",
+    ],
+    judgments: [canonical("concepts/zettelkasten")],
+  },
+  {
+    key: "obsidian-graph",
+    category: "graph_scope",
+    split: "heldout",
+    texts: [
+      "does Obsidian graph improve search ranking",
+      "what is graph view useful for",
+      "find orphan notes visually",
+      "can the Obsidian graph replace retrieval",
+      "human link visualization versus machine relevance",
+    ],
+    judgments: [canonical("concepts/obsidian-graph-view")],
+  },
+  {
+    key: "reindex-evidence",
+    category: "evidence_request",
+    split: "train",
+    texts: [
+      "how do I rebuild a stale wiki search index",
+      "what evidence says failed reindex keeps the old database",
+      "refresh lexical documents and stale vectors",
+      "remove deleted notes from search",
+      "wiki_reindex recovery requirement",
+    ],
+    judgments: [canonical("concepts/wiki-reindex"), evidence("sources/reindex-failure-recovery")],
+  },
+  {
+    key: "node-temporal",
+    category: "temporal",
+    split: "train",
+    texts: [
+      "which Node version does the next major require",
+      "can Node 18 use the QMD major",
+      "current runtime decision for QMD",
+      "why did the project move to Node 22",
+      "published QMD package Node requirement",
+    ],
+    judgments: [canonical("concepts/node-runtime-policy"), evidence("sources/node-22-decision")],
+  },
+  {
+    key: "memory-conflict",
+    category: "contradiction",
+    split: "heldout",
+    texts: [
+      "what happens when two memories disagree",
+      "raw observations or canonical cards should rank first",
+      "show both conflicting claims",
+      "which note superseded the older ranking claim",
+      "do not silently resolve contradictory memory",
+    ],
+    judgments: [
+      canonical("concepts/conflict-preservation"),
+      evidence("sources/old-conflicting-claim", 3),
+      evidence("sources/new-conflicting-claim", 3),
+    ],
+    expectedConflicts: ["sources/old-conflicting-claim", "sources/new-conflicting-claim"],
+  },
+  {
+    key: "feedback-conclusion",
+    category: "conclusion",
+    split: "train",
+    texts: [
+      "what did we conclude about retrieval feedback",
+      "should ignored search results change facts",
+      "how strong is an opened-result signal",
+      "explicit correction versus implicit engagement",
+      "position bias in second-brain feedback",
+    ],
+    judgments: [canonical("concepts/retrieval-feedback"), evidence("sources/feedback-evaluation")],
+  },
+  {
+    key: "architecture-synthesis",
+    category: "synthesis",
+    split: "train",
+    texts: [
+      "best architecture for an AI second brain",
+      "combine QMD with canonical evidence memory",
+      "full retrieval design summary",
+      "why QMD alone is not enough",
+      "candidate search plus wiki memory semantics",
+    ],
+    judgments: [canonical("syntheses/second-brain-retrieval"), canonical("analyses/qmd-adoption-decision", 2)],
+  },
+  {
+    key: "unrelated-negative",
+    category: "negative",
+    split: "train",
+    texts: [
+      "Flipkart casual mens wear",
+      "Razorpay webhook endpoint",
+      "hotel trial balance audit",
+      "exercise deletion in an admin panel",
+      "sales register round off convention",
+    ],
+    judgments: [],
+    autoExpectation: "none",
+  },
+];
+
+export const benchmarkQueries: BenchmarkQuery[] = groups.flatMap((group) =>
+  group.texts.map((text, index) => ({
+    id: `${group.key}-${index + 1}`,
+    text,
+    category: group.category,
+    split: group.split,
+    judgments: group.judgments.map((judgment) => ({ ...judgment })),
+    autoExpectation: group.autoExpectation ?? "hit",
+    expectedConflicts: group.expectedConflicts ? [...group.expectedConflicts] : undefined,
+  })),
+);
+```
+
+- [ ] **Step 4: Run the fixture-contract test**
+
+Run:
+
+```bash
+pnpm exec vitest run test/retrieval-benchmark-fixture.test.ts --reporter=verbose
+```
+
+Expected: 4 tests PASS; query count is 60, split is 45/15, and no privacy pattern appears.
+
+- [ ] **Step 5: Commit the fixture**
+
+```bash
+git add test/fixtures/retrieval-benchmark/fixture.ts test/retrieval-benchmark-fixture.test.ts
+git commit -m "test: add retrieval benchmark fixture"
+```
+
+---
+
+### Task 3: Implement deterministic retrieval metrics
+
+**Files:**
+- Create: `test/helpers/retrieval-metrics.ts`
+- Create: `test/retrieval-metrics.test.ts`
+
+- [ ] **Step 1: Write failing unit tests for ranking metrics**
+
+Create `test/retrieval-metrics.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { BenchmarkQuery } from "./fixtures/retrieval-benchmark/fixture.js";
+import {
+  evaluateBenchmark,
+  ndcgAt,
+  reciprocalRank,
+  recallAt,
+  type BenchmarkRun,
+} from "./helpers/retrieval-metrics.js";
+
+const queries: BenchmarkQuery[] = [
+  {
+    id: "ranked",
+    text: "ranked query",
+    category: "contradiction",
+    split: "train",
+    judgments: [
+      { pageId: "cards/a", grade: 3, role: "canonical" },
+      { pageId: "sources/b", grade: 2, role: "evidence" },
+    ],
+    autoExpectation: "hit",
+    expectedConflicts: ["cards/a", "sources/b"],
+  },
+  {
+    id: "negative",
+    text: "unrelated query",
+    category: "negative",
+    split: "heldout",
+    judgments: [],
+    autoExpectation: "none",
+  },
+];
+
+const runs: BenchmarkRun[] = [
+  { queryId: "ranked", rankedPageIds: ["sources/b", "cards/a", "other/x"], autoPageIds: ["sources/b"] },
+  { queryId: "negative", rankedPageIds: ["other/x"], autoPageIds: ["other/x"] },
+];
+
+describe("retrieval metrics", () => {
+  it("computes recall and reciprocal rank", () => {
+    expect(recallAt(["x", "a", "b"], new Set(["a", "b"]), 2)).toBe(0.5);
+    expect(reciprocalRank(["x", "a", "b"], new Set(["a", "b"]))).toBe(0.5);
+  });
+
+  it("computes graded nDCG independent of raw retrieval scores", () => {
+    const grades = new Map([
+      ["cards/a", 3],
+      ["sources/b", 2],
+    ]);
+    expect(ndcgAt(["cards/a", "sources/b"], grades, 2)).toBe(1);
+    expect(ndcgAt(["sources/b", "cards/a"], grades, 2)).toBeGreaterThan(0.8);
+    expect(ndcgAt(["sources/b", "cards/a"], grades, 2)).toBeLessThan(1);
+    expect(ndcgAt(["sources/b", "cards/a"], grades, 2)).toBeCloseTo(0.834, 3);
+  });
+
+  it("separates relevance, evidence, contradiction, and auto false-positive measures", () => {
+    const report = evaluateBenchmark(queries, runs);
+    expect(report.all.candidateRecall20).toBe(1);
+    expect(report.all.mrr).toBe(1);
+    expect(report.all.canonicalAt3).toBe(1);
+    expect(report.all.evidenceRecall20).toBe(1);
+    expect(report.all.contradictionCoverage).toBe(1);
+    expect(report.all.autoFalsePositiveRate).toBe(1);
+    expect(report.train.queryCount).toBe(1);
+    expect(report.heldout.queryCount).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the metric test and verify the helper is missing**
+
+Run:
+
+```bash
+pnpm exec vitest run test/retrieval-metrics.test.ts --reporter=verbose
+```
+
+Expected: FAIL with a module-resolution error for `helpers/retrieval-metrics.js`.
+
+- [ ] **Step 3: Implement the pure metric helper**
+
+Create `test/helpers/retrieval-metrics.ts`:
+
+```ts
+import type {
+  BenchmarkJudgment,
+  BenchmarkQuery,
+  BenchmarkSplit,
+} from "../fixtures/retrieval-benchmark/fixture.js";
+
+export interface BenchmarkRun {
+  queryId: string;
+  rankedPageIds: string[];
+  autoPageIds: string[];
+}
+
+export interface RetrievalMetrics {
+  queryCount: number;
+  judgedQueryCount: number;
+  candidateRecall20: number;
+  mrr: number;
+  ndcg5: number;
+  ndcg10: number;
+  canonicalAt3: number;
+  evidenceRecall20: number;
+  contradictionCoverage: number;
+  autoFalsePositiveRate: number;
+}
+
+export interface RetrievalMetricReport {
+  all: RetrievalMetrics;
+  train: RetrievalMetrics;
+  heldout: RetrievalMetrics;
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function mean(values: number[]): number {
+  return values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function recallAt(rankedIds: string[], relevantIds: Set<string>, k: number): number {
+  if (relevantIds.size === 0) return 0;
+  const found = new Set(rankedIds.slice(0, k).filter((id) => relevantIds.has(id)));
+  return found.size / relevantIds.size;
+}
+
+export function reciprocalRank(rankedIds: string[], relevantIds: Set<string>): number {
+  const index = rankedIds.findIndex((id) => relevantIds.has(id));
+  return index < 0 ? 0 : 1 / (index + 1);
+}
+
+function dcg(grades: number[]): number {
+  return grades.reduce((sum, grade, index) => sum + (2 ** grade - 1) / Math.log2(index + 2), 0);
+}
+
+export function ndcgAt(rankedIds: string[], gradesById: Map<string, number>, k: number): number {
+  const actual = rankedIds.slice(0, k).map((id) => gradesById.get(id) ?? 0);
+  const ideal = [...gradesById.values()].sort((a, b) => b - a).slice(0, k);
+  const idealDcg = dcg(ideal);
+  return idealDcg === 0 ? 0 : dcg(actual) / idealDcg;
+}
+
+function idsForRole(judgments: BenchmarkJudgment[], role?: BenchmarkJudgment["role"]): Set<string> {
+  return new Set(
+    judgments
+      .filter((judgment) => judgment.grade > 0 && (role === undefined || judgment.role === role))
+      .map((judgment) => judgment.pageId),
+  );
+}
+
+function evaluateSlice(queries: BenchmarkQuery[], runById: Map<string, BenchmarkRun>): RetrievalMetrics {
+  const judged = queries.filter((query) => query.judgments.length > 0);
+  const canonical = queries.filter((query) => idsForRole(query.judgments, "canonical").size > 0);
+  const evidence = queries.filter((query) => idsForRole(query.judgments, "evidence").size > 0);
+  const conflicts = queries.filter((query) => (query.expectedConflicts?.length ?? 0) > 0);
+  const negatives = queries.filter((query) => query.autoExpectation === "none");
+
+  const rankedFor = (query: BenchmarkQuery) => runById.get(query.id)?.rankedPageIds ?? [];
+  const autoFor = (query: BenchmarkQuery) => runById.get(query.id)?.autoPageIds ?? [];
+
+  return {
+    queryCount: queries.length,
+    judgedQueryCount: judged.length,
+    candidateRecall20: round(
+      mean(judged.map((query) => recallAt(rankedFor(query), idsForRole(query.judgments), 20))),
+    ),
+    mrr: round(
+      mean(judged.map((query) => reciprocalRank(rankedFor(query), idsForRole(query.judgments)))),
+    ),
+    ndcg5: round(
+      mean(
+        judged.map((query) =>
+          ndcgAt(
+            rankedFor(query),
+            new Map(query.judgments.map((judgment) => [judgment.pageId, judgment.grade])),
+            5,
+          ),
+        ),
+      ),
+    ),
+    ndcg10: round(
+      mean(
+        judged.map((query) =>
+          ndcgAt(
+            rankedFor(query),
+            new Map(query.judgments.map((judgment) => [judgment.pageId, judgment.grade])),
+            10,
+          ),
+        ),
+      ),
+    ),
+    canonicalAt3: round(
+      mean(
+        canonical.map((query) => {
+          const relevant = idsForRole(query.judgments, "canonical");
+          return rankedFor(query).slice(0, 3).some((id) => relevant.has(id)) ? 1 : 0;
+        }),
+      ),
+    ),
+    evidenceRecall20: round(
+      mean(
+        evidence.map((query) => recallAt(rankedFor(query), idsForRole(query.judgments, "evidence"), 20)),
+      ),
+    ),
+    contradictionCoverage: round(
+      mean(
+        conflicts.map((query) => {
+          const found = new Set(rankedFor(query).slice(0, 20));
+          return query.expectedConflicts!.every((id) => found.has(id)) ? 1 : 0;
+        }),
+      ),
+    ),
+    autoFalsePositiveRate: round(
+      mean(negatives.map((query) => (autoFor(query).length > 0 ? 1 : 0))),
+    ),
+  };
+}
+
+export function evaluateBenchmark(
+  queries: BenchmarkQuery[],
+  runs: BenchmarkRun[],
+): RetrievalMetricReport {
+  const runById = new Map(runs.map((run) => [run.queryId, run]));
+  const bySplit = (split: BenchmarkSplit) => queries.filter((query) => query.split === split);
+  return {
+    all: evaluateSlice(queries, runById),
+    train: evaluateSlice(bySplit("train"), runById),
+    heldout: evaluateSlice(bySplit("heldout"), runById),
+  };
+}
+```
+
+- [ ] **Step 4: Run fixture and metric tests**
+
+Run:
+
+```bash
+pnpm exec vitest run test/retrieval-benchmark-fixture.test.ts test/retrieval-metrics.test.ts --reporter=verbose
+```
+
+Expected: 7 tests PASS.
+
+- [ ] **Step 5: Commit the metric engine**
+
+```bash
+git add test/helpers/retrieval-metrics.ts test/retrieval-metrics.test.ts
+git commit -m "test: add retrieval quality metrics"
+```
+
+---
+
+### Task 4: Record the current heuristic recall baseline
+
+**Files:**
+- Create: `test/retrieval-benchmark.test.ts`
+- Create: `scripts/update-retrieval-baseline.mjs`
+- Create: `docs/superpowers/benchmarks/phase-1-current-baseline.json` (generated)
+- Modify: `package.json`
+
+- [ ] **Step 1: Create the benchmark runner test**
+
+Create `test/retrieval-benchmark.test.ts`:
+
+```ts
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { rebuildMetadata } from "../extensions/llm-wiki/lib/metadata.js";
+import { searchWiki } from "../extensions/llm-wiki/lib/recall.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+import {
+  BENCHMARK_VERSION,
+  benchmarkPages,
+  benchmarkQueries,
+  type BenchmarkPage,
+} from "./fixtures/retrieval-benchmark/fixture.js";
+import { rootDir } from "./helpers.js";
+import { evaluateBenchmark, type BenchmarkRun } from "./helpers/retrieval-metrics.js";
+
+const baselinePath = join(
+  rootDir,
+  "docs",
+  "superpowers",
+  "benchmarks",
+  "phase-1-current-baseline.json",
+);
+const tempRoot = mkdtempSync(join(tmpdir(), "pi-llm-wiki-retrieval-"));
+
+afterAll(() => rmSync(tempRoot, { recursive: true, force: true }));
+
+function renderPage(page: BenchmarkPage): string {
+  const metadata = [
+    "---",
+    `type: ${page.type}`,
+    `title: ${JSON.stringify(page.title)}`,
+    `status: ${page.status ?? "stable"}`,
+    ...(page.aliases ? [`aliases: ${JSON.stringify(page.aliases)}`] : []),
+    ...(page.tags ? [`tags: ${JSON.stringify(page.tags)}`] : []),
+    "---",
+    "",
+  ];
+  return `${metadata.join("\n")}${page.body}\n`;
+}
+
+function createBenchmarkVault(): ReturnType<typeof getVaultPaths> {
+  const paths = getVaultPaths(tempRoot);
+  ensureVaultStructure(paths);
+  writeFileSync(
+    join(paths.dotWiki, "config.json"),
+    `${JSON.stringify({ name: "Retrieval Benchmark", knowledge_format: "legacy" }, null, 2)}\n`,
+  );
+  for (const page of benchmarkPages) {
+    const path = join(paths.wiki, `${page.id}.md`);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, renderPage(page));
+  }
+  const rebuilt = rebuildMetadata(paths);
+  expect(rebuilt.ok, JSON.stringify(rebuilt.diagnostics, null, 2)).toBe(true);
+  return paths;
+}
+
+function currentPackageContract(): { node: string; qmd: string } {
+  const pkg = JSON.parse(readFileSync(join(rootDir, "package.json"), "utf8")) as {
+    engines: { node: string };
+    dependencies: Record<string, string>;
+  };
+  return { node: pkg.engines.node, qmd: pkg.dependencies["@tobilu/qmd"] };
+}
+
+describe("current heuristic retrieval benchmark", () => {
+  it("matches the committed deterministic Phase 1 baseline", () => {
+    const paths = createBenchmarkVault();
+    const runs: BenchmarkRun[] = benchmarkQueries.map((query) => ({
+      queryId: query.id,
+      rankedPageIds: searchWiki(paths, query.text, 20, 0).map((result) => result.id),
+      autoPageIds: searchWiki(paths, query.text, 3, 5).map((result) => result.id),
+    }));
+    const report = {
+      schema: 1,
+      fixtureVersion: BENCHMARK_VERSION,
+      engine: "current-heuristic",
+      productionRecallChanged: false,
+      packageContract: currentPackageContract(),
+      queryCounts: {
+        all: benchmarkQueries.length,
+        train: benchmarkQueries.filter((query) => query.split === "train").length,
+        heldout: benchmarkQueries.filter((query) => query.split === "heldout").length,
+      },
+      metrics: evaluateBenchmark(benchmarkQueries, runs),
+    };
+
+    if (process.env.UPDATE_RETRIEVAL_BASELINE === "1") {
+      mkdirSync(dirname(baselinePath), { recursive: true });
+      writeFileSync(baselinePath, `${JSON.stringify(report, null, 2)}\n`);
+    }
+
+    expect(existsSync(baselinePath), `Run pnpm benchmark:retrieval:update to create ${baselinePath}`).toBe(
+      true,
+    );
+    expect(JSON.parse(readFileSync(baselinePath, "utf8"))).toEqual(report);
+  });
+});
+```
+
+- [ ] **Step 2: Run the benchmark test and verify the baseline is missing**
+
+Run:
+
+```bash
+pnpm exec vitest run test/retrieval-benchmark.test.ts --reporter=verbose
+```
+
+Expected: FAIL with `Run pnpm benchmark:retrieval:update` because the committed baseline does not exist yet.
+
+- [ ] **Step 3: Add the cross-platform baseline update script**
+
+Create `scripts/update-retrieval-baseline.mjs`:
+
+```js
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { join, resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const vitest = join(root, "node_modules", "vitest", "vitest.mjs");
+const result = spawnSync(
+  process.execPath,
+  [vitest, "run", "test/retrieval-benchmark.test.ts", "--reporter=verbose"],
+  {
+    cwd: root,
+    env: { ...process.env, UPDATE_RETRIEVAL_BASELINE: "1" },
+    stdio: "inherit",
+  },
+);
+
+process.exit(result.status ?? 1);
+```
+
+- [ ] **Step 4: Add benchmark scripts to `package.json`**
+
+Add these entries to the existing `scripts` object:
+
+```json
+"benchmark:retrieval": "vitest run test/retrieval-benchmark.test.ts --reporter=verbose",
+"benchmark:retrieval:update": "node scripts/update-retrieval-baseline.mjs"
+```
+
+- [ ] **Step 5: Generate and inspect the deterministic baseline artifact**
+
+Run:
+
+```bash
+pnpm benchmark:retrieval:update
+pnpm benchmark:retrieval
+```
+
+Expected: both commands PASS and create `docs/superpowers/benchmarks/phase-1-current-baseline.json` with schema 1, 60/45/15 query counts, QMD contract `2.5.3`, and separate all/train/heldout metrics. Do not hand-edit metric values.
+
+- [ ] **Step 6: Prove the baseline is reproducible**
+
+Run:
+
+```bash
+node -e "const f=require('node:fs').readFileSync('docs/superpowers/benchmarks/phase-1-current-baseline.json');const c=require('node:crypto').createHash('sha256').update(f).digest('hex');console.log(c)"
+pnpm benchmark:retrieval:update
+node -e "const f=require('node:fs').readFileSync('docs/superpowers/benchmarks/phase-1-current-baseline.json');const c=require('node:crypto').createHash('sha256').update(f).digest('hex');console.log(c)"
+```
+
+Expected: both hashes are identical.
+
+- [ ] **Step 7: Run all benchmark unit tests**
+
+Run:
+
+```bash
+pnpm exec vitest run test/retrieval-benchmark-fixture.test.ts test/retrieval-metrics.test.ts test/retrieval-benchmark.test.ts --reporter=verbose
+```
+
+Expected: 8 tests PASS.
+
+- [ ] **Step 8: Commit the baseline harness and artifact**
+
+```bash
+git add package.json scripts/update-retrieval-baseline.mjs test/retrieval-benchmark.test.ts docs/superpowers/benchmarks/phase-1-current-baseline.json
+git commit -m "test: record current retrieval baseline"
+```
+
+---
+
+### Task 5: Contract-test QMD's public SDK without activating it
+
+**Files:**
+- Create: `test/qmd-contract.test.ts`
+
+- [ ] **Step 1: Create exact compile-time mode contracts and model-free runtime smoke**
+
+Create `test/qmd-contract.test.ts`:
+
+```ts
+import { homedir, tmpdir } from "node:os";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  createStore,
+  type ExpandedQuery,
+  type QMDStore,
+  type SearchOptions,
+} from "@tobilu/qmd";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const hybridQueries: ExpandedQuery[] = [
+  { type: "lex", query: "signed access tokens" },
+  { type: "vec", query: "how users authenticate" },
+];
+
+const modeContracts = {
+  hybrid: {
+    queries: hybridQueries,
+    rerank: false,
+    candidateLimit: 40,
+    limit: 10,
+    explain: true,
+  },
+  adaptiveUncertain: {
+    query: "how users authenticate",
+    intent: "Authentication documentation",
+    rerank: true,
+    candidateLimit: 40,
+    limit: 10,
+    explain: true,
+  },
+  quality: {
+    query: "how users authenticate",
+    intent: "Authentication documentation",
+    rerank: true,
+    candidateLimit: 40,
+    limit: 10,
+    explain: true,
+  },
+} satisfies Record<string, SearchOptions>;
+
+const tempRoot = mkdtempSync(join(tmpdir(), "pi-llm-wiki-qmd-contract-"));
+const docsPath = join(tempRoot, "docs");
+const dbPath = join(tempRoot, "index.sqlite");
+let store: QMDStore;
+
+function modelFiles(): string[] {
+  const modelDir = join(homedir(), ".cache", "qmd", "models");
+  if (!existsSync(modelDir)) return [];
+  return readdirSync(modelDir).sort();
+}
+
+beforeAll(async () => {
+  mkdirSync(docsPath, { recursive: true });
+  writeFileSync(join(docsPath, "auth.md"), "# Authentication\n\nUsers authenticate with signed access tokens.\n");
+  writeFileSync(join(docsPath, "cache.md"), "# Cache\n\nCache entries expire after five minutes.\n");
+  store = await createStore({
+    dbPath,
+    config: {
+      global_context: "SDK compatibility fixture",
+      collections: {
+        docs: { path: docsPath, pattern: "**/*.md" },
+      },
+    },
+  });
+});
+
+afterAll(async () => {
+  await store?.close();
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("QMD 2.5.3 SDK contract", () => {
+  it("keeps the four-mode request shapes type-compatible", () => {
+    expect(modeContracts.hybrid.queries).toEqual(hybridQueries);
+    expect(modeContracts.adaptiveUncertain.rerank).toBe(true);
+    expect(modeContracts.quality.candidateLimit).toBe(40);
+  });
+
+  it("updates and performs lexical search without downloading a model", async () => {
+    const beforeModels = modelFiles();
+    const updated = await store.update();
+    expect(updated.collections).toBe(1);
+    expect(updated.indexed).toBe(2);
+    expect(updated.needsEmbedding).toBe(2);
+
+    const results = await store.searchLex("signed access tokens", { collection: "docs", limit: 5 });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].source).toBe("fts");
+    expect(results[0].score).toBeGreaterThan(0);
+    expect(results[0].title).toContain("Authentication");
+
+    const status = await store.getStatus();
+    expect(status.totalDocuments).toBe(2);
+    expect(status.needsEmbedding).toBe(2);
+    expect(modelFiles()).toEqual(beforeModels);
+  });
+
+  it.runIf(process.env.QMD_MODEL_SMOKE === "1")(
+    "embeds, performs vector/hybrid search, expands, and reranks",
+    async () => {
+      const embedded = await store.embed({ force: true, chunkStrategy: "regex" });
+      expect(embedded.docsProcessed).toBe(2);
+      expect(embedded.errors).toBe(0);
+
+      const vector = await store.searchVector("how users log in", { collection: "docs", limit: 5 });
+      expect(vector.length).toBeGreaterThan(0);
+
+      const hybrid = await store.search({ ...modeContracts.hybrid, collections: ["docs"] });
+      expect(hybrid.length).toBeGreaterThan(0);
+
+      const expanded = await store.expandQuery("how users authenticate", {
+        intent: "Authentication documentation",
+      });
+      expect(expanded.length).toBeGreaterThan(0);
+
+      const quality = await store.search({ ...modeContracts.quality, collections: ["docs"] });
+      expect(quality.length).toBeGreaterThan(0);
+      expect(quality[0].score).toBeGreaterThan(0);
+    },
+    1_200_000,
+  );
+});
+```
+
+- [ ] **Step 2: Run the ordinary contract test**
+
+Run:
+
+```bash
+QMD_FORCE_CPU=1 pnpm exec vitest run test/qmd-contract.test.ts --reporter=verbose
+```
+
+Windows PowerShell equivalent: `$env:QMD_FORCE_CPU='1'; pnpm exec vitest run test/qmd-contract.test.ts --reporter=verbose`
+
+Expected: mode-shape and lexical tests PASS; model-backed test is skipped; no QMD model file is created.
+
+- [ ] **Step 3: Run the full typecheck against QMD's exported declarations**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: PASS. A missing or changed QMD method/type fails here before Phase 2 planning.
+
+- [ ] **Step 4: Commit the SDK contract**
+
+```bash
+git add test/qmd-contract.test.ts
+git commit -m "test: lock QMD SDK compatibility"
+```
+
+---
+
+### Task 6: Add platform CI, model smoke, and operator documentation
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Create: `.github/workflows/qmd-model-smoke.yml`
+- Create: `docs/retrieval-benchmark.md`
+- Create: `docs/qmd-compatibility.md`
+
+- [ ] **Step 1: Restrict the normal quality matrix to supported Node.js LTS versions**
+
+In `.github/workflows/ci.yml`, replace:
+
+```yaml
+node-version: [20, 22, 23, 24, 25]
+```
+
+with:
+
+```yaml
+node-version: [22, 24]
+```
+
+Keep the standalone Node 18 migration-script job: it executes the shipped migration file directly and does not claim the new extension runtime supports Node 18.
+
+- [ ] **Step 2: Add cross-platform native-install and lexical contract coverage to `ci.yml`**
+
+Add this job after `quality` and before `migration-node18`:
+
+```yaml
+  qmd-native-compatibility:
+    name: QMD native compatibility (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+
+      - name: Verify QMD SDK and model-free lexical search
+        run: pnpm exec vitest run test/qmd-contract.test.ts --reporter=verbose
+        env:
+          QMD_FORCE_CPU: "1"
+```
+
+Expected: the same package and lexical SDK test runs against native SQLite dependencies on Linux x64, macOS arm64, and Windows x64.
+
+- [ ] **Step 3: Create the opt-in and scheduled model-backed workflow**
+
+Create `.github/workflows/qmd-model-smoke.yml`:
+
+```yaml
+name: QMD Model Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1"
+
+concurrency:
+  group: qmd-model-smoke
+  cancel-in-progress: true
+
+jobs:
+  model-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+
+      - name: Cache QMD models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/qmd/models
+          key: qmd-2.5.3-models-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Exercise embedding, vector, expansion, fusion, and reranking
+        run: pnpm exec vitest run test/qmd-contract.test.ts --reporter=verbose
+        env:
+          QMD_FORCE_CPU: "1"
+          QMD_MODEL_SMOKE: "1"
+```
+
+- [ ] **Step 4: Document the benchmark contract and commands**
+
+Create `docs/retrieval-benchmark.md`:
+
+```markdown
+# Retrieval Benchmark
+
+The Phase 1 benchmark records current heuristic recall quality before QMD powers production retrieval.
+
+## Corpus
+
+`test/fixtures/retrieval-benchmark/fixture.ts` contains 22 sanitized Markdown pages and 60 graded queries:
+
+- 45 train queries
+- 15 immutable held-out queries
+- exact lookup, aliases, paraphrase, vague recollection, concepts, graph scope, evidence, time, conflicts, conclusions, synthesis, and unrelated negatives
+- English, Chinese, and mixed-language examples
+
+The fixture must not contain raw home paths, email addresses, credentials, customer identifiers, or copied private notes. Sanitize representative phrasing before committing it.
+
+The CJK query `什么是卡片盒笔记法` (zettelkasten-concept #4) is an intentional guaranteed miss for the current heuristic engine: the page body is English-only, so lexical score is zero by construction. Do not reword the page to make it pass; it exists to prove that only CJK-aware lexical handling (QMD's normalized FTS) can recover it.
+
+## Judgments
+
+Grades are:
+
+- `3`: directly answers the query
+- `2`: useful supporting evidence or secondary answer
+- `1`: relevant context
+
+Roles are `canonical` or `evidence`. Contradiction queries list every claim that must appear together.
+
+## Metrics
+
+The report records candidate Recall@20, MRR, nDCG@5, nDCG@10, canonical@3, evidence Recall@20, contradiction coverage, and automatic-recall false-positive rate. Scores are computed from ranked page IDs, never raw engine scores.
+
+## Commands
+
+Verify the committed baseline:
+
+```bash
+pnpm benchmark:retrieval
+```
+
+Regenerate after an intentional fixture or baseline-engine change:
+
+```bash
+pnpm benchmark:retrieval:update
+pnpm benchmark:retrieval
+```
+
+Never hand-edit `docs/superpowers/benchmarks/phase-1-current-baseline.json`. Every update must explain why the benchmark or baseline engine changed. Later phases may tune against `train`, but must not inspect or alter held-out judgments while tuning.
+```
+
+- [ ] **Step 5: Document the pinned QMD compatibility contract**
+
+Create `docs/qmd-compatibility.md`:
+
+```markdown
+# QMD Compatibility
+
+pi-llm-wiki's next major pins `@tobilu/qmd` **2.5.3**, the latest version published to npm when Phase 1 was planned.
+
+## Runtime
+
+- Node.js: `>=22.0.0`
+- TypeScript development peer: `^5.9.3`
+- Package manager: pnpm 9
+
+Users requiring Node.js 18 must remain on the previous pi-llm-wiki major.
+
+## Native compatibility
+
+Clean-install CI covers:
+
+- Linux x64
+- macOS arm64
+- Windows x64
+
+QMD brings `better-sqlite3`, `sqlite-vec`, and `node-llama-cpp`. Failure to install required native packages is an installation failure, not a runtime lexical fallback.
+
+## Model-free contract
+
+`createStore`, `update`, `searchLex`, `getStatus`, and `close` must work without downloading or loading an embedding, expansion, or reranking model. Ordinary CI tests this path with `QMD_FORCE_CPU=1`.
+
+## Model-backed contract
+
+The scheduled/manual model smoke exercises:
+
+- `embed`
+- `searchVector`
+- typed hybrid `search` with reranking disabled
+- `expandQuery`
+- expanded/reranked `search`
+
+QMD stores default models under `~/.cache/qmd/models`. First use downloads roughly 2 GB across embedding, reranking, and expansion models. CI caches that directory. `QMD_FORCE_CPU=1` avoids GPU probing in compatibility jobs.
+
+## Upgrade rule
+
+Do not widen the QMD version range. A QMD upgrade requires:
+
+1. exact-version lock update
+2. SDK contract and clean-install CI passing
+3. model smoke passing
+4. retrieval benchmark comparison before production use
+5. updated model and native-support documentation
+```
+
+- [ ] **Step 6: Run all Phase 1 checks**
+
+Run:
+
+```bash
+pnpm benchmark:retrieval
+QMD_FORCE_CPU=1 pnpm exec vitest run test/qmd-contract.test.ts --reporter=verbose
+pnpm typecheck
+pnpm lint
+pnpm test
+pnpm build:mcp
+```
+
+Expected: all commands exit 0; QMD model-backed smoke remains skipped locally unless explicitly enabled.
+
+- [ ] **Step 7: Verify active recall code did not change**
+
+Run:
+
+```bash
+git diff 42d6fd1 -- extensions/llm-wiki/lib/recall.ts extensions/llm-wiki/index.ts mcp/operations.ts
+```
+
+Expected: no diff. Phase 1 must not alter production recall or indexing behavior.
+
+- [ ] **Step 8: Commit CI and documentation**
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/qmd-model-smoke.yml docs/retrieval-benchmark.md docs/qmd-compatibility.md
+git commit -m "ci: verify QMD compatibility"
+```
+
+- [ ] **Step 9: Confirm a clean phase boundary**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -6
+```
+
+Expected: clean working tree and six Phase 1 commits after the planning commits. Active recall remains current heuristic retrieval; Phase 2 may now plan validated per-vault QMD indexing.

--- a/docs/superpowers/roadmaps/2026-08-09-qmd-retrieval-roadmap.md
+++ b/docs/superpowers/roadmaps/2026-08-09-qmd-retrieval-roadmap.md
@@ -35,7 +35,7 @@
 - Build a deterministic benchmark runner for the current heuristic recall path and record baseline metrics.
 - Curate 50–100 sanitized queries representing the approved query categories, including dense-retrieval false positives and multilingual cases present in the corpus.
 - Raise development and CI toolchains to Node.js 22 and a TypeScript version compatible with the pinned QMD peer range.
-- Pin and contract-test `@tobilu/qmd` 2.6.3, including the SDK calls required by all four retrieval modes.
+- Pin and contract-test the published `@tobilu/qmd` 2.5.3 package, including the SDK calls required by all four retrieval modes.
 - Add clean-install/native-package smoke coverage for the supported release platforms.
 - Verify lexical QMD operation without model download and document default model cache/download expectations.
 
@@ -56,7 +56,7 @@
 **Dependencies:**
 - Approved design spec.
 - Access to representative queries that can be sanitized before entering the repository.
-- QMD 2.6.3 package and supported native binaries remaining available.
+- QMD 2.5.3 package and supported native binaries remaining available.
 
 **Verification:**
 - Existing typecheck, lint, and test suites pass on Node.js 22.

--- a/docs/superpowers/roadmaps/2026-08-09-qmd-retrieval-roadmap.md
+++ b/docs/superpowers/roadmaps/2026-08-09-qmd-retrieval-roadmap.md
@@ -1,0 +1,448 @@
+# QMD-Backed Second-Brain Retrieval Roadmap
+
+> **For agentic workers:** Use /skill:writing-plans to create one detailed implementation plan per phase. Start with Phase 1 and proceed sequentially unless the user explicitly changes the order.
+
+**Goal:** Replace heuristic wiki recall with measured QMD-backed retrieval that returns canonical knowledge, evidence, and conflicts safely across personal and project vaults.
+
+**Design Spec:** [`docs/superpowers/specs/2026-08-08-qmd-retrieval-design.md`](../specs/2026-08-08-qmd-retrieval-design.md)
+
+**Planning Strategy:** This change spans runtime compatibility, local native dependencies, indexing, retrieval cutover, knowledge semantics, feedback, conflict resolution, and release validation. Seven ordered phases keep each detailed plan within one context window, establish quality measurements before tuning, and leave the existing package functional at every boundary.
+
+---
+
+## Phase Map
+
+| Phase | Outcome | Depends on |
+|---|---|---|
+| 1. Quality Baseline and QMD Compatibility | Reproducible benchmark plus proven Node/QMD build contract | Approved design |
+| 2. Validated QMD Indexing | Rebuildable per-vault QMD indexes and `wiki_reindex` | Phase 1 |
+| 3. Retrieval Modes and Recall Cutover | QMD powers Pi, MCP, and automatic recall | Phase 2 |
+| 4. Card-First Memory Assembly | Canonical cards, evidence, typed links, and conflicts are packed deterministically | Phase 3 |
+| 5. User Conflict Resolution | User decisions become immutable, scoped resolution records | Phase 4 |
+| 6. Retrieval Feedback | Explicit and implicit signals produce bounded local reranking adjustments | Phase 5 |
+| 7. Hardening and Major Release | Release gates pass and migration/documentation ship | Phases 1–6 |
+
+---
+
+## Phase 1: Quality Baseline and QMD Compatibility
+
+**Outcome:** The repository has a versioned retrieval benchmark, current-system baseline metrics, and a verified dependency/runtime contract for the pinned QMD release without changing active recall behavior.
+
+**Why now:** Retrieval quality cannot be improved responsibly without a baseline, and all later phases depend on QMD's actual SDK, native packages, model behavior, and supported platforms matching the design assumptions.
+
+**Scope:**
+- Define the benchmark schema for queries, graded canonical-card relevance, evidence relevance, contradiction expectations, and held-out membership.
+- Build a deterministic benchmark runner for the current heuristic recall path and record baseline metrics.
+- Curate 50–100 sanitized queries representing the approved query categories, including dense-retrieval false positives and multilingual cases present in the corpus.
+- Raise development and CI toolchains to Node.js 22 and a TypeScript version compatible with the pinned QMD peer range.
+- Pin and contract-test `@tobilu/qmd` 2.6.3, including the SDK calls required by all four retrieval modes.
+- Add clean-install/native-package smoke coverage for the supported release platforms.
+- Verify lexical QMD operation without model download and document default model cache/download expectations.
+
+**Out of scope:**
+- Creating persistent QMD vault indexes.
+- Routing production recall through QMD.
+- Tuning ranking constants against the held-out benchmark set.
+- Card assembly, conflict resolution, or feedback.
+
+**Key files/areas likely affected:**
+- `package.json` and `pnpm-lock.yaml`: Node, TypeScript, and pinned QMD dependency contract.
+- `.github/workflows/`: supported-platform clean-install and model-smoke jobs.
+- `test/fixtures/`: sanitized benchmark corpus and graded judgments.
+- `scripts/` or `test/`: benchmark runner and metric reporting.
+- `extensions/llm-wiki/lib/recall.ts`: stable baseline adapter only; active behavior remains unchanged.
+- `docs/`: benchmark methodology, privacy rules, and hardware/model reporting.
+
+**Dependencies:**
+- Approved design spec.
+- Access to representative queries that can be sanitized before entering the repository.
+- QMD 2.6.3 package and supported native binaries remaining available.
+
+**Verification:**
+- Existing typecheck, lint, and test suites pass on Node.js 22.
+- Clean package installation succeeds on Linux x64, macOS arm64, and Windows x64 CI.
+- QMD SDK contract tests cover lexical, typed hybrid, expanded/reranked, update, embed, status, and close operations.
+- Benchmark runner reproduces the same baseline metrics from the same fixture and emits Recall@20, MRR, nDCG, card/evidence measures, contradiction coverage, and false-positive rate.
+- Lexical QMD smoke test performs no model download or load.
+
+**Phase boundary health:** Active wiki recall is still the current implementation, so users do not receive a half-integrated engine. The package has moved to its next-major runtime floor, but all existing functionality and CI remain green.
+
+**Risks:**
+- QMD's published SDK may differ from documentation; treat contract-test failure as a design dependency failure before production integration.
+- Personal benchmark queries may expose private data; sanitize fixtures and keep any private source benchmark outside version control.
+- Native CI may be slow or flaky; separate install smoke from cached model-heavy tests.
+
+**Context notes:** The detailed plan should focus on measurement and compatibility, not begin production indexing. Record immutable benchmark train/held-out membership before later ranking work.
+
+---
+
+## Phase 2: Validated QMD Indexing
+
+**Outcome:** Each vault can build, incrementally update, inspect, and safely replace a QMD index derived only from parser-valid Markdown, while active recall still has a safe existing path.
+
+**Why now:** Retrieval cannot cut over until indexing excludes malformed or reserved pages, maintains personal/project isolation, survives interrupted rebuilds, and exposes a repair command.
+
+**Scope:**
+- Add stable `vault_id` creation and one-time backfill while preserving existing config.
+- Introduce a QMD adapter boundary that hides QMD-specific types from shared wiki services.
+- Build canonical/evidence mirror trees from successfully parsed `KnowledgeDocument` pages.
+- Maintain the mirror-to-authoritative-path manifest and exclude reserved generated pages.
+- Create one independent QMD store per vault with non-overlapping canonical and evidence collections.
+- Support incremental add, update, invalidation, and deletion.
+- Implement recoverable full-store replacement covering SQLite, WAL/SHM, and native sidecars as one closed artifact directory.
+- Add `wiki_reindex` for lexical/vector, changed/all, force, and vault scopes.
+- Extend status and lint diagnostics for index health, stale content, models, and interrupted swaps.
+- Schedule incremental indexing only after successful metadata projection rebuilds.
+
+**Out of scope:**
+- Replacing `wiki_recall` ranking.
+- Adaptive or quality query execution.
+- Typed knowledge relations or card-first context packing.
+- Feedback and conflict-resolution events.
+
+**Key files/areas likely affected:**
+- `extensions/llm-wiki/lib/indexing.ts`: indexing coordination and stale-state reporting.
+- `extensions/llm-wiki/lib/knowledge-document.ts`: validated mirror input contract.
+- `extensions/llm-wiki/lib/bootstrap.ts` and `extensions/llm-wiki/lib/utils.ts`: vault IDs and generated paths.
+- New QMD adapter/index-store module under `extensions/llm-wiki/lib/`.
+- `extensions/llm-wiki/lib/task-config.ts`: index-related configuration parsing where needed.
+- `extensions/llm-wiki/lib/tools.ts` and `extensions/llm-wiki/lib/wiki-service.ts`: reindex/status shared operations.
+- `extensions/llm-wiki/lib/guardrails.ts`: generated QMD ownership and post-rebuild scheduling.
+- `mcp/operations.ts`: parity for reindex and status.
+- `test/indexing.test.ts`, `test/indexing-fail-closed.test.ts`, and new QMD indexing tests.
+
+**Dependencies:**
+- Phase 1's pinned, contract-tested QMD SDK and Node.js 22 runtime.
+- Existing shared document parser and fail-closed projection behavior.
+
+**Verification:**
+- Valid pages appear in the correct mirror collection and map back to their authoritative paths.
+- Malformed, deleted, and reserved pages cannot enter QMD candidates.
+- Incremental indexing reports accurate indexed, changed, unchanged, removed, and embedding-needed counts.
+- Forced rebuild closes, swaps, reopens, and validates the complete QMD artifact.
+- Simulated interruption at each swap phase recovers or rolls back to a usable store.
+- Personal and project indexes remain isolated even when page IDs collide.
+- `wiki_reindex`, status, Pi, and MCP return equivalent structured results.
+
+**Phase boundary health:** Existing recall remains functional. QMD indexing is independently usable and repairable through `wiki_reindex` and status, but no automatic context depends on it yet.
+
+**Risks:**
+- Mirror and manifest can diverge after a crash; reconcile both from authoritative Markdown before every full rebuild and during startup recovery.
+- Native stores may retain open handles; require explicit close and validation before any directory swap.
+- Background embedding can consume resources unexpectedly; lexical-only indexing must remain model-free and vector work visible/cancellable.
+
+**Context notes:** Keep QMD table details private to its SDK. The detailed plan should treat generated mirror, manifest, and store as one lifecycle without manipulating QMD's schema directly.
+
+---
+
+## Phase 3: Retrieval Modes and Recall Cutover
+
+**Outcome:** QMD becomes the single active relevance engine for explicit recall, automatic injection, and MCP, with lexical, hybrid, adaptive, and quality modes plus deterministic fallback.
+
+**Why now:** The validated stores and repair path from Phase 2 are prerequisites for switching production queries without risking malformed-content influence or unrecoverable failures.
+
+**Scope:**
+- Implement exact SDK mappings for lexical, typed hybrid, adaptive escalation, and quality retrieval.
+- Normalize queries and construct bounded vault intent according to the spec.
+- Apply deterministic adaptive triggers, confidence floors, candidate limits, and exact-match bypass.
+- Merge personal/project ranked lists using rank-based normalization and project duplicate precedence.
+- Preserve exact identifiers, titles, aliases, commands, paths, and filenames.
+- Route `wiki_recall`, automatic `before_agent_start` recall, and MCP through one shared retrieval service.
+- Keep automatic recall precision-first and explicit recall broader.
+- Preserve links-first rendering and skill/case inlining behavior where applicable.
+- Implement model/store fallback chains and structured diagnostics.
+- Remove the old heuristic scorer and page-level embedding path from active recall after parity checks pass.
+- Deprecate `wiki_reindex_embeddings` through the consolidated reindex operation.
+
+**Out of scope:**
+- Typed-link evidence expansion.
+- Canonical/evidence bundle assembly beyond role labels.
+- User conflict decisions.
+- Learning from feedback.
+
+**Key files/areas likely affected:**
+- `extensions/llm-wiki/lib/recall.ts`: shared QMD-backed query and layered merge behavior.
+- QMD adapter module from Phase 2: mode-specific SDK calls and fallback.
+- `extensions/llm-wiki/lib/task-config.ts`: `retrievalMode` validation and defaults.
+- `extensions/llm-wiki/index.ts`: automatic recall integration and cache-safe dynamic context.
+- `extensions/llm-wiki/lib/inject.ts`: unchanged cache boundary with new structured recall blocks.
+- `extensions/llm-wiki/lib/wiki-service.ts`: shared Pi/MCP operation.
+- `mcp/operations.ts`: recall parity.
+- `test/recall.test.ts`, `test/agent-start-injection.test.ts`, and `test/mcp-parity.test.ts`.
+- `extensions/llm-wiki/lib/embeddings.ts`: retirement or compatibility handling for the old sidecar path.
+
+**Dependencies:**
+- Phase 2's validated, healthy QMD stores and status diagnostics.
+- Phase 1's SDK contract tests and baseline benchmark.
+
+**Verification:**
+- Each retrieval mode invokes only its specified QMD SDK path.
+- Missing vectors, model failures, reranker timeouts, and store failures follow the designed fallback chain.
+- Automatic recall injects nothing below the confidence floor.
+- Exact lookup remains within release-gate tolerance against the baseline.
+- Personal/project merging is deterministic and duplicate-safe.
+- Pi automatic recall, explicit tool recall, and MCP produce equivalent structured candidates.
+- Existing tests remain green after the old scorer leaves active paths.
+
+**Phase boundary health:** Retrieval is fully usable through QMD in every supported mode, but results still use a conservative flat presentation. Later semantic assembly can improve context without changing the retrieval engine again.
+
+**Risks:**
+- QMD scores may vary by mode or model; use them only for within-store confidence and ranks for cross-store merging.
+- Query expansion can introduce drift; adaptive mode retains the initial hybrid list on reranker failure and lexical mode stays available.
+- Cutover could increase cold latency; expose progress/status and retain precision-first no-injection behavior.
+
+**Context notes:** This phase should end dual-engine behavior. Transitional comparison may exist in tests or benchmark tooling, not as two production ranking paths.
+
+---
+
+## Phase 4: Card-First Memory Assembly
+
+**Outcome:** Recall returns deterministic memory bundles containing the best canonical card, bounded evidence, qualifiers, and competing claims instead of a flat page list.
+
+**Why now:** QMD must first provide reliable candidates. This phase adds wiki-specific semantics without entangling them with indexing or model integration.
+
+**Scope:**
+- Classify canonical and evidence roles from parsed page types and status.
+- Add the optional `relations` profile field with parse, validation, serialization, and lint behavior.
+- Require matching ordinary Markdown links so Obsidian and plain Markdown navigation remain intact.
+- Build typed relation adjacency without duplicate backlink edges.
+- Apply bounded status, human-verification, exact-match, freshness, and trust adjustments.
+- Expand at most one hop through evidence, qualification, supersession, applicability, derivation, and contradiction relations.
+- Group chunks by parent page and create `MemoryBundle` structures.
+- Enforce automatic bundle count, excerpt count/length, diversity, tie-break, and context-budget rules.
+- Label raw matches as unpromoted evidence when no suitable canonical page exists.
+- Render match reasons, provenance, scope, freshness, relation type, and conflicts.
+- Keep generic `related_to` and untyped links out of automatic expansion.
+
+**Out of scope:**
+- Automatically creating or promoting canonical cards.
+- Persisting user conflict choices.
+- Feedback-derived score adjustments.
+- Graph database or multi-hop traversal.
+
+**Key files/areas likely affected:**
+- `extensions/llm-wiki/lib/knowledge-document.ts`: typed relation extension model.
+- `extensions/llm-wiki/lib/knowledge-links.ts`: relation/link coexistence and normalized target resolution.
+- `extensions/llm-wiki/lib/metadata.ts`: typed adjacency projection and diagnostics.
+- `extensions/llm-wiki/lib/recall.ts` or a focused memory-assembly module: grouping and bounded adjustments.
+- `extensions/llm-wiki/lib/wiki-service.ts`: structured bundle output.
+- `extensions/llm-wiki/lib/tools.ts`: rendering and diagnostics.
+- `test/knowledge-document.test.ts`, `test/knowledge-links.test.ts`, `test/recall.test.ts`, and OKF integration fixtures.
+- `docs/obsidian.md` and architecture documentation: human graph behavior and profile field.
+
+**Dependencies:**
+- Phase 3's shared, QMD-backed candidate stream.
+- Existing OKF shared parser/serializer and backlink projections.
+
+**Verification:**
+- Relation metadata round-trips and unknown relation types remain preserved but inert.
+- Lint catches missing body links, invalid scopes, duplicates, self-links, and unresolved targets.
+- A canonical card precedes equally relevant evidence without introducing non-candidates.
+- Evidence and contradictions expand only through allowed one-hop relations.
+- Context packing obeys all count, length, diversity, and budget limits deterministically.
+- Obsidian still sees ordinary Markdown links and backlinks do not duplicate edges.
+- Card/evidence benchmark measures improve without violating exact-lookup or Recall@20 gates.
+
+**Phase boundary health:** Recall now delivers useful card-first context with provenance and visible unresolved conflicts. It does not yet mutate knowledge based on those conflicts or usage.
+
+**Risks:**
+- Canonical boosts may overpower relevance; keep the combined multiplier clamped and benchmarked.
+- Relation metadata may diverge from body links; lint makes the relation inert until both agree.
+- Dense results can duplicate evidence; parent-page deduplication and fixed excerpt caps protect context.
+
+**Context notes:** Keep all assembly logic pure where possible. Do not add card-promotion workflows; they require a separate future design.
+
+---
+
+## Phase 5: User Conflict Resolution
+
+**Outcome:** When competing claims appear, an explicit user choice can be recorded as an immutable, scoped, idempotent resolution with identical Pi and MCP behavior.
+
+**Why now:** Conflict records depend on Phase 4's typed relations and memory bundles. Implementing this before general feedback also establishes the durable internal-event and writer-lock foundation that feedback will reuse.
+
+**Scope:**
+- Extend the authoritative event service with internal-event visibility and cross-process per-vault locking.
+- Ensure human-readable logs omit internal feedback events while full-vault backups retain them.
+- Implement `wiki_resolve_conflict` with exact page IDs, relation direction, scope rules, rationale, and replacement-chain validation.
+- Write one immutable resolution analysis page per semantic decision using atomic single-file publication.
+- Derive active resolution state without rewriting or deleting competing claim pages.
+- Add idempotent replay and replacement behavior.
+- Emit `conflict_selected` internal events and keep them aligned with committed resolution pages.
+- Update metadata, relation projections, indexing, status, and recall after resolution.
+- Expose the same tool parameters, result codes, and validation through Pi and MCP.
+
+**Out of scope:**
+- Automatic contradiction resolution.
+- General relevance/irrelevance feedback.
+- Rewriting historical claim status.
+- Multi-party approvals or voting.
+
+**Key files/areas likely affected:**
+- `extensions/llm-wiki/lib/metadata.ts`: event visibility, locking, replay, and projections.
+- New focused conflict-resolution service under `extensions/llm-wiki/lib/`.
+- `extensions/llm-wiki/lib/knowledge-document.ts`: resolution metadata validation.
+- `extensions/llm-wiki/lib/knowledge-links.ts`: resolution links and derived relation direction.
+- `extensions/llm-wiki/lib/tools.ts` and `extensions/llm-wiki/lib/wiki-service.ts`: shared operation and Pi tool.
+- `mcp/operations.ts`: MCP parity.
+- `extensions/llm-wiki/lib/indexing.ts`: post-resolution incremental update.
+- Conflict, event-concurrency, mutation-guard, and parity tests.
+- `docs/architecture.md` and OKF ownership documentation: internal events and resolution records.
+
+**Dependencies:**
+- Phase 4's typed relation model and contradiction bundles.
+- Existing event stream and atomic knowledge-document writer patterns.
+
+**Verification:**
+- Invalid, cross-vault, same-page, or malformed-scope decisions make no writes.
+- Repeating the same decision returns the existing resolution.
+- Changed choices require a valid `replaces` chain and preserve old records.
+- Lock contention follows explicit-event timeout behavior without partial knowledge mutation.
+- Resolution pages preserve both claim links and all prior provenance.
+- Recall follows the active resolution for applicable scope while retaining the competing claim for audit.
+- Pi and MCP results are structurally equivalent.
+
+**Phase boundary health:** Conflict handling is complete and useful without general behavioral learning. Existing recall remains deterministic when no resolution exists.
+
+**Risks:**
+- Event/page publication can diverge on I/O failure; acquire the event lock before publication and test rollback/replay states.
+- User language can be ambiguous; only explicit resolved page IDs and relation choices reach the mutation service.
+- Synced vaults may retain stale locks; use the specified owner/time recovery rule and surface unresolved locks through lint/status.
+
+**Context notes:** The detailed plan should preserve one authoritative decision record rather than coordinating edits across both claim pages.
+
+---
+
+## Phase 6: Retrieval Feedback
+
+**Outcome:** Local explicit and observable implicit feedback produces small, decaying, explainable ranking adjustments without rewriting facts or introducing candidates.
+
+**Why now:** Feedback needs stable QMD result identities, card-first results, active-turn tracking, and the internal-event concurrency semantics established in earlier phases.
+
+**Scope:**
+- Add `recall_feedback` schema-versioned internal events keyed by stable vault/page identity and query hash.
+- Track shown results per active turn.
+- Instrument `shown`, `opened`, `cited`, and `shown_only` through the specified service and hooks.
+- Implement `wiki_recall_feedback` for explicit relevance, irrelevance, and correction judgments on previously shown results.
+- Preserve corrections as human-readable source observations before appending feedback events.
+- Build and replay the generated feedback aggregate projection.
+- Apply the 90-day half-life, signal strengths, and total `±0.02` post-retrieval clamp.
+- Disable feedback safely on event-source corruption or configuration opt-out.
+- Expose feedback state and diagnostics without storing raw query text.
+- Add correction cases to the retrieval regression corpus.
+
+**Out of scope:**
+- Copy, dwell-time, or unavailable UI signals.
+- Online model training.
+- Global or cross-user feedback sharing.
+- Feedback-based candidate generation or fact mutation.
+- Automated card promotion.
+
+**Key files/areas likely affected:**
+- New focused feedback aggregation module under `extensions/llm-wiki/lib/`.
+- `extensions/llm-wiki/lib/metadata.ts`: internal event replay and projection preservation.
+- `extensions/llm-wiki/lib/guardrails.ts` or extension hooks: read/open observation.
+- `extensions/llm-wiki/index.ts`: active-turn shown/cited lifecycle.
+- `extensions/llm-wiki/lib/observation.ts`: correction observation producer reuse.
+- `extensions/llm-wiki/lib/recall.ts` or memory-assembly module: bounded post-retrieval adjustment.
+- `extensions/llm-wiki/lib/task-config.ts`: `recallFeedback` setting.
+- `extensions/llm-wiki/lib/tools.ts`, `wiki-service.ts`, and `mcp/operations.ts`: explicit feedback operation and parity.
+- Feedback, event replay, hook instrumentation, privacy, and ranking-bound tests.
+
+**Dependencies:**
+- Phase 3's stable QMD result identity and active recall service.
+- Phase 4's final ranking/assembly boundary.
+- Phase 5's internal event visibility and writer locking.
+
+**Verification:**
+- Raw query text never enters feedback events.
+- Identical page IDs in different vaults receive independent signals.
+- Only results shown in the active session can receive explicit feedback.
+- Each observable hook emits the documented action; unavailable signals are not claimed.
+- Corrupt events disable adjustments and preserve the last projection.
+- Deleted pages and stale event references cannot affect ranking.
+- Aggregate feedback never exceeds its clamp or introduces a non-candidate.
+- Disabling implicit feedback leaves explicit corrections and conflict records working.
+
+**Phase boundary health:** The full retrieval experience now learns conservatively from use while Markdown facts and candidate generation remain unchanged.
+
+**Risks:**
+- Position and engagement bias can reinforce popular pages; keep implicit weights tiny and decayed.
+- Turn-hook instrumentation may misclassify use; `shown_only` remains a minimal proxy, never strong negative evidence.
+- Event volume can grow; no compaction ships in this release, so status should report size for future evidence-based work.
+
+**Context notes:** Keep feedback aggregation deterministic and replayable. Do not broaden the event schema into a general analytics platform.
+
+---
+
+## Phase 7: Hardening and Major Release
+
+**Outcome:** The next major version ships with documented migration, supported-platform validation, published quality metrics, and all release gates passing.
+
+**Why now:** Final migration, removals, documentation, and versioning should happen only after every capability is integrated and measured together.
+
+**Scope:**
+- Run all retrieval-mode ablations on train and held-out benchmark sets with recorded model/index versions and hardware context.
+- Tune only implementation constants allowed by the spec while preserving the held-out set.
+- Enforce exact lookup, nDCG, MRR, false-positive, contradiction, and Recall@20 release gates.
+- Run model-heavy smoke tests with cached pinned models.
+- Complete migration handling for `vault_id`, lazy indexes, stale old embedding sidecars, and first-run reindex prompts.
+- Confirm QMD model-cache behavior, first-use download messaging, cancellation, and runtime fallback.
+- Finalize deprecation behavior for `wiki_reindex_embeddings` and remove old active scorer code that no longer serves compatibility or benchmark needs.
+- Update README, configuration, API, architecture, Obsidian, troubleshooting, migration, and release documentation.
+- Publish supported-platform and Node.js 22 requirements prominently.
+- Prepare changelog and use the release script for the major version; never edit the package version manually.
+
+**Out of scope:**
+- Automated canonical-card promotion.
+- Graph database or graph viewer work beyond existing Obsidian compatibility.
+- Additional QMD backends or remote rerankers.
+- Feedback compaction or learned ranking models.
+- Features deferred by the approved design.
+
+**Key files/areas likely affected:**
+- Benchmark fixtures, reports, and release-gate scripts.
+- `package.json`, `pnpm-lock.yaml`, and `scripts/release.js` integration.
+- `.github/workflows/`: full release matrix and cached model smoke.
+- `README.md`, `docs/configuration.md`, `docs/api.md`, `docs/architecture.md`, `docs/obsidian.md`, and troubleshooting/migration docs.
+- `CHANGELOG.md`.
+- Legacy recall/embedding modules and tests retained only where still required.
+- Package smoke and MCP parity tests.
+
+**Dependencies:**
+- Completion of Phases 1–6.
+- Release-candidate benchmark results meeting every approved gate.
+- Supported-platform CI availability.
+
+**Verification:**
+- Full typecheck, lint, unit, integration, MCP, package-smoke, and supported-platform suites pass.
+- Held-out benchmark satisfies every numeric release gate.
+- Fresh vault, existing personal vault, and project-plus-personal vault migration scenarios work without content loss.
+- Lexical mode works without model downloads; hybrid/adaptive/quality provide clear model progress and fallback.
+- Full reindex repairs stale or interrupted state.
+- Documentation matches actual tool schemas, settings, model sizes, platform support, and deprecations.
+- Release artifact installs and runs on each claimed platform.
+
+**Phase boundary health:** This is the final coherent release boundary. The previous major remains available for Node.js 18 users, while the new major has one active retrieval engine and no undocumented migration requirement.
+
+**Risks:**
+- Benchmark tuning can overfit; preserve held-out judgments and publish ablations.
+- Native/model packaging can regress late; require clean-install and cached model smoke before tagging.
+- Major-release documentation may understate storage/model cost; include explicit generated-index and full-vault-backup implications.
+
+**Context notes:** Use the release script only after the release candidate passes every gate. If a gate fails, return to the owning phase rather than weakening the criterion during release work.
+
+---
+
+## Deferred Follow-Up Designs
+
+The following work remains intentionally outside this roadmap:
+
+- evidence-driven canonical-card promotion and review queues
+- graph visualization beyond Obsidian compatibility
+- graph databases or multi-hop agentic retrieval
+- remote or alternative reranker providers
+- feedback-log compaction and retention controls
+- personalized learned ranking models
+- automatic contradiction detection beyond proposed, reviewable links
+
+Each item requires evidence from production retrieval and its own reviewed design before implementation.

--- a/docs/superpowers/specs/2026-08-08-qmd-retrieval-design.md
+++ b/docs/superpowers/specs/2026-08-08-qmd-retrieval-design.md
@@ -128,29 +128,45 @@ Pi tool, MCP, and automatic recall adapters
 
 - `.llm-wiki/wiki/**/*.md` remains authoritative, user-editable knowledge.
 - `.llm-wiki/raw/**` remains immutable source material.
-- `.llm-wiki/meta/qmd.sqlite` is generated, extension-owned, and rebuildable.
+- `.llm-wiki/meta/qmd/**` is generated, extension-owned, and rebuildable. It contains the validated document mirror, path manifest, and complete QMD database artifacts.
 - QMD model files remain in QMD's standard local cache.
-- `.llm-wiki/meta/recall-feedback.jsonl` is durable, append-only local state and is not part of an OKF export.
-- `.llm-wiki/meta/recall-feedback.json` is a rebuildable aggregate projection.
+- Recall feedback uses the existing authoritative `.llm-wiki/meta/events.jsonl` stream. `recall_feedback` events have `visibility: internal`, so generated human-readable logs omit them.
+- `.llm-wiki/meta/recall-feedback.json` is a rebuildable aggregate projection of valid internal feedback events.
 
-The existing guardrails for `meta/**` apply to the QMD index and feedback files. Only extension code may modify them.
+The existing guardrails for `meta/**` apply. Only extension code may modify QMD artifacts, feedback events, or projections. Full-vault backups retain feedback through `events.jsonl`; OKF-only exports exclude it, matching existing event-stream behavior. The implementation must update `docs/architecture.md` and the OKF ownership documentation to describe internal events and the feedback projection.
+
+Feedback appends go through the existing `appendEvent` service as one append operation. This release upgrades that service to serialize writers with a per-vault in-process queue plus an extension-owned `meta/events.lock` acquired by exclusive file creation. The lock records writer ID and acquisition time; a writer may recover a lock older than 30 seconds only after confirming the recorded local process no longer exists. Implicit events wait at most 250 ms and may be dropped with a diagnostic; explicit corrections and conflict choices wait up to 2 seconds and return an error without mutating knowledge if the lock remains busy. Replay ignores events for deleted pages. There is no automatic retention or compaction in this release. If the event source is unreadable or malformed, feedback adjustments are disabled, lint reports the corruption, and the last generated projection is preserved rather than guessed or rewritten.
 
 ### One store per vault
 
-Each personal or project vault gets an independent QMD store under its own `meta/` directory. This prevents a project index from copying personal content and keeps index invalidation local to the vault that changed.
+Each personal or project vault gets an independent QMD store under its own `meta/qmd/` directory. This prevents a project index from copying personal content and keeps index invalidation local to the vault that changed.
 
 Automatic recall searches only the active project vault when one exists, matching the current contamination guard. Outside a project vault, it searches the personal vault. Explicit `wiki_recall` searches both applicable vaults in parallel, deduplicates by page ID with project precedence, and combines the ranked lists using rank-based fusion rather than assuming raw scores are comparable across stores.
 
-### QMD collections
+Every vault has a stable UUID in `.llm-wiki/config.json` (`vault_id`). Bootstrap creates it; first QMD indexing backfills it once for existing vaults while preserving all other configuration. Feedback and layered result identities use `(vault_id, page_id)`, so identical personal and project page IDs never share signals.
 
-Each store defines two logical collections over `.llm-wiki/wiki/`:
+### Validated QMD mirror and collections
 
-- **canonical:** concepts, entities, analyses, syntheses, requirements, skills, and cases
-- **evidence:** sources and observations
+QMD must never scan authoritative `wiki/**` directly. Before `store.update`, pi-llm-wiki parses changed pages through the shared `KnowledgeDocument` layer and writes only valid documents into a generated mirror:
 
-Unknown page types remain searchable and default to evidence unless configured as canonical. Generated reserved files such as `index.md` and `log.md` are excluded.
+```text
+meta/qmd/documents/
+├── canonical/<folder-qualified-id>.md
+└── evidence/<folder-qualified-id>.md
+```
 
-Collection context tells QMD that canonical pages contain reusable conclusions while evidence pages contain provenance and historical observations. pi-llm-wiki still validates every result against parsed page metadata; collection membership alone does not make a page authoritative.
+`meta/qmd/manifest.json` maps each mirror path to its original absolute path, vault ID, page ID, content hash, and role. Malformed pages and reserved generated `index.md`/`log.md` files have no mirror entry, so they cannot influence QMD candidate generation, expansion, or reranking. Removing or invalidating an authoritative page removes its mirror copy before the next QMD update.
+
+The store defines two non-overlapping filesystem collections through QMD's supported `path` plus `pattern` configuration:
+
+```ts
+collections: {
+  canonical: { path: "<meta>/qmd/documents/canonical", pattern: "**/*.md" },
+  evidence: { path: "<meta>/qmd/documents/evidence", pattern: "**/*.md" },
+}
+```
+
+Unknown page types default to the evidence mirror. Collection context tells QMD that canonical pages contain reusable conclusions while evidence pages contain provenance and historical observations. Every QMD result is mapped back through the manifest and parsed metadata before it enters memory assembly.
 
 ### Shared service boundary
 
@@ -160,13 +176,30 @@ Conceptual interfaces:
 
 ```ts
 type RetrievalMode = "lexical" | "hybrid" | "adaptive" | "quality";
+type ConflictRelation = "supersedes" | "qualifies" | "applies_under";
+
+type ConflictResolution = {
+  id: string;
+  vaultId: string;
+  selectedPageId: string;
+  otherPageId: string;
+  relation: ConflictRelation;
+  scope?: string;
+  status: "active";
+  decidedBy: "user";
+  decidedAt: string;
+  replaces?: string;
+};
 
 type MemoryCandidate = {
   vault: "project" | "personal";
+  vaultId: string;
   pageId: string;
   path: string;
   heading?: string;
   excerpt: string;
+  qmdRank: number;
+  qmdScore?: number;
   score: number;
   role: "canonical" | "evidence";
   status: "draft" | "stable" | "deprecated";
@@ -224,7 +257,7 @@ Recommended body sections are:
 ## Related
 ```
 
-The existing OKF-compatible metadata remains authoritative for type, title, description, sources, generation, verification, status, and staleness. pi-llm-wiki adds one optional preserved extension field for typed card relationships:
+The existing OKF-compatible metadata remains authoritative for type, title, description, sources, generation, verification, status, and staleness. pi-llm-wiki defines `relations` as an optional profile extension:
 
 ```yaml
 relations:
@@ -232,7 +265,7 @@ relations:
     type: contradicts
 ```
 
-Allowed first-release relationship types are:
+Each relation is a mapping with exactly `target`, `type`, and optional `scope`. `target` is a normalized folder-qualified page ID without a heading or block fragment. `scope` is required for `applies_under` and forbidden for the other first-release types. Allowed types are:
 
 - `supports`
 - `contradicts`
@@ -242,19 +275,21 @@ Allowed first-release relationship types are:
 - `derived_from`
 - `related_to`
 
-Only the first six affect evidence or conflict expansion. `related_to` remains a browsing link and receives no automatic inclusion privilege.
+The shared parser preserves the extension, validator checks its shape, serializer round-trips it, lint resolves each target and reports duplicates, self-links, missing targets, invalid scope use, and unknown relation types. Unknown imported relation types are preserved but inert. The generated relation adjacency map deduplicates equivalent edges.
 
-Evidence links should target the exact source page and, when available, a heading or Obsidian block anchor. Backlink generation may normalize the page target while preserving the anchor in Markdown.
+A typed relation must also have an ordinary Markdown link to the same page in the body. The Markdown link keeps Obsidian and plain OKF consumers navigable; `relations` supplies machine-readable semantics. If the body link is absent, lint reports `relation_missing_body_link` and the relation does not participate in expansion. Heading and Obsidian block anchors belong on the body link; relationship identity remains page-level. Backlinks derive one page edge from the Markdown link and attach the validated relation type without creating a duplicate edge.
+
+Only `supports`, `contradicts`, `qualifies`, `supersedes`, `applies_under`, and `derived_from` affect evidence or conflict expansion. `related_to` remains a browsing link and receives no automatic inclusion privilege. Active user resolution records take precedence when a declared relation and a later resolution disagree, while both remain visible for audit.
 
 ### Unpromoted evidence
 
-When no canonical card exists, recall may return the strongest source excerpt as **unpromoted evidence**. It must not be presented as an established conclusion. Repeated use can place it in a card-promotion queue.
+When no canonical card exists, recall may return the strongest source excerpt as **unpromoted evidence**. It must not be presented as an established conclusion. Promotion automation is outside this design; usage and corrections may inform a separately specified future workflow.
 
 ## Indexing and Reindexing
 
 ### Normal write path
 
-After a successful metadata rebuild for changed Markdown pages, the indexing coordinator calls QMD's incremental update. Stale embeddings are generated in the background. A write remains successful even if QMD indexing fails; the last valid index stays available and status reports the failure.
+After a successful metadata rebuild, the indexing coordinator parses changed Markdown pages and atomically updates their validated mirror copies and manifest entries. It then calls QMD's incremental update against the mirror. Stale embeddings are generated in the background. A write remains successful even if mirror or QMD indexing fails; the last valid QMD index stays available and status reports the authoritative page hash that has not yet been indexed. A malformed page never receives or retains a mirror copy for its invalid content.
 
 ### Explicit tool
 
@@ -292,9 +327,19 @@ The existing `wiki_reindex_embeddings` tool is deprecated in the new major and d
 
 ### Index lifecycle
 
-QMD owns its SQLite schema and transactions. pi-llm-wiki does not manipulate QMD tables directly. Before a forced full rebuild, the adapter builds or validates replacement state without deleting the last usable index. If QMD cannot provide atomic replacement through its SDK, the adapter rebuilds into a sibling temporary database, closes it, validates basic status and document counts, then renames it into place.
+QMD owns its SQLite schema and transactions. pi-llm-wiki does not manipulate QMD tables directly. Generated state lives as a complete artifact directory:
 
-Content hashes, QMD schema/version information, and model identities determine staleness. A removed Markdown page must disappear from QMD results after the next incremental update. Historical feedback may retain its page ID but cannot boost a result that no longer exists.
+```text
+meta/qmd/
+├── current/          # index.sqlite plus any WAL/SHM/native sidecars
+├── documents/        # validated mirror
+├── manifest.json
+└── swap.json         # present only during recoverable replacement
+```
+
+A forced rebuild uses QMD-supported replacement if the pinned SDK provides it. Otherwise it builds `staging-<uuid>/`, closes both QMD stores, checkpoints through QMD when supported, validates status and document counts, and swaps the complete directory rather than a lone SQLite file. The adapter records the swap phase in `swap.json`, renames `current` to `previous`, renames staging to `current`, reopens and validates it, then removes `previous`. Startup recovery completes or rolls back any interrupted phase. A failed reopen restores `previous`. No rename occurs while either store is open.
+
+Content hashes, QMD schema/version information, and resolved model identities determine staleness. A removed Markdown page must disappear from QMD results after the next incremental update. Historical feedback may retain its page ID but cannot boost a result that no longer exists.
 
 ## Retrieval Modes
 
@@ -310,37 +355,56 @@ Configuration adds one primary setting:
 
 Invalid explicit values fail closed with a configuration diagnostic. Default is `adaptive`.
 
+### QMD adapter mapping
+
+| Mode | Exact QMD SDK path | Model-failure fallback |
+|---|---|---|
+| `lexical` | `store.searchLex(query, { limit: 40 })` | no lower mode; return diagnostic on native/store failure |
+| `hybrid` | `store.search({ queries: [{ type: "lex", query }, { type: "vec", query }], rerank: false, candidateLimit: 40, limit: 10, explain: true })` | `searchLex` |
+| `adaptive` initial | same typed-query call as `hybrid` | `searchLex` |
+| `adaptive` uncertain | `store.search({ query, intent, rerank: true, candidateLimit: 40, limit: 10, explain: true })` | retain initial hybrid list |
+| `quality` | same expanded/reranked call as adaptive-uncertain | typed hybrid, then lexical |
+
+A typed `queries` call is mandatory for hybrid mode because plain `search({ query })` performs QMD query expansion. The adapter verifies these mappings against the pinned QMD SDK in contract tests.
+
 ### `lexical`
 
-- QMD BM25 only
-- no embedding, expansion, or reranking model load
-- best for exact names, commands, identifiers, filenames, and low-resource systems
+QMD BM25 only; no embedding, expansion, or reranking model is loaded. This mode is best for exact names, commands, identifiers, filenames, and low-resource systems.
 
 ### `hybrid`
 
-- lexical and vector candidates
-- reciprocal-rank fusion
-- no final reranking
-- uses the original query as both lexical and vector intent without generative query expansion
+The original query is sent as explicit lexical and vector subqueries. QMD performs rank fusion without generative expansion or final reranking.
 
 ### `adaptive`
 
-- starts with hybrid retrieval
-- reruns through QMD's expanded and reranked query path only when the initial result is uncertain
-- uncertainty includes a small top-result margin, lexical/vector disagreement, broad question form, multiple topical clusters, or a detected contradiction cluster
-- exact high-confidence identifiers bypass reranking
+Adaptive starts with the exact hybrid call. It invokes QMD's expanded and reranked path when any initial condition is true:
 
-Adaptive thresholds are internal defaults initially. They become settings only if benchmark results show users need to tune them.
+- normalized top-two score margin is below `0.08`
+- Jaccard overlap between lexical and vector top-five page IDs is below `0.40`
+- the normalized query begins with `who`, `what`, `when`, `where`, `why`, `how`, `which`, `compare`, `explain`, or their benchmarked multilingual equivalents
+- the initial candidates contain a validated contradiction edge
+
+An exact title, alias, command, filename, or page-ID match with normalized score at least `0.80` bypasses reranking.
 
 ### `quality`
 
-- QMD query expansion
-- lexical and vector candidate generation
-- reciprocal-rank fusion
-- local reranking of the bounded candidate pool
-- intended for maximum relevance despite higher latency and model load
+Quality always uses QMD query expansion, lexical and vector retrieval, rank fusion, and local reranking of at most 40 candidates.
+
+### Score normalization and first-release limits
+
+QMD raw scores are used for within-store confidence only. Cross-vault merging converts each store's ordered results to reciprocal-rank score `1 / (60 + rank)`. The final bounded multiplier is clamped to `0.90–1.10`: exact identity match `+0.05`, stable canonical role `+0.03`, evidence role `-0.02`, deprecated status `-0.08`, and all implicit feedback combined at no more than `±0.02`. Ties resolve by lower QMD rank, then project vault, then page ID. These constants are changed only through benchmarked code changes.
+
+Automatic recall requests at most 10 QMD candidates per vault, requires normalized QMD score `>= 0.50`, emits at most 3 memory bundles, and uses an 8,000-character context budget. Explicit recall uses caller `max_results` (default 5, maximum 10), a `0.25` QMD floor, and existing links-first rendering above the vault threshold.
+
+Each automatic bundle contains at most one canonical page and two evidence excerpts of at most 800 characters each. Parent-page deduplication is mandatory. If alternatives exist, no more than two canonical cards with the same `(type, domain)` pair may occupy the three automatic slots. Evidence order is direct `supports`/`derived_from`, then QMD rank, then page ID. Lower-ranked bundles are removed before evidence attached to the top bundle.
 
 QMD's supported environment variables remain the model-override surface. pi-llm-wiki will not duplicate every QMD model setting.
+
+### Query and intent construction
+
+The adapter derives `query` by applying Unicode NFKC normalization, trimming, and collapsing whitespace to the explicit `wiki_recall` query or current automatic-recall prompt. It does not remove punctuation, quoted phrases, path separators, or identifier characters before QMD receives the string. Empty queries return no result. Inputs above 2,000 characters are rejected with `recall_query_too_long` rather than silently truncated.
+
+For expanded/reranked calls, `intent` is the concatenation of non-empty vault `topic` and `mode` values from config, capped at 256 characters. It provides collection disambiguation only and never replaces or expands the query itself. If both are absent, `intent` is omitted. The full conversational transcript is never sent to QMD.
 
 ## Recall Data Flow
 
@@ -363,9 +427,9 @@ QMD's supported environment variables remain the model-override surface. pi-llm-
 Automatic recall is precision-first:
 
 - active project only when present; personal otherwise
-- small result count
-- strict confidence threshold
-- no injection when confidence is insufficient
+- at most 10 candidates and 3 packed bundles
+- normalized QMD score floor `0.50`
+- no injection when no candidate clears that floor
 - no generic graph expansion
 
 Explicit `wiki_recall` is recall-first:
@@ -385,6 +449,7 @@ After QMD ranking, pi-llm-wiki may apply only bounded, explainable adjustments f
 
 - exact title, alias, command, or identifier match
 - stable versus draft canonical status
+- current human verification (`+0.02` within the existing combined clamp)
 - applicable freshness and verification state
 - explicit user relevance judgment
 - weak local usage evidence
@@ -414,13 +479,42 @@ Conflicting claims are preserved separately with their dates, scope, status, and
 
 When recall finds a confirmed or plausible conflict, context shows both claims and asks the user which applies. The prompt identifies exact page IDs so the response can be applied deterministically.
 
-An unambiguous user response causes the agent to invoke a focused conflict-resolution operation that:
+An unambiguous user response causes the agent to invoke:
 
-1. records a dated resolution event
-2. adds `supersedes`, `qualifies`, or `applies_under` relations as selected
-3. marks the endorsed current interpretation without deleting the older claim
-4. preserves all source links and prior verification history
-5. rebuilds metadata and updates the affected QMD store
+```text
+wiki_resolve_conflict(
+  vault: "personal" | "project",
+  selected_page_id: string,
+  other_page_id: string,
+  relation: "supersedes" | "qualifies" | "applies_under",
+  scope?: string,
+  rationale?: string,
+  replaces?: string
+)
+```
+
+`selected_page_id` is the user-endorsed claim. Relation direction is always selected → other. `supersedes` means selected is current and the other claim is historical; `qualifies` means both remain stable and selected narrows the other; `applies_under` requires non-empty `scope` and means selected applies in that scope while the other remains applicable outside it. The tool rejects identical page IDs, missing pages, cross-vault pairs, invalid scope use, and any `replaces` ID that is not the active resolution for the same unordered pair.
+
+The tool writes one atomic resolution page under `wiki/analyses/` rather than editing both claim pages:
+
+```yaml
+type: analysis
+category: conflict-resolution
+status: stable
+resolution:
+  id: <semantic-hash>
+  selected: concepts/selected
+  other: concepts/other
+  relation: supersedes
+  scope: null
+  decided_by: user
+  decided_at: <ISO timestamp>
+  replaces: null
+```
+
+The body records the rationale and ordinary Markdown links to both claims. The ID and filename are a hash of vault ID, ordered page IDs, relation, normalized scope, and optional replaced resolution. Repeating the same operation is an idempotent no-op that returns the existing page. A changed choice requires `replaces` and creates a new immutable resolution record; recall follows the active replacement chain. A single temporary-file write, validation, and atomic rename commits the resolution. Metadata and QMD update occur afterward; failure leaves the valid resolution committed and reports stale derived state.
+
+The resolution page is authoritative evidence of the user's choice. For `supersedes`, recall treats the other claim as historical without rewriting its `status`; for the other relations, both remain stable. The derived relation graph and feedback projection mark the selected interpretation as current for the specified scope. Pi and MCP expose identical parameters, validation codes, and structured results.
 
 If the response is ambiguous, the system asks one clarifying question and makes no change. An LLM may map natural language to the explicit page IDs and relation, but it may not invent a third claim or silently edit unrelated content.
 
@@ -430,10 +524,10 @@ Recall returns grouped memory bundles rather than a flat list of chunks.
 
 Packing order:
 
-1. best applicable canonical card
-2. one or two strongest supporting evidence excerpts
+1. highest final-score applicable canonical card, using the documented tie-breaks
+2. at most two supporting evidence excerpts, ordered by typed relation and QMD rank
 3. relevant qualifier, superseding claim, or competing claim
-4. additional diverse canonical cards while budget remains
+4. additional canonical cards under the `(type, domain)` diversity cap while the 8,000-character automatic budget remains
 5. unpromoted evidence only when no suitable card covers the need
 
 Every packed item includes:
@@ -454,60 +548,49 @@ The existing links-first behavior remains useful for interactive expansion, but 
 
 ### Durable event format
 
-Implicit retrieval feedback is append-only local state in `meta/recall-feedback.jsonl`. To reduce accidental prompt retention, events store a hash of the normalized query rather than raw query text by default.
+Recall feedback is recorded through internal `recall_feedback` entries in the existing append-only `meta/events.jsonl`. To reduce accidental prompt retention, events store a SHA-256 hash of the normalized query rather than raw query text.
 
 Each event includes:
 
+- `schema: 1`
 - timestamp
+- `visibility: internal`
+- stable vault ID and page ID
 - query hash
 - retrieval mode
 - index and model versions
-- page ID and rank
+- shown rank
 - action
 
-Supported actions are:
+Supported actions are `shown`, `opened`, `cited`, `shown_only`, `relevant`, `irrelevant`, `corrected`, and `conflict_selected`.
 
-- `shown`
-- `opened`
-- `cited`
-- `ignored`
-- `relevant`
-- `irrelevant`
-- `corrected`
-- `conflict_selected`
+Instrumentation is exact:
 
-Explicit corrections are also preserved in human-readable wiki knowledge or resolution records; the feedback log is not their only source of truth.
+- the recall service emits `shown` after context or links are successfully delivered
+- the tool-call hook emits `opened` when a later `read` path resolves to a result shown in the active turn
+- the turn-end hook emits `cited` when the assistant output contains the shown page's wikilink or ID
+- the turn-end hook emits `shown_only` when no open or citation was observed; this is only an engagement proxy, not proof of irrelevance
+- the agent calls `wiki_recall_feedback(vault_id, page_id, judgment, correction?)` for an explicit `relevant`, `irrelevant`, or `corrected` user statement; the pair must exist in the active session's shown-result set, `correction` is required only for `corrected`, and the service obtains the query hash from that set rather than accepting arbitrary query text
+- `wiki_resolve_conflict` emits `conflict_selected`
+
+For `corrected`, `wiki_recall_feedback` first creates a normal human-readable `source` observation containing the user's correction and a Markdown link to the corrected page, using the existing observation producer and parser validation. Its frontmatter includes `status: observation`, `category: recall-correction`, `corrected_page`, `vault_id`, and `query_hash`; this shape is how projection replay identifies it. It then appends the internal feedback event. If observation creation fails, neither event nor ranking adjustment is written. If the later event append fails, the correction page remains authoritative and the tool reports `correction_saved_feedback_pending`; a metadata rebuild can replay such correction observations into the feedback projection. `relevant` and `irrelevant` write only internal events.
+
+`wiki_resolve_conflict` acquires the event lock before writing its resolution page, appends `conflict_selected` before releasing the lock, and aborts without a page if the lock cannot be acquired. This keeps the durable resolution and its feedback event aligned.
+
+Copy and dwell-time signals are unavailable in Pi's current hooks and are not claimed. Explicit corrections are therefore preserved in human-readable wiki knowledge or resolution records; the event stream is not their only source of truth.
 
 ### Signal strength
 
 - explicit correction or conflict choice: strong
 - explicit relevant/irrelevant judgment: strong
-- cited or copied result: moderate
+- cited result: moderate
 - opened result: weak positive
-- visibly shown but ignored result: very weak negative
+- `shown_only`: at most `-0.005` before decay
 - result not shown: no signal
 
-All boosts decay, remain bounded, and apply only after retrieval. Implicit signals cannot rewrite Markdown, resolve contradictions, or make a non-candidate appear. Position bias is accounted for by giving ignored results minimal weight.
+All boosts decay with a 90-day half-life, remain bounded to `±0.02` in final ranking, and apply only after retrieval. Implicit signals cannot rewrite Markdown, resolve contradictions, or make a non-candidate appear.
 
-Feedback collection is local and enabled by default in the new major. A single boolean setting disables implicit event capture without disabling explicit corrections.
-
-## Card Promotion
-
-The existing corpus is indexed immediately without bulk conversion.
-
-A background promotion queue prioritizes evidence that is:
-
-- repeatedly retrieved
-- frequently cited or opened
-- involved in explicit corrections
-- repeated across several sources
-- linked from multiple canonical pages
-- central to active projects
-- contradictory or time-sensitive
-
-The model may propose a canonical card containing one durable idea and exact source references. Proposed metadata and body content remain draft until reviewed. Promotion does not delete, merge, or rewrite underlying source pages.
-
-Low-value observations remain searchable evidence indefinitely. The target is a useful canonical layer, not one generated card per observation.
+Feedback collection is local and enabled by default in the new major. A single boolean setting disables `shown`, `opened`, `cited`, and `shown_only` capture without disabling explicit corrections or conflict records.
 
 ## Error Handling
 
@@ -540,7 +623,8 @@ Model downloads and long-running indexing show visible progress. Cancellation st
 ### Added
 
 - `wiki_reindex` consolidates lexical and vector reindexing.
-- one focused conflict-resolution operation records user-approved resolutions safely.
+- `wiki_resolve_conflict` records a user-approved resolution as one immutable analysis page.
+- `wiki_recall_feedback` records explicit relevance, irrelevance, or correction judgments for an already shown `(vault_id, page_id)` result.
 
 ### Deprecated
 
@@ -566,16 +650,22 @@ QMD model overrides use QMD's documented environment variables. Candidate counts
 The next major release:
 
 1. raises `engines.node` to Node.js 22 or newer
-2. adds QMD as a runtime dependency
-3. creates QMD stores lazily per vault
-4. keeps Markdown and existing metadata schemas readable without content migration
-5. ignores old page-level embedding sidecars after QMD activation
-6. prompts users to run `wiki_reindex` for full hybrid/quality recall
-7. supports immediate lexical recall after document indexing, even before embeddings finish
-8. documents QMD model download size and first-run latency
-9. leaves the previous major release available for Node.js 18 users
+2. pins `@tobilu/qmd` to the exact contract-tested version `2.6.3`, raises the development TypeScript version to satisfy QMD's declared peer range, and requires adapter tests plus benchmark comparison before any QMD upgrade
+3. supports the QMD package's tested native targets: Linux x64/arm64, macOS x64/arm64, and Windows x64; release CI performs clean-install smoke tests on Linux x64, macOS arm64, and Windows x64
+4. treats native dependency installation failure as package installation failure with a clear supported-platform message; there is no runtime shim for an installation that never completed
+5. records QMD schema version and resolved embedding, expansion, and reranker model IDs in index status
+6. uses QMD's standard model cache and documents the approximately 2 GB first-use download for default embedding, reranking, and expansion models
+7. verifies that `searchLex` indexes and queries without downloading or loading model files
+8. creates QMD stores lazily per vault
+9. keeps Markdown and existing metadata schemas readable without content migration, except for one stable `vault_id` backfill in config
+10. ignores old page-level embedding sidecars after QMD activation
+11. prompts users to run `wiki_reindex` for full hybrid/quality recall
+12. supports immediate lexical recall after validated document indexing, even before embeddings finish
+13. leaves the previous major release available for Node.js 18 users
 
-No existing source or canonical page is deleted or rewritten merely to adopt QMD. Card promotion and typed-link enrichment remain incremental, reviewable work.
+No existing source or canonical page is deleted or rewritten merely to adopt QMD. Typed-link enrichment remains incremental and reviewable. Automated card promotion requires a separate future design.
+
+The approved scope spans runtime migration, validated indexing, retrieval, memory assembly, feedback, and conflict resolution. It therefore requires a multi-phase implementation roadmap rather than one monolithic implementation plan.
 
 ## Evaluation
 
@@ -624,15 +714,17 @@ Run the same benchmark against:
 
 ### Release gates
 
-- no regression on exact identifier and title lookup
-- lower automatic-recall false-positive rate than the current baseline
-- material held-out improvement in canonical-card and evidence ranking
-- contradiction cases surface all judged competing claims
+- every exact identifier/title benchmark query that the baseline places in the top three remains in the top three
+- held-out nDCG@10 improves by at least 10% relative to the current baseline in `quality` mode
+- held-out MRR does not decline by more than 2% in any mode intended to supersede the baseline
+- automatic-recall false-positive rate falls by at least 25% relative to baseline
+- contradiction coverage is 100% on judged conflict cases
+- candidate Recall@20 does not decline by more than two percentage points
 - malformed pages and unavailable models degrade as specified
 - Pi and MCP return equivalent structured results
 - every explicit correction becomes a persistent regression case
 
-Exact numeric improvement thresholds are set after the initial benchmark establishes baseline variance; they must be recorded before tuning final ranking constants.
+The first benchmark run records confidence intervals and hardware context. Constants may be tightened before implementation, but the release cannot weaken these gates without a new reviewed design decision.
 
 ## Testing Strategy
 
@@ -655,15 +747,19 @@ QMD adapter tests use fakes and do not load local models.
 
 ### Integration tests
 
-- temporary Markdown vault indexed through the QMD SDK
-- incremental add, update, and delete
-- lexical recall before embeddings
+- temporary Markdown vault indexed through the pinned QMD SDK
+- incremental add, update, and delete through the validated mirror
+- malformed or reserved pages absent from QMD candidates
+- lexical recall before and without model downloads
 - forced vector reindex
+- complete SQLite artifact close/swap/reopen and interrupted-swap recovery
 - failed rebuild preserving the prior database
-- personal and project store isolation
+- personal and project store isolation, including duplicate page IDs and feedback
 - Pi/MCP parity
-- automatic recall suppressing low-confidence results
-- conflict-resolution operation preserving both claims
+- automatic recall suppressing low-confidence results at specified defaults
+- conflict-resolution idempotency, replacement chains, and preservation of both claims
+- `relations` parse/serialize/lint/Markdown-link coexistence
+- internal feedback event instrumentation and replay failure behavior
 
 Model-heavy embedding and reranking smoke tests may use a separate CI job with cached models; ordinary unit tests must remain deterministic and network-free.
 
@@ -678,7 +774,7 @@ Benchmark runs are versioned artifacts, not ordinary per-commit unit tests. Rele
 - **Reranker hides minority evidence:** add contradiction neighbors after seed ranking and test contradiction coverage.
 - **Implicit feedback creates popularity bias:** keep it weak, bounded, decayed, and post-retrieval only.
 - **QMD/model upgrade changes ranking:** record versions, mark affected indexes stale, and rerun benchmark before release.
-- **Native dependency or model failure:** fall back to QMD lexical search or no injection with clear diagnostics.
+- **Native dependency or model failure:** supported-platform clean-install CI catches native packaging defects; runtime model failures fall back to QMD lexical search or no injection with clear diagnostics.
 - **Index contains sensitive content:** keep it under protected local `meta/`, exclude it from OKF exports, and document that full-vault backups contain derived searchable text.
 - **Graph hubs dominate:** only typed one-hop relationships can add candidates; generic links do not boost rank.
 - **Over-atomization harms browsing:** atomicity follows useful idea boundaries, not arbitrary size limits.

--- a/docs/superpowers/specs/2026-08-08-qmd-retrieval-design.md
+++ b/docs/superpowers/specs/2026-08-08-qmd-retrieval-design.md
@@ -1,0 +1,710 @@
+# QMD-Backed Second-Brain Retrieval Design
+
+**Status:** Approved design  
+**Target:** Next major release  
+**Runtime:** Node.js 22 or newer  
+**Date:** 2026-08-08
+
+## Summary
+
+pi-llm-wiki will replace its heuristic recall ranking with QMD as its first-class retrieval engine. QMD will own Markdown indexing, BM25 retrieval, dense retrieval, rank fusion, query expansion, and local reranking. pi-llm-wiki will continue to own the knowledge model: canonical-card prioritization, evidence and contradiction assembly, feedback, context packing, layered vault behavior, and quality evaluation.
+
+Markdown remains authoritative. QMD's SQLite database and model artifacts are local, rebuildable implementation details. No custom database or graph database will be introduced.
+
+The product goal is not to return pages that merely resemble a query. Recall must provide useful memory for an AI: the best reviewed conclusion first, its strongest evidence, applicable scope and freshness, and any relevant competing claim.
+
+## Current-State Audit
+
+The personal vault inspected during design contained:
+
+- 701 registered pages
+- 626 `source` pages
+- 40 `concept` pages
+- 26 `entity` pages
+- 9 generic pages
+- titles and types on every registered page
+- tags on 63% of pages
+- effectively no summaries, descriptions, aliases, recall triggers, or domain metadata
+- no `meta/embeddings.json`, so live recall was lexical-only
+
+Current recall performs weighted substring matching over metadata and heading chunks, heuristic pseudo-relevance feedback, optional page-level embedding boosts, and raw additive score fusion. Its tests establish deterministic mechanics but do not measure relevance on real queries.
+
+The live recall examples observed during brainstorming returned unrelated accounting, webhook, shopping, and build notes for questions about retrieval architecture. This is unacceptable for automatic AI context injection.
+
+## Goals
+
+1. Make recall precise and useful enough to improve downstream AI work.
+2. Return reviewed canonical knowledge before raw observations whenever possible.
+3. Preserve source evidence, provenance, scope, freshness, and conflicting claims.
+4. Support exact lookup, paraphrase, vague recollection, temporal questions, contradiction discovery, and synthesis.
+5. Provide lexical, hybrid, adaptive, and maximum-quality retrieval modes.
+6. Reindex incrementally during ordinary writes and fully on explicit request.
+7. Learn conservatively from explicit corrections and local usage signals.
+8. Measure retrieval quality against a versioned benchmark built from real queries.
+9. Keep Markdown portable and Obsidian-compatible.
+10. Fail toward no recall or a cheaper retrieval mode, never toward unrelated injected memory.
+
+## Non-Goals
+
+- A custom vector database
+- A graph database
+- Graph-first or agentic traversal as the primary retriever
+- Automatic conversion of every observation into a canonical card
+- Automatic deletion or silent replacement of conflicting claims
+- Training a personalized ranking model from a small feedback corpus
+- Supporting Node.js 18 in the new major release
+- Maintaining two independent full retrieval engines
+- Treating Obsidian Graph View as a ranking algorithm
+
+## Decisions and Alternatives
+
+### Rejected: tune the existing scorer
+
+Adding metadata, enabling page embeddings, and adjusting weights would be the smallest change, but it would preserve the weakest parts of the current system: broad page representations, incomparable score addition, heuristic query drift, and no strong reranker.
+
+### Rejected: graph-first retrieval
+
+A Zettelkasten graph improves human thinking and navigation, but graph traversal cannot reliably find a seed note from an arbitrary query. The current graph is also dominated by source observations. Typed links will support bounded evidence assembly after retrieval, not replace retrieval.
+
+### Selected: QMD retrieval plus pi-llm-wiki memory semantics
+
+QMD already supplies the retrieval machinery this project would otherwise need to build and maintain:
+
+- BM25 full-text retrieval
+- dense retrieval over chunks
+- reciprocal-rank fusion
+- query expansion
+- local reranking
+- incremental indexing and embedding
+- a typed TypeScript SDK
+
+pi-llm-wiki will use QMD as a library rather than copy its implementation. The next major release will require Node.js 22 or newer and include QMD as a runtime dependency. Users who need Node.js 18 can remain on the previous major release.
+
+## Zettelkasten Role
+
+Zettelkasten is the knowledge organization model, not the search engine.
+
+Its useful principles are:
+
+- one durable idea per permanent note at a useful retrieval granularity
+- source or literature notes retained as evidence
+- explicit links that communicate meaningful relationships
+- structure notes and backlinks that support browsing and synthesis
+
+In pi-llm-wiki, existing `concept`, `entity`, `analysis`, `synthesis`, `skill`, and similar pages can act as permanent cards. Existing `source` and observation pages act as evidence. QMD finds candidates; Zettelkasten structure makes those candidates useful and composable.
+
+Obsidian Graph View remains a human curation surface for finding orphans, clusters, and missing links. It visualizes existing links and tags but does not affect query relevance by itself.
+
+## Architecture
+
+```text
+Markdown vaults
+  ├── canonical knowledge pages
+  ├── source and observation evidence
+  └── typed Markdown relationships
+          │
+          ▼
+QMD stores, one per vault
+  ├── filesystem index
+  ├── BM25 index
+  ├── heading-aware chunks
+  ├── embeddings
+  └── local reranker
+          │
+          ▼
+pi-llm-wiki recall service
+  ├── layered vault merge
+  ├── canonical/evidence classification
+  ├── trust, scope, and freshness adjustments
+  ├── feedback adjustments
+  ├── evidence and contradiction expansion
+  └── diverse token-budgeted context packing
+          │
+          ▼
+Pi tool, MCP, and automatic recall adapters
+```
+
+### Ownership
+
+- `.llm-wiki/wiki/**/*.md` remains authoritative, user-editable knowledge.
+- `.llm-wiki/raw/**` remains immutable source material.
+- `.llm-wiki/meta/qmd.sqlite` is generated, extension-owned, and rebuildable.
+- QMD model files remain in QMD's standard local cache.
+- `.llm-wiki/meta/recall-feedback.jsonl` is durable, append-only local state and is not part of an OKF export.
+- `.llm-wiki/meta/recall-feedback.json` is a rebuildable aggregate projection.
+
+The existing guardrails for `meta/**` apply to the QMD index and feedback files. Only extension code may modify them.
+
+### One store per vault
+
+Each personal or project vault gets an independent QMD store under its own `meta/` directory. This prevents a project index from copying personal content and keeps index invalidation local to the vault that changed.
+
+Automatic recall searches only the active project vault when one exists, matching the current contamination guard. Outside a project vault, it searches the personal vault. Explicit `wiki_recall` searches both applicable vaults in parallel, deduplicates by page ID with project precedence, and combines the ranked lists using rank-based fusion rather than assuming raw scores are comparable across stores.
+
+### QMD collections
+
+Each store defines two logical collections over `.llm-wiki/wiki/`:
+
+- **canonical:** concepts, entities, analyses, syntheses, requirements, skills, and cases
+- **evidence:** sources and observations
+
+Unknown page types remain searchable and default to evidence unless configured as canonical. Generated reserved files such as `index.md` and `log.md` are excluded.
+
+Collection context tells QMD that canonical pages contain reusable conclusions while evidence pages contain provenance and historical observations. pi-llm-wiki still validates every result against parsed page metadata; collection membership alone does not make a page authoritative.
+
+### Shared service boundary
+
+A shared retrieval service owns all behavior. Pi tools, automatic injection, and MCP call the same service and only render its structured result.
+
+Conceptual interfaces:
+
+```ts
+type RetrievalMode = "lexical" | "hybrid" | "adaptive" | "quality";
+
+type MemoryCandidate = {
+  vault: "project" | "personal";
+  pageId: string;
+  path: string;
+  heading?: string;
+  excerpt: string;
+  score: number;
+  role: "canonical" | "evidence";
+  status: "draft" | "stable" | "deprecated";
+  matchReasons: string[];
+};
+
+type MemoryBundle = {
+  card?: MemoryCandidate;
+  evidence: MemoryCandidate[];
+  conflicts: MemoryCandidate[];
+  resolution?: ConflictResolution;
+};
+```
+
+QMD-specific objects must not escape the QMD adapter. This keeps memory semantics testable without loading local models.
+
+## Knowledge Model
+
+### Card role
+
+“Card” is a retrieval role, not a new required page type.
+
+Canonical candidates include:
+
+- `concept`
+- `entity`
+- `analysis`
+- `synthesis`
+- `requirement`
+- `skill`
+- `case`
+
+Evidence candidates include:
+
+- `source`
+- observation pages
+- `trajectory`
+- unknown or generic pages unless explicitly promoted
+
+Within canonical candidates, `status: stable` and current verification receive bounded preference. Draft pages remain retrievable but are labeled. Deprecated and stale pages remain retrievable when relevant and carry warnings.
+
+### Atomic canonical pages
+
+A canonical page should express one independently useful idea, claim, entity, requirement, or reusable procedure. Atomicity is measured by retrieval usefulness, not sentence count. The system must not split a coherent idea into artificial fragments merely to create more cards.
+
+Recommended body sections are:
+
+```md
+## Claim
+
+## Scope
+
+## Evidence
+
+## Related
+```
+
+The existing OKF-compatible metadata remains authoritative for type, title, description, sources, generation, verification, status, and staleness. pi-llm-wiki adds one optional preserved extension field for typed card relationships:
+
+```yaml
+relations:
+  - target: concepts/other-card
+    type: contradicts
+```
+
+Allowed first-release relationship types are:
+
+- `supports`
+- `contradicts`
+- `qualifies`
+- `supersedes`
+- `applies_under`
+- `derived_from`
+- `related_to`
+
+Only the first six affect evidence or conflict expansion. `related_to` remains a browsing link and receives no automatic inclusion privilege.
+
+Evidence links should target the exact source page and, when available, a heading or Obsidian block anchor. Backlink generation may normalize the page target while preserving the anchor in Markdown.
+
+### Unpromoted evidence
+
+When no canonical card exists, recall may return the strongest source excerpt as **unpromoted evidence**. It must not be presented as an established conclusion. Repeated use can place it in a card-promotion queue.
+
+## Indexing and Reindexing
+
+### Normal write path
+
+After a successful metadata rebuild for changed Markdown pages, the indexing coordinator calls QMD's incremental update. Stale embeddings are generated in the background. A write remains successful even if QMD indexing fails; the last valid index stays available and status reports the failure.
+
+### Explicit tool
+
+The next major release adds one consolidated tool:
+
+```text
+wiki_reindex(
+  scope: "changed" | "all" = "changed",
+  components: ["lexical", "vectors"] = ["lexical", "vectors"],
+  force: boolean = false,
+  vault: "active" | "personal" | "project" | "all" = "active"
+)
+```
+
+Semantics:
+
+- `changed` scans files and updates added, changed, and removed documents.
+- `all` scans the entire selected vault but still skips fresh vectors unless `force` is true.
+- selecting only `lexical` never loads embedding or reranking models.
+- selecting `vectors` first performs the document update required to identify stale chunks.
+- `force` applies only to selected components.
+- `all` vault scope processes stores independently and reports each outcome.
+
+The tool reports:
+
+- collections scanned
+- pages indexed, updated, unchanged, and removed
+- chunks needing embeddings
+- vectors generated or skipped
+- index and model versions
+- elapsed time
+- structured warnings and errors
+
+The existing `wiki_reindex_embeddings` tool is deprecated in the new major and delegates to `wiki_reindex(components=["vectors"])` for one release before removal.
+
+### Index lifecycle
+
+QMD owns its SQLite schema and transactions. pi-llm-wiki does not manipulate QMD tables directly. Before a forced full rebuild, the adapter builds or validates replacement state without deleting the last usable index. If QMD cannot provide atomic replacement through its SDK, the adapter rebuilds into a sibling temporary database, closes it, validates basic status and document counts, then renames it into place.
+
+Content hashes, QMD schema/version information, and model identities determine staleness. A removed Markdown page must disappear from QMD results after the next incremental update. Historical feedback may retain its page ID but cannot boost a result that no longer exists.
+
+## Retrieval Modes
+
+Configuration adds one primary setting:
+
+```json
+{
+  "llm-wiki": {
+    "retrievalMode": "adaptive"
+  }
+}
+```
+
+Invalid explicit values fail closed with a configuration diagnostic. Default is `adaptive`.
+
+### `lexical`
+
+- QMD BM25 only
+- no embedding, expansion, or reranking model load
+- best for exact names, commands, identifiers, filenames, and low-resource systems
+
+### `hybrid`
+
+- lexical and vector candidates
+- reciprocal-rank fusion
+- no final reranking
+- uses the original query as both lexical and vector intent without generative query expansion
+
+### `adaptive`
+
+- starts with hybrid retrieval
+- reruns through QMD's expanded and reranked query path only when the initial result is uncertain
+- uncertainty includes a small top-result margin, lexical/vector disagreement, broad question form, multiple topical clusters, or a detected contradiction cluster
+- exact high-confidence identifiers bypass reranking
+
+Adaptive thresholds are internal defaults initially. They become settings only if benchmark results show users need to tune them.
+
+### `quality`
+
+- QMD query expansion
+- lexical and vector candidate generation
+- reciprocal-rank fusion
+- local reranking of the bounded candidate pool
+- intended for maximum relevance despite higher latency and model load
+
+QMD's supported environment variables remain the model-override surface. pi-llm-wiki will not duplicate every QMD model setting.
+
+## Recall Data Flow
+
+1. Resolve active personal and project vaults.
+2. Normalize the query while preserving exact identifiers and original wording.
+3. Select automatic or explicit recall policy.
+4. Query applicable QMD stores using the configured retrieval mode.
+5. Merge layered result lists by rank and deduplicate project/personal page ID collisions with project precedence.
+6. Parse each candidate through the shared knowledge-document layer.
+7. Classify canonical versus evidence role and derive status, trust, scope, and freshness warnings.
+8. Apply bounded feedback and exact-match adjustments.
+9. Group excerpts under their parent pages.
+10. Prefer reviewed canonical cards.
+11. Follow at most one typed relationship hop for direct evidence, qualifiers, superseding claims, and contradictions.
+12. Pack diverse memory bundles under the context budget.
+13. Render structured context for Pi or MCP.
+
+### Automatic versus explicit recall
+
+Automatic recall is precision-first:
+
+- active project only when present; personal otherwise
+- small result count
+- strict confidence threshold
+- no injection when confidence is insufficient
+- no generic graph expansion
+
+Explicit `wiki_recall` is recall-first:
+
+- searches personal and project stores when both exist
+- accepts a larger result count
+- returns alternatives and unpromoted evidence
+- exposes match explanations and diagnostics
+
+“No reliable memory found” is a valid successful outcome. The system must not fill an empty slot with a weak candidate.
+
+## Reranking and Adjustments
+
+QMD's reranker judges direct query usefulness. It is not a candidate generator and cannot create evidence.
+
+After QMD ranking, pi-llm-wiki may apply only bounded, explainable adjustments for:
+
+- exact title, alias, command, or identifier match
+- stable versus draft canonical status
+- applicable freshness and verification state
+- explicit user relevance judgment
+- weak local usage evidence
+- project duplicate precedence
+
+These adjustments cannot introduce a candidate that QMD did not retrieve. Trust, freshness, and popularity must not hide an otherwise relevant conflicting claim.
+
+## Typed-Link Expansion
+
+Graph expansion is an assembly step after strong seed retrieval.
+
+Rules:
+
+- at most one hop by default
+- only `supports`, `contradicts`, `qualifies`, `supersedes`, `applies_under`, and `derived_from` can add a result
+- a generic Markdown or `related_to` link never forces inclusion
+- evidence expansion is capped per card
+- high-degree pages do not receive an automatic popularity boost
+- graph-derived items are labeled with the relation that admitted them
+- a contradiction neighbor is kept with its seed even when diversity selection would otherwise remove it
+
+No graph database is needed. Existing generated backlinks plus parsed typed relations are sufficient.
+
+## Contradictions and User Resolution
+
+Conflicting claims are preserved separately with their dates, scope, status, and evidence. Automated detection may propose a conflict, but it cannot permanently declare one without review.
+
+When recall finds a confirmed or plausible conflict, context shows both claims and asks the user which applies. The prompt identifies exact page IDs so the response can be applied deterministically.
+
+An unambiguous user response causes the agent to invoke a focused conflict-resolution operation that:
+
+1. records a dated resolution event
+2. adds `supersedes`, `qualifies`, or `applies_under` relations as selected
+3. marks the endorsed current interpretation without deleting the older claim
+4. preserves all source links and prior verification history
+5. rebuilds metadata and updates the affected QMD store
+
+If the response is ambiguous, the system asks one clarifying question and makes no change. An LLM may map natural language to the explicit page IDs and relation, but it may not invent a third claim or silently edit unrelated content.
+
+## Context Packing
+
+Recall returns grouped memory bundles rather than a flat list of chunks.
+
+Packing order:
+
+1. best applicable canonical card
+2. one or two strongest supporting evidence excerpts
+3. relevant qualifier, superseding claim, or competing claim
+4. additional diverse canonical cards while budget remains
+5. unpromoted evidence only when no suitable card covers the need
+
+Every packed item includes:
+
+- page ID and readable path
+- title and type
+- vault label
+- exact excerpt and heading when available
+- date, status, freshness, and scope when present
+- match reason
+- relationship to the canonical card
+
+Deduplication prevents several chunks from one page or repeated observations from consuming the context budget. Contradictory claims remain grouped. Context truncation removes lower-value bundles before removing evidence from the highest-value bundle.
+
+The existing links-first behavior remains useful for interactive expansion, but automatic AI context receives the compact canonical/evidence bundle directly when it fits the configured budget.
+
+## Feedback
+
+### Durable event format
+
+Implicit retrieval feedback is append-only local state in `meta/recall-feedback.jsonl`. To reduce accidental prompt retention, events store a hash of the normalized query rather than raw query text by default.
+
+Each event includes:
+
+- timestamp
+- query hash
+- retrieval mode
+- index and model versions
+- page ID and rank
+- action
+
+Supported actions are:
+
+- `shown`
+- `opened`
+- `cited`
+- `ignored`
+- `relevant`
+- `irrelevant`
+- `corrected`
+- `conflict_selected`
+
+Explicit corrections are also preserved in human-readable wiki knowledge or resolution records; the feedback log is not their only source of truth.
+
+### Signal strength
+
+- explicit correction or conflict choice: strong
+- explicit relevant/irrelevant judgment: strong
+- cited or copied result: moderate
+- opened result: weak positive
+- visibly shown but ignored result: very weak negative
+- result not shown: no signal
+
+All boosts decay, remain bounded, and apply only after retrieval. Implicit signals cannot rewrite Markdown, resolve contradictions, or make a non-candidate appear. Position bias is accounted for by giving ignored results minimal weight.
+
+Feedback collection is local and enabled by default in the new major. A single boolean setting disables implicit event capture without disabling explicit corrections.
+
+## Card Promotion
+
+The existing corpus is indexed immediately without bulk conversion.
+
+A background promotion queue prioritizes evidence that is:
+
+- repeatedly retrieved
+- frequently cited or opened
+- involved in explicit corrections
+- repeated across several sources
+- linked from multiple canonical pages
+- central to active projects
+- contradictory or time-sensitive
+
+The model may propose a canonical card containing one durable idea and exact source references. Proposed metadata and body content remain draft until reviewed. Promotion does not delete, merge, or rewrite underlying source pages.
+
+Low-value observations remain searchable evidence indefinitely. The target is a useful canonical layer, not one generated card per observation.
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| vectors missing or stale | continue with BM25; report stale vector status |
+| embedding model load fails | fall back to lexical retrieval |
+| reranker fails or times out | return fused hybrid results |
+| QMD store cannot open | automatic recall injects nothing; explicit recall returns a structured diagnostic |
+| incremental update fails | retain previous usable index and mark it stale |
+| full rebuild fails | keep previous database; remove temporary replacement |
+| malformed Markdown | exclude page from new results and report shared parser diagnostic |
+| index/model mismatch | mark stale and recommend `wiki_reindex` |
+| deleted page referenced by feedback | ignore feedback entry during aggregation |
+| low confidence | return no reliable memory rather than weak results |
+
+Model downloads and long-running indexing show visible progress. Cancellation stops new work without deleting the last usable index.
+
+## Tools and Interfaces
+
+### Updated
+
+- `wiki_recall` uses the shared QMD-backed recall service.
+- automatic `before_agent_start` recall uses the same service with precision-first policy.
+- MCP `wiki_recall` uses the same structured operation.
+- `wiki_status` reports QMD document, chunk, embedding, model, and stale-index state.
+- `wiki_lint` reports missing evidence, invalid typed relations, unresolved conflict markers, and stale search state.
+- `wiki_rebuild_meta` schedules incremental QMD update after successful projection rebuild.
+
+### Added
+
+- `wiki_reindex` consolidates lexical and vector reindexing.
+- one focused conflict-resolution operation records user-approved resolutions safely.
+
+### Deprecated
+
+- `wiki_reindex_embeddings` delegates to `wiki_reindex` for one major release cycle.
+- the old heuristic recall and page-level embedding scorer are removed from active `wiki_recall` paths.
+- `wiki_search` remains a fast exact registry lookup and is not presented as relevance-ranked recall.
+
+## Configuration
+
+First-release configuration remains narrow:
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `retrievalMode` | `adaptive` | `lexical`, `hybrid`, `adaptive`, or `quality` |
+| `recallFeedback` | `true` | capture bounded local implicit signals |
+| `recallLinksThreshold` | existing default | switch interactive rendering to links-first |
+| `recallSkillInlineMax` | existing default | inline recalled skills/cases |
+
+QMD model overrides use QMD's documented environment variables. Candidate counts, adaptive thresholds, fusion constants, and feedback weights remain implementation constants until benchmark evidence justifies exposing them.
+
+## Migration and Release
+
+The next major release:
+
+1. raises `engines.node` to Node.js 22 or newer
+2. adds QMD as a runtime dependency
+3. creates QMD stores lazily per vault
+4. keeps Markdown and existing metadata schemas readable without content migration
+5. ignores old page-level embedding sidecars after QMD activation
+6. prompts users to run `wiki_reindex` for full hybrid/quality recall
+7. supports immediate lexical recall after document indexing, even before embeddings finish
+8. documents QMD model download size and first-run latency
+9. leaves the previous major release available for Node.js 18 users
+
+No existing source or canonical page is deleted or rewritten merely to adopt QMD. Card promotion and typed-link enrichment remain incremental, reviewable work.
+
+## Evaluation
+
+### Benchmark
+
+Create a versioned benchmark from 50–100 real queries, with at least 20% held out from tuning. Include:
+
+- exact note lookup
+- vague recollection
+- paraphrased conceptual recall
+- entity and alias lookup
+- “what did I conclude about” questions
+- source and evidence requests
+- temporal questions
+- contradictory claims
+- multi-note synthesis
+- multilingual queries represented in the vault
+- generic language that may produce dense-retrieval false positives
+
+Each query receives graded relevance judgments for both canonical cards and evidence excerpts. Acceptable competing claims are identified for contradiction cases.
+
+### Metrics
+
+- candidate Recall@20
+- MRR
+- nDCG@5 and nDCG@10
+- canonical-card-first success rate
+- evidence precision and evidence recall
+- contradiction coverage
+- duplicate/context waste
+- automatic-recall false-positive rate
+- warm and cold latency by mode
+- model download and steady-state resource cost
+
+### Ablations
+
+Run the same benchmark against:
+
+1. current heuristic recall baseline
+2. QMD lexical
+3. QMD hybrid
+4. adaptive reranking
+5. quality mode
+6. quality mode without typed-link assembly
+7. quality mode without feedback adjustments
+
+### Release gates
+
+- no regression on exact identifier and title lookup
+- lower automatic-recall false-positive rate than the current baseline
+- material held-out improvement in canonical-card and evidence ranking
+- contradiction cases surface all judged competing claims
+- malformed pages and unavailable models degrade as specified
+- Pi and MCP return equivalent structured results
+- every explicit correction becomes a persistent regression case
+
+Exact numeric improvement thresholds are set after the initial benchmark establishes baseline variance; they must be recorded before tuning final ranking constants.
+
+## Testing Strategy
+
+### Unit tests
+
+- retrieval-mode parsing and fail-closed invalid values
+- QMD adapter request mapping
+- canonical/evidence classification
+- layered rank fusion and project duplicate precedence
+- bounded trust, freshness, and feedback adjustments
+- typed-link admission and one-hop cap
+- canonical/evidence bundle grouping
+- contradiction preservation
+- context deduplication and budget trimming
+- query hashing and feedback aggregation
+- stale and deleted feedback references
+- fallback state machine
+
+QMD adapter tests use fakes and do not load local models.
+
+### Integration tests
+
+- temporary Markdown vault indexed through the QMD SDK
+- incremental add, update, and delete
+- lexical recall before embeddings
+- forced vector reindex
+- failed rebuild preserving the prior database
+- personal and project store isolation
+- Pi/MCP parity
+- automatic recall suppressing low-confidence results
+- conflict-resolution operation preserving both claims
+
+Model-heavy embedding and reranking smoke tests may use a separate CI job with cached models; ordinary unit tests must remain deterministic and network-free.
+
+### Benchmark tests
+
+Benchmark runs are versioned artifacts, not ordinary per-commit unit tests. Release candidates run the complete benchmark and publish mode-by-mode metrics, regressions, model versions, index versions, and hardware context.
+
+## Risks and Mitigations
+
+- **Generated cards distort evidence:** require exact source references and review before stable status.
+- **Dense retrieval overmatches generic prose:** preserve BM25, use RRF and reranking, and include this failure class in the benchmark.
+- **Reranker hides minority evidence:** add contradiction neighbors after seed ranking and test contradiction coverage.
+- **Implicit feedback creates popularity bias:** keep it weak, bounded, decayed, and post-retrieval only.
+- **QMD/model upgrade changes ranking:** record versions, mark affected indexes stale, and rerun benchmark before release.
+- **Native dependency or model failure:** fall back to QMD lexical search or no injection with clear diagnostics.
+- **Index contains sensitive content:** keep it under protected local `meta/`, exclude it from OKF exports, and document that full-vault backups contain derived searchable text.
+- **Graph hubs dominate:** only typed one-hop relationships can add candidates; generic links do not boost rank.
+- **Over-atomization harms browsing:** atomicity follows useful idea boundaries, not arbitrary size limits.
+- **Stale sidecars:** content hashes, incremental updates, status diagnostics, and explicit reindexing keep them rebuildable.
+
+## Success Criteria
+
+The design succeeds when:
+
+1. unrelated automatic recall is measurably reduced
+2. reviewed canonical cards appear before raw observations for judged queries
+3. correct evidence accompanies the selected card
+4. relevant conflicts appear together and remain unresolved until user input
+5. lexical recall works without loading local models
+6. adaptive and quality modes materially improve held-out ranking
+7. users can inspect status and repair search with one reindex tool
+8. feedback improves repeated use without mutating facts
+9. Obsidian and plain Markdown workflows remain intact
+10. all generated search state can be rebuilt from Markdown plus durable feedback events
+
+## Research References
+
+- QMD repository and SDK documentation: https://github.com/tobi/qmd
+- Obsidian Graph View documentation: https://obsidian.md/help/plugins/graph
+- Zettelkasten introduction: https://zettelkasten.de/introduction/
+- Zettelkasten atomicity guide: https://zettelkasten.de/atomicity/guide/
+- Reciprocal Rank Fusion, Cormack, Clarke, and Buettcher: https://doi.org/10.1145/1571941.1572114
+- Existing pi-llm-wiki architecture: `docs/architecture.md`
+- Existing OKF interoperability design: `docs/superpowers/specs/2026-08-02-okf-v0.2-interoperability-design.md`

--- a/docs/superpowers/specs/2026-08-08-qmd-retrieval-design.md
+++ b/docs/superpowers/specs/2026-08-08-qmd-retrieval-design.md
@@ -650,7 +650,7 @@ QMD model overrides use QMD's documented environment variables. Candidate counts
 The next major release:
 
 1. raises `engines.node` to Node.js 22 or newer
-2. pins `@tobilu/qmd` to the exact contract-tested version `2.6.3`, raises the development TypeScript version to satisfy QMD's declared peer range, and requires adapter tests plus benchmark comparison before any QMD upgrade
+2. pins `@tobilu/qmd` to the exact published, contract-tested version `2.5.3`, raises the development TypeScript version to satisfy QMD's declared peer range, and requires adapter tests plus benchmark comparison before any QMD upgrade
 3. supports the QMD package's tested native targets: Linux x64/arm64, macOS x64/arm64, and Windows x64; release CI performs clean-install smoke tests on Linux x64, macOS arm64, and Windows x64
 4. treats native dependency installation failure as package installation failure with a clear supported-platform message; there is no runtime shim for an installation that never completed
 5. records QMD schema version and resolved embedding, expansion, and reranker model IDs in index status

--- a/extensions/llm-wiki/lib/knowledge-document.ts
+++ b/extensions/llm-wiki/lib/knowledge-document.ts
@@ -588,6 +588,22 @@ export function serializeKnowledgeDocument(document: KnowledgeDocument): string 
   return body ? `---\n${yaml}---\n\n${body}\n` : `---\n${yaml}---\n`;
 }
 
+/** Escape wikilink alias pipes so generated content remains valid in Markdown tables. */
+function escapeWikilinkAliasPipes(body: string): string {
+  let inFence = false;
+  return body
+    .split("\n")
+    .map((line) => {
+      if (/^\s*(`{3,}|~{3,})/.test(line)) {
+        inFence = !inFence;
+        return line;
+      }
+      if (inFence) return line;
+      return line.replace(/\[\[([^\]\n]*?)(?<!\\)\|([^\]\n]*?)\]\]/g, "[[$1\\|$2]]");
+    })
+    .join("\n");
+}
+
 export function createKnowledgeDocument<T extends KnowledgeCreationFields>(
   path: string,
   fields: T & NoInfer<KnowledgeCreationFields>,
@@ -614,7 +630,7 @@ export function createKnowledgeDocument<T extends KnowledgeCreationFields>(
     ? { kind: "canonical" as const, value: sources }
     : { kind: "absent" as const };
 
-  const normalizedBody = body.replace(/\r\n?/g, "\n").replace(/\n*$/, "");
+  const normalizedBody = escapeWikilinkAliasPipes(body.replace(/\r\n?/g, "\n")).replace(/\n*$/, "");
 
   return {
     id: path.replace(/\.md$/, ""),
@@ -643,7 +659,9 @@ export function patchKnowledgeDocument(
     }
   }
 
-  const newBody = patch.body ?? document.body;
+  const newBody = patch.body
+    ? escapeWikilinkAliasPipes(patch.body.replace(/\r\n?/g, "\n"))
+    : document.body;
 
   return {
     ...document,

--- a/extensions/llm-wiki/lib/knowledge-links.ts
+++ b/extensions/llm-wiki/lib/knowledge-links.ts
@@ -33,13 +33,17 @@ function diag(
   return { severity, code, path, message };
 }
 
+function normalizeWikilinkTarget(target: string): string {
+  return target.trim().replace(/\\$/, "");
+}
+
 export function extractKnowledgeLinks(body: string): KnowledgeLinks {
   const markdown: ExtractedLink[] = [];
   const wikilinks: ExtractedLink[] = [];
 
-  // Extract legacy wikilinks
+  // Extract legacy wikilinks. A table-safe alias uses an escaped pipe: [[target\\|alias]].
   for (const match of body.matchAll(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g)) {
-    wikilinks.push({ target: match[1].trim(), offset: match.index ?? 0 });
+    wikilinks.push({ target: normalizeWikilinkTarget(match[1]), offset: match.index ?? 0 });
   }
 
   // Parse with CommonMark AST
@@ -111,7 +115,7 @@ export function extractKnowledgeLinks(body: string): KnowledgeLinks {
 export function extractLegacyWikilinks(body: string): ExtractedLink[] {
   const links: ExtractedLink[] = [];
   for (const match of body.matchAll(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g)) {
-    links.push({ target: match[1].trim(), offset: match.index ?? 0 });
+    links.push({ target: normalizeWikilinkTarget(match[1]), offset: match.index ?? 0 });
   }
   return links;
 }

--- a/extensions/llm-wiki/lib/metadata.ts
+++ b/extensions/llm-wiki/lib/metadata.ts
@@ -508,7 +508,7 @@ export function buildDirectoryIndexes(
       lines.push("## Directories");
       lines.push("");
       for (const subDir of [...dirs].sort(compareCodePoint)) {
-        const encoded = `${encodeRelativePath(subDir)}/`;
+        const encoded = encodeRelativePath(`${subDir}/index.md`);
         lines.push(`- [${escapeLabel(subDir)}/](${encoded})`);
       }
     }

--- a/prompts/wiki-ingest.md
+++ b/prompts/wiki-ingest.md
@@ -33,4 +33,5 @@ $ARGUMENTS
 **Rules:**
 - Never modify files in `raw/` — source packets are immutable after capture.
 - Never fabricate information — always cite sources with `[[sources/SRC-...]]`.
+- Inside Markdown table cells, write aliased wikilinks as `[[target\|alias]]`, never `[[target|alias]]`.
 - The extension auto-updates metadata — you do NOT need to manually edit `meta/` files.

--- a/prompts/wiki-req.md
+++ b/prompts/wiki-req.md
@@ -53,3 +53,4 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand th
 - Use status values: `draft` → `clarified` → `active` → `implemented` → `deferred` → `rejected`
 - Use priority values: `p0` (blocking), `p1` (critical), `p2` (important), `p3` (nice-to-have)
 - Do not create requirements in `raw/` — that layer is for external source artifacts only
+- Inside Markdown table cells, write aliased wikilinks as `[[target\|alias]]`, never `[[target|alias]]`.

--- a/prompts/wiki-retro.md
+++ b/prompts/wiki-retro.md
@@ -32,3 +32,4 @@ Read the LLM Wiki skill at `.pi/skills/llm-wiki/SKILL.md` first to understand th
 - One atomic insight per `wiki_retro` call. Use multiple calls for multiple insights.
 - Don't save obvious things. Save non-obvious patterns, tradeoffs, and design decisions.
 - Always add `[[wikilinks]]` to connect the new insight with existing wiki knowledge.
+- Inside Markdown table cells, write aliased wikilinks as `[[target\|alias]]`, never `[[target|alias]]`.

--- a/test/fixtures/okf/indexes/concepts.md
+++ b/test/fixtures/okf/indexes/concepts.md
@@ -2,7 +2,7 @@
 
 ## Directories
 
-- [nested/](nested/)
+- [nested/](nested/index.md)
 
 ## Concepts
 

--- a/test/fixtures/okf/indexes/root.md
+++ b/test/fixtures/okf/indexes/root.md
@@ -6,7 +6,7 @@ okf_version: "0.2"
 
 ## Directories
 
-- [concepts/](concepts/)
+- [concepts/](concepts/index.md)
 
 ## Concepts
 

--- a/test/knowledge-document.test.ts
+++ b/test/knowledge-document.test.ts
@@ -56,6 +56,16 @@ describe("KnowledgeDocument", () => {
     expect(serializeKnowledgeDocument(doc)).toBe("---\ntype: concept\n---\n\nBody\n");
   });
 
+  it("escapes aliased wikilinks in generated Markdown without changing fenced code", () => {
+    const doc = createKnowledgeDocument(
+      "concepts/table.md",
+      { type: "concept" },
+      "| Name |\n| --- |\n| [[entities/gildan|Gildan]] |\n\n```md\n[[entities/raw|Raw]]\n```",
+    );
+    expect(doc.body).toContain("[[entities/gildan\\|Gildan]]");
+    expect(doc.body).toContain("[[entities/raw|Raw]]");
+  });
+
   it.each([
     ["frontmatter_duplicate_key", "---\ntype: concept\ntype: entity\n---\n"],
     ["frontmatter_alias_forbidden", "---\ntype: concept\nx: &x [1]\ny: *x\n---\n"],

--- a/test/knowledge-links.test.ts
+++ b/test/knowledge-links.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildResolvedBacklinks,
   extractKnowledgeLinks,
+  extractLegacyWikilinks,
 } from "../extensions/llm-wiki/lib/knowledge-links.js";
 
 const known = new Set([
@@ -45,11 +46,20 @@ describe("knowledge links", () => {
       "[root](/shared/root.md?x=1)",
       "[relative](../concepts/encoded%20name.md)",
       "[[concepts/inline|Inline]]",
+      "[[concepts/inline\\|Inline]]",
       "[external](https://example.com/x.md)",
     ].join("\n");
     const result = buildResolvedBacklinks("concepts/source", body, known);
     expect(result.targets).toEqual(["concepts/encoded name", "concepts/inline", "shared/root"]);
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("strips the escape before an aliased wikilink target", () => {
+    const body = "[[entities/gildan\\|Gildan]]";
+    expect(extractKnowledgeLinks(body).wikilinks).toEqual([
+      { target: "entities/gildan", offset: 0 },
+    ]);
+    expect(extractLegacyWikilinks(body)).toEqual([{ target: "entities/gildan", offset: 0 }]);
   });
 
   it("rejects bundle escape and reports unresolved internal targets", () => {


### PR DESCRIPTION
## Summary

- Fix escaped aliased wikilinks being indexed with a trailing backslash.
- Link generated directory indexes to `subdir/index.md` instead of bare folders.
- Escape aliased wikilink pipes in generated Markdown while preserving fenced code.
- Add prompt guidance and regression coverage.

## Validation

- `pnpm exec vitest run test/knowledge-links.test.ts test/knowledge-document.test.ts test/okf-projections.test.ts`
- `pnpm typecheck`
- Full `pnpm test` has unrelated MCP HTTP/recall timeout failures in the current environment.

Fixes #155
Fixes #156
Fixes #157