### PR TITLE
fix: dedupe wiki-observe-reminder across retry storms (fixes #151)

### DIFF
--- a/extensions/llm-wiki/lib/observation.ts
+++ b/extensions/llm-wiki/lib/observation.ts
@@ -345,10 +345,12 @@ export function registerObservationReminder(
     return true;
   };
   let turnsSinceLastReminder = 0;
+  let agentEndsInUserTurn = 0;
 
   pi.on("session_start", async () => {
     turnsSinceLastReminder = 0;
     reminderState.observeDoneThisSession = false;
+    agentEndsInUserTurn = 0;
   });
 
   // After compaction, reset turn counter so reminders resume
@@ -358,10 +360,18 @@ export function registerObservationReminder(
     turnsSinceLastReminder = 0;
   });
 
+  // A retry re-runs the agent within the same user turn, and pi does not
+  // forward `willRetry` to extensions (zosmaai/pi-llm-wiki#151). Only the
+  // user-role message_start separates real user turns from retried agent
+  // runs, so the per-turn agent_end count resets there.
+  pi.on("message_start", async (event) => {
+    if (event.message.role === "user") agentEndsInUserTurn = 0;
+  });
+
   pi.on("agent_end", async (event, _ctx) => {
-    // Skip reminder on retries — willRetry means pi will re-run the agent,
-    // and queuing another reminder would duplicate them (issue: connection
-    // errors cause multiple retries, each firing agent_end).
+    // Legacy guard: this pi build does not forward `willRetry` to extension
+    // events, but keep the check in case a future one does. The dedup that
+    // actually works is the per-turn agent_end count below.
     if ("willRetry" in event && (event as { willRetry?: boolean }).willRetry) return;
 
     // No wiki applies here: never nag, and never accumulate a pending reminder
@@ -371,6 +381,12 @@ export function registerObservationReminder(
     turnsSinceLastReminder++;
     if (turnsSinceLastReminder < REMINDER_INTERVAL) return;
     if (reminderState.observeDoneThisSession) return;
+
+    // One agent_end per user turn may queue a reminder. A rate-limit storm
+    // re-runs the agent several times within the same turn, each firing
+    // agent_end, so count them and let only the first through.
+    agentEndsInUserTurn++;
+    if (agentEndsInUserTurn > 1) return;
 
     pi.sendMessage(
       {
@@ -382,5 +398,9 @@ export function registerObservationReminder(
         deliverAs: "nextTurn",
       },
     );
+
+    // Reset the interval counter after queueing: without it the count stays
+    // at/above the threshold and every later agent_end queues a reminder.
+    turnsSinceLastReminder = 0;
   });
 }

--- a/test/observation.test.ts
+++ b/test/observation.test.ts
@@ -334,14 +334,18 @@ describe("registerObservationReminder — retry deduplication", () => {
     const state = createReminderState();
     registerObservationReminder(pi, state, { turnsBetweenReminders: 1 });
 
-    // 1 turn fires reminder
+    // 1 turn fires reminder (counter resets after queueing)
     await emit("agent_end", {});
     expect(messages).toHaveLength(1);
 
-    // Counter stays at 1, compact resets it
+    // Compaction happens mid-retry within the same user turn — it must not
+    // re-arm the reminder on its own.
     await emit("session_compact");
+    await emit("agent_end", {});
+    expect(messages).toHaveLength(1);
 
-    // Counter = 0, next turn = 1 → fires again
+    // A new user turn re-arms the reminder
+    await emit("message_start", { message: { role: "user" } });
     await emit("agent_end", {});
     expect(messages).toHaveLength(2);
   });
@@ -354,6 +358,44 @@ describe("registerObservationReminder — retry deduplication", () => {
     // event without willRetry field at all
     await emit("agent_end", {});
     expect(messages).toHaveLength(1);
+  });
+
+  it("queues at most one reminder per user turn on retry storms (no willRetry field)", async () => {
+    const { pi, emit, messages } = createMockPi();
+    const state = createReminderState();
+    registerObservationReminder(pi, state, { turnsBetweenReminders: 1 });
+
+    // One user turn: original run + 4 rate-limit retries = 5 agent_end events.
+    // pi never forwards willRetry to extensions (zosmaai/pi-llm-wiki#151), so
+    // each event looks like a normal turn end.
+    await emit("message_start", { message: { role: "user" } });
+    for (let i = 0; i < 5; i++) await emit("agent_end", {});
+    expect(messages).toHaveLength(1);
+
+    // The next user turn queues fresh
+    await emit("message_start", { message: { role: "user" } });
+    await emit("agent_end", {});
+    expect(messages).toHaveLength(2);
+  });
+
+  it("re-queues only after REMINDER_INTERVAL user turns, not on the next agent_end", async () => {
+    const { pi, emit, messages } = createMockPi();
+    const state = createReminderState();
+    registerObservationReminder(pi, state, { turnsBetweenReminders: 2 });
+
+    const userTurn = async () => {
+      await emit("message_start", { message: { role: "user" } });
+      await emit("agent_end", {});
+    };
+
+    await userTurn();
+    expect(messages).toHaveLength(0);
+    await userTurn(); // 2nd user turn crosses the interval
+    expect(messages).toHaveLength(1);
+    await userTurn(); // counter reset after queueing — must not re-queue
+    expect(messages).toHaveLength(1);
+    await userTurn(); // interval elapsed again
+    expect(messages).toHaveLength(2);
   });
 
   it("respects display option (false = silent injection)", async () => {
@@ -382,10 +424,14 @@ describe("registerObservationReminder — retry deduplication", () => {
     expect(messages[0].msg.display).toBe(true);
 
     noticesOn = false;
-    await emit("agent_end", {}); // next interval cycle would need reset
-    // For this test, we manually reset to trigger again
-    await emit("session_start");
+    // Same user turn: a retry-style agent_end must not re-queue
     await emit("agent_end", {});
-    expect(messages[2].msg.display).toBe(false);
+    expect(messages).toHaveLength(1);
+
+    // A new user turn re-arms, and display is re-resolved
+    await emit("message_start", { message: { role: "user" } });
+    await emit("agent_end", {});
+    expect(messages).toHaveLength(2);
+    expect(messages[1].msg.display).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem (#151)

A rate-limit retry storm duplicates the `wiki-observe-reminder`: pi auto-retries via `agent.continue()`, and each retried run fires its own `agent_end`, each queueing another `nextTurn` reminder — a 4-retry storm injected the reminder 5× on the next turn.

The guard added in 4cd5639 is dead code: pi's `_emitExtensionEvent` only forwards `{ type, messages }` for `agent_end`; `willRetry` is added to the *internal* session bus only, never to extension events (verified against `pi-coding-agent` dist: `AgentEndEvent` has no `willRetry` field).

A second latent bug in the same handler: `turnsSinceLastReminder` was never reset after queueing, so once the threshold was crossed the reminder re-queued on **every** subsequent `agent_end` — nag every turn, not every N turns.

## Fix (extension-side, defense-in-depth)

`extensions/llm-wiki/lib/observation.ts::registerObservationReminder`:

- **Per-turn dedup:** count `agent_end` events since the last user-role `message_start`; only the first may queue a reminder. Boundary choice is deliberate — verified in `pi-agent-core` that a retried run re-fires `agent_start` **and** `turn_start` (`runAgentLoopContinue` emits both), so neither is a safe "new user turn" marker; only a user-role message is.
- **Interval reset:** `turnsSinceLastReminder = 0` after queueing, restoring true every-N-user-turns semantics.
- Kept the `willRetry` guard (harmless; works if a future pi forwards the field). Root-cause on the pi side (forwarding `willRetry` to extensions) is a separate upstream ask.

## Tests

- New regression (fails on old code, verified): 5 `agent_end` events in one user turn (no `willRetry` field — as pi actually emits them) → exactly 1 reminder; next user turn re-arms.
- New regression (fails on old code): re-queues only after `REMINDER_INTERVAL` user turns, not on the immediately following `agent_end`.
- Reworked 2 existing tests whose sequences only made sense under the buggy "queues every agent_end" behavior (compact/resume and display-resolver).
- `test/observation.test.ts` 20/20, `test/ambient-gate.test.ts` 17/17, typecheck, biome all green. (A few unrelated slow e2e/mcp files flake under full-parallel load on this machine — pass in isolated runs on both this branch and pristine `main`.)