### PR TITLE
fix: declare typebox as runtime dependency (fixes #153)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,8 +82,7 @@
     "extensions": ["./extensions/llm-wiki/index.ts"]
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "typebox": "*"
+    "@mariozechner/pi-coding-agent": "*"
   },
   "packageManager": "pnpm@9.15.4",
   "engines": {
@@ -94,6 +93,7 @@
     "@modelcontextprotocol/server": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.3",
     "node-html-markdown": "^2.0.0",
+    "typebox": "^1.1.34",
     "yaml": "^2.9.0",
     "zod": "^4.0"
   },
@@ -106,7 +106,6 @@
     "@types/mdast": "^4.0.4",
     "@types/node": "^22",
     "@vitest/coverage-v8": "^3.2.4",
-    "typebox": "^1.1.34",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       node-html-markdown:
         specifier: ^2.0.0
         version: 2.0.0
+      typebox:
+        specifier: ^1.1.34
+        version: 1.3.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -51,9 +54,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(yaml@2.9.0))
-      typebox:
-        specifier: ^1.1.34
-        version: 1.3.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3

--- a/test/package-structure.test.ts
+++ b/test/package-structure.test.ts
@@ -24,7 +24,11 @@ describe("package structure", () => {
     expect(pkg.pi.prompts).toContain("./prompts");
     expect(pkg.peerDependencies).toBeDefined();
     expect(pkg.peerDependencies["@mariozechner/pi-coding-agent"]).toBe("*");
-    expect(pkg.peerDependencies.typebox).toBe("*");
+    // `typebox` is imported at runtime by the dist extension modules, so it
+    // must be a real dependency — a fresh install without the pi host (e.g.
+    // MCP-only, peers omitted) has to resolve it (issue #153).
+    expect(pkg.peerDependencies.typebox).toBeUndefined();
+    expect(pkg.dependencies.typebox).toBeTruthy();
   });
 
   // oh-my-pi reads `package.json#omp` first and only falls back to `#pi`


### PR DESCRIPTION
## Summary

Fresh installs of the published package fail with `ERR_MODULE_NOT_FOUND: Cannot find package 'typebox'` when the MCP server is configured outside the pi host (e.g. Codex). The dist extension modules import `typebox` at runtime, but the package declared it only as a peer dependency, so a clean install without the pi host has nothing to resolve it.

## Changes

- Move `typebox` from `peerDependencies` / `devDependencies` into `dependencies` (`^1.1.34`, previously installed dev version kept).
- `@mariozechner/pi-coding-agent` remains a peer — it is the host and is provided by the consuming environment.
- Update `test/package-structure.test.ts` to assert the new shape: `peerDependencies.typebox` undefined and `dependencies.typebox` present, so this cannot regress silently.

## Verification

- Reproduced the original failure on published `0.11.4`: clean `npm install --omit=peer` of the tarball, then importing `dist/extensions/llm-wiki/lib/tools.js` failed with `ERR_MODULE_NOT_FOUND` for `typebox`.
- With this change: clean consumer install resolves `typebox@1.3.19` and the importing modules load.
- Normal clean consumer install: `node node_modules/@zosmaai/pi-llm-wiki/dist/mcp/index.js` boots ("LLM Wiki MCP Server running on stdio").
- `pnpm install` lockfile sync, targeted `test/package-structure.test.ts` (19/19), `pnpm typecheck`, `biome check` on touched files — all pass.