### PR TITLE
fix: synthesis maxTokens default 16384 + /wiki-settings screen, docs sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Instructions for AI agents working on this codebase.
 ## File Layout
 
 ```
-├── extensions/llm-wiki/     # TypeScript extension (12 tools + guardrails)
+├── extensions/llm-wiki/     # TypeScript extension (14 tools + 3 opt-in trajectory tools + guardrails)
 │   ├── index.ts             # Entry point
 │   └── lib/                 # tools.ts, metadata.ts, guardrails.ts, utils.ts, source-packet.ts, host.ts
 ├── skills/llm-wiki/         # SKILL.md + templates

--- a/README.de.md
+++ b/README.de.md
@@ -125,7 +125,9 @@ Das Ergebnis ist ein Wiki, das wächst, während du Quellen erfasst, Fragen stel
 | `wiki_search` | Search the generated wiki registry |
 | `wiki_lint` | Deterministic health checks (orphans, gaps, contradictions, auto-fix) |
 | `wiki_status` | Show counts, source states, and recent activity |
+| `wiki_observe` | Aktuelle Sitzung als zeitgestempelte, durchsuchbare Beobachtung im wiki vermerken |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
+| `wiki_reindex_embeddings` | Semantische Embeddings neuer oder veralteter Seiten aktualisieren (no-op ohne Embedding-Provider) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 | `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
@@ -147,10 +149,12 @@ Das Ergebnis ist ein Wiki, das wächst, während du Quellen erfasst, Fragen stel
 | `/wiki-status` | Show a concise operational summary |
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
+| `/wiki-model [provider/id | session]` | Modell für Hintergrund-Aufgaben setzen (ohne Argument: interaktiver Auswahlbildschirm) |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
 | `/wiki-trajectories <on\|off>` | Enable/disable agent working-memory (opt-in, off by default) |
 | `/wiki-record <title>` | Capture the completed task's trajectory (requires trajectories enabled) |
 | `/wiki-skills [query]` | Search distilled skills + past cases (requires trajectories enabled) |
+| `/wiki-settings` | Interaktive Einstellungensoberfläche — alle `llm-wiki`-Einstellungen in Projekt- oder globaler Sicht anzeigen/ändern |
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -111,7 +111,9 @@ El resultado es un wiki que **se acumula** mientras capturas fuentes, haces preg
 | `wiki_search` | Busca en el registro generado del wiki |
 | `wiki_lint` | Comprobaciones de salud deterministas (huérfanos, lagunas, contradicciones, auto-reparación) |
 | `wiki_status` | Muestra conteos, estados de fuentes y actividad reciente |
+| `wiki_observe` | Registra observaciones de la sesión actual con marca de tiempo y buscables |
 | `wiki_rebuild_meta` | Fuerza una reconstrucción completa de metadatos (registro, backlinks, índice, registro) |
+| `wiki_reindex_embeddings` | Refresca los embeddings semánticos de páginas nuevas o desactualizadas (no hace nada sin proveedor de embeddings) |
 | `wiki_log_event` | Adjunta un evento estructurado al registro de actividad del wiki |
 | `wiki_watch` | Imprime una línea `crontab` para actualizaciones automáticas del wiki (diaria / semanal / horaria) — no la instala |
 | `wiki_capture_trajectory` _(opcional)_ | Captura la trayectoria de llamadas de herramientas de la tarea completada (memoria de trabajo del agente) |
@@ -133,10 +135,12 @@ El resultado es un wiki que **se acumula** mientras capturas fuentes, haces preg
 | `/wiki-status` | Muestra un resumen operativo conciso |
 | `/wiki-digest [--period daily\|weekly]` | Genera un resumen de actividad reciente |
 | `/wiki-retro` | Guarda ideas atómicas de tareas completadas |
+| `/wiki-model [provider/id | session]` | Fija el modelo de las tareas en segundo plano (sin argumento: selector interactivo) |
 | `/wiki-req <concept>` | Descompone un concepto en páginas de requisitos atómicas y rastreables |
 | `/wiki-trajectories <on\|off>` | Activa/desactiva la memoria de trabajo del agente (opcional, desactivada por defecto) |
 | `/wiki-record <title>` | Captura la trayectoria de la tarea completada (requiere trayectorias activadas) |
 | `/wiki-skills [query]` | Busca habilidades destiladas + casos pasados (requiere trayectorias activadas) |
+| `/wiki-settings` | Pantalla interactiva de ajustes — ver/cambiar todos los ajustes `llm-wiki` en alcance de proyecto o global |
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -125,7 +125,9 @@ Le résultat est un wiki qui s'accumule au fur et à mesure que vous capturez de
 | `wiki_search` | Search the generated wiki registry |
 | `wiki_lint` | Deterministic health checks (orphans, gaps, contradictions, auto-fix) |
 | `wiki_status` | Show counts, source states, and recent activity |
+| `wiki_observe` | Enregistre les observations horodatées et recherchables de la session en cours |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
+| `wiki_reindex_embeddings` | Actualise les embeddings sémantiques des pages nouvelles ou obsolètes (no-op sans fournisseur d'embeddings) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 | `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
@@ -147,10 +149,12 @@ Le résultat est un wiki qui s'accumule au fur et à mesure que vous capturez de
 | `/wiki-status` | Show a concise operational summary |
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
+| `/wiki-model [provider/id | session]` | Définit le modèle des tâches en arrière-plan (sans argument : sélecteur interactif) |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
 | `/wiki-trajectories <on\|off>` | Enable/disable agent working-memory (opt-in, off by default) |
 | `/wiki-record <title>` | Capture the completed task's trajectory (requires trajectories enabled) |
 | `/wiki-skills [query]` | Search distilled skills + past cases (requires trajectories enabled) |
+| `/wiki-settings` | Écran interactif des réglages — voir/modifier tous les réglages `llm-wiki` en portée projet ou globale |
 
 ---
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -125,7 +125,9 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `wiki_search` | Search the generated wiki registry |
 | `wiki_lint` | Deterministic health checks (orphans, gaps, contradictions, auto-fix) |
 | `wiki_status` | Show counts, source states, and recent activity |
+| `wiki_observe` | चालू session की timestamped, search-able observations को wiki में दर्ज करें |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
+| `wiki_reindex_embeddings` | नई/पुरानी pages के semantic embeddings को refresh करें (बिना embedding provider के no-op) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 | `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
@@ -147,10 +149,12 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `/wiki-status` | Show a concise operational summary |
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
+| `/wiki-model [provider/id | session]` | Background-task model set करें (बिना argument: interactive picker) |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
 | `/wiki-trajectories <on\|off>` | Enable/disable agent working-memory (opt-in, off by default) |
 | `/wiki-record <title>` | Capture the completed task's trajectory (requires trajectories enabled) |
 | `/wiki-skills [query]` | Search distilled skills + past cases (requires trajectories enabled) |
+| `/wiki-settings` | Interactive settings screen — saare `llm-wiki` settings ko project ya global scope में dekh/change करें |
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -125,7 +125,9 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `wiki_search` | Search the generated wiki registry |
 | `wiki_lint` | Deterministic health checks (orphans, gaps, contradictions, auto-fix) |
 | `wiki_status` | Show counts, source states, and recent activity |
+| `wiki_observe` | 現在のセッションの日時付き・検索可能な観察を wiki に記録する |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
+| `wiki_reindex_embeddings` | 新規または古いページの意味的埋め込みを再計算する（プロバイダ未設定の場合は no-op） |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 | `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
@@ -147,10 +149,12 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `/wiki-status` | Show a concise operational summary |
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
+| `/wiki-model [provider/id | session]` | バックグラウンドタスクのモデルを設定（引数なしで対話式ピッカー） |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
 | `/wiki-trajectories <on\|off>` | Enable/disable agent working-memory (opt-in, off by default) |
 | `/wiki-record <title>` | Capture the completed task's trajectory (requires trajectories enabled) |
 | `/wiki-skills [query]` | Search distilled skills + past cases (requires trajectories enabled) |
+| `/wiki-settings` | インタラクティブな設定画面 — `llm-wiki` 設定を project/global スコープで一覧/変更 |
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -125,7 +125,9 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `wiki_search` | Search the generated wiki registry |
 | `wiki_lint` | Deterministic health checks (orphans, gaps, contradictions, auto-fix) |
 | `wiki_status` | Show counts, source states, and recent activity |
+| `wiki_observe` | 현재 세션의 시각이 기록된 검색 가능한 관찰을 wiki에 기록 |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
+| `wiki_reindex_embeddings` | 신규/변경된 페이지의 시맨틱 임베딩을 재인덱싱 (임베딩 제공자 미설정 시 no-op) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 | `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
@@ -147,10 +149,12 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `/wiki-status` | Show a concise operational summary |
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
+| `/wiki-model [provider/id | session]` | 백그라운드 태스크 모델 설정 (인자 없으면 대화형 선택기) |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
 | `/wiki-trajectories <on\|off>` | Enable/disable agent working-memory (opt-in, off by default) |
 | `/wiki-record <title>` | Capture the completed task's trajectory (requires trajectories enabled) |
 | `/wiki-skills [query]` | Search distilled skills + past cases (requires trajectories enabled) |
+| `/wiki-settings` | 대화형 설정 화면 — `llm-wiki` 설정을 project/global 스코프로 보기/변경 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | `wiki_search` | Search the generated wiki registry |
 | `wiki_lint` | Deterministic health checks (orphans, gaps, contradictions, auto-fix) |
 | `wiki_status` | Show counts, source states, and recent activity |
+| `wiki_observe` | Record timestamped, searchable observations from the current session (decisions, findings, constraints) — later distilled into pages |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
+| `wiki_reindex_embeddings` | Refresh semantic embeddings for new or stale pages (no-op if no embedding provider is configured) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 | `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
@@ -146,10 +148,12 @@ The result is a wiki that **compounds** as you capture sources, ask questions, a
 | `/wiki-status` | Show a concise operational summary |
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
+| `/wiki-model [provider/id | session]` | Set the background-task model (interactive picker when run without arguments) |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
 | `/wiki-trajectories <on\|off>` | Enable/disable agent working-memory (opt-in, off by default) |
 | `/wiki-record <title>` | Capture the completed task's trajectory (requires trajectories enabled) |
 | `/wiki-skills [query]` | Search distilled skills + past cases (requires trajectories enabled) |
+| `/wiki-settings` | Interactive settings screen — view and change all `llm-wiki` settings in project or global scope |
 
 ---
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -125,7 +125,9 @@ O resultado é um wiki que se acumula conforme você captura fontes, faz pergunt
 | `wiki_search` | Search the generated wiki registry |
 | `wiki_lint` | Deterministic health checks (orphans, gaps, contradictions, auto-fix) |
 | `wiki_status` | Show counts, source states, and recent activity |
+| `wiki_observe` | Registra observações datadas e pesquisáveis da sessão atual no wiki |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
+| `wiki_reindex_embeddings` | Atualiza os embeddings semânticos de páginas novas ou desatualizadas (no-op sem provedor de embeddings) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 | `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
@@ -147,10 +149,12 @@ O resultado é um wiki que se acumula conforme você captura fontes, faz pergunt
 | `/wiki-status` | Show a concise operational summary |
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
+| `/wiki-model [provider/id | session]` | Define o modelo das tarefas em segundo plano (sem argumento: seletor interativo) |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
 | `/wiki-trajectories <on\|off>` | Enable/disable agent working-memory (opt-in, off by default) |
 | `/wiki-record <title>` | Capture the completed task's trajectory (requires trajectories enabled) |
 | `/wiki-skills [query]` | Search distilled skills + past cases (requires trajectories enabled) |
+| `/wiki-settings` | Tela interativa de ajustes — ver/mudar todos os ajustes `llm-wiki` em escopo de projeto ou global |
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -125,7 +125,9 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `wiki_search` | Search the generated wiki registry |
 | `wiki_lint` | Deterministic health checks (orphans, gaps, contradictions, auto-fix) |
 | `wiki_status` | Show counts, source states, and recent activity |
+| `wiki_observe` | Записывает во wiki атомарные наблюдения текущей сессии с временн…уткой |
 | `wiki_rebuild_meta` | Force a full metadata rebuild (registry, backlinks, index, log) |
+| `wiki_reindex_embeddings` | Обновляет семантические эмбеддинги новых или устаревших страниц (no-op при отсутствии провайдера эмбеддингов) |
 | `wiki_log_event` | Append a structured event to the wiki activity log |
 | `wiki_watch` | Print a `crontab` line for automatic wiki updates (daily / weekly / hourly) — does not install it |
 | `wiki_capture_trajectory` _(opt-in)_ | Capture the completed task's tool-call trajectory (agent working-memory) |
@@ -147,10 +149,12 @@ The extension will proactively suggest creating a wiki on your first session. Al
 | `/wiki-status` | Show a concise operational summary |
 | `/wiki-digest [--period daily\|weekly]` | Generate a digest of recent activity |
 | `/wiki-retro` | Save atomic insights from completed tasks |
+| `/wiki-model [provider/id | session]` | Задаёт модель для фоновых задач (без аргумента — интерактивный выбор) |
 | `/wiki-req <concept>` | Decompose a concept into atomic, traceable requirement pages |
 | `/wiki-trajectories <on\|off>` | Enable/disable agent working-memory (opt-in, off by default) |
 | `/wiki-record <title>` | Capture the completed task's trajectory (requires trajectories enabled) |
 | `/wiki-skills [query]` | Search distilled skills + past cases (requires trajectories enabled) |
+| `/wiki-settings` | Интерактивный экран настроек — просмотр/изменение всех настроек `llm-wiki` в проектном или глобальном scope |
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -111,7 +111,9 @@ pi install npm:@zosmaai/pi-llm-wiki
 | `wiki_search` | 搜索生成的 wiki 注册表 |
 | `wiki_lint` | 确定性健康检查（孤儿、缺口、矛盾、自动修复） |
 | `wiki_status` | 显示计数、来源状态和最近活动 |
+| `wiki_observe` | 记录当前会话的带时间戳、可搜索观察 |
 | `wiki_rebuild_meta` | 强制完整元数据重建（注册表、反向链接、索引、日志） |
+| `wiki_reindex_embeddings` | 为新增或过期的页面刷新语义嵌入（未配置 embedding 提供方时为空操作） |
 | `wiki_log_event` | 将结构化事件追加到 wiki 活动日志 |
 | `wiki_watch` | 打印自动 wiki 更新的 `crontab` 行（每日/每周/每小时）——不安装它 |
 | `wiki_capture_trajectory` _（可选）_ | 捕获已完成任务的工具调用轨迹（代理工作记忆） |
@@ -133,10 +135,12 @@ pi install npm:@zosmaai/pi-llm-wiki
 | `/wiki-status` | 显示简洁的操作摘要 |
 | `/wiki-digest [--period daily\|weekly]` | 生成最近活动的摘要 |
 | `/wiki-retro` | 保存已完成任务的原子洞察 |
+| `/wiki-model [provider/id | session]` | 设置后台任务模型（无参数时为交互式选择器） |
 | `/wiki-req <concept>` | 将概念分解为原子、可追踪的需求页面 |
 | `/wiki-trajectories <on\|off>` | 启用/禁用代理工作记忆（可选，默认关闭） |
 | `/wiki-record <title>` | 捕获已完成任务的轨迹（需要启用轨迹） |
 | `/wiki-skills [query]` | 搜索提炼的技能+过去案例（需要启用轨迹） |
+| `/wiki-settings` | 交互式设置屏幕 — 在 project/global 作用域下查看/修改全部 `llm-wiki` 设置 |
 
 ---
 

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
-    "ignore": ["coverage", "dist", "node_modules"]
+    "ignore": ["coverage", "dist", "node_modules", "tmp"]
   },
   "organizeImports": {
     "enabled": true

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 All tools registered by the extension. Parameters marked `?` are optional.
 
-13 tools are always registered. The 3 agent-trajectory tools
+14 tools are always registered. The 3 agent-trajectory tools
 (`wiki_capture_trajectory`, `wiki_distill_skills`, `wiki_recall_skill`) are **opt-in,
 off by default** (issue #80) — they are only registered when `llm-wiki.trajectories`
 is `true`; enable with `/wiki-trajectories on`.
@@ -455,6 +455,29 @@ details: {
 
 Returns empty `matches: []` with a hint to capture work via `wiki_capture_trajectory` /
 `wiki_distill_skills` when nothing matches.
+
+---
+
+## wiki_reindex_embeddings
+
+Backfill or refresh semantic embeddings for the vault. Embeds pages that are new or stale
+(content changed); pass `force` to re-embed everything. No-op when no embedding provider is
+configured — set `llm-wiki.embeddingProvider` first (see `docs/configuration.md`).
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `force` | `boolean` | — | Re-embed every page, ignoring staleness (default: `false`) |
+
+**Returns**
+
+```
+details: { enabled: true, model: string, embedded: number, skipped: number, pruned: number }
+```
+
+Fails soft with `details: { enabled: false }` plus a hint to configure `embeddingProvider` when
+no embedding provider is set.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,10 +17,12 @@
 | `/wiki-trajectories` | Enable/disable agent working-memory (`on`/`off`, opt-in) |
 | `/wiki-record`   | Capture the completed task's trajectory (requires trajectories enabled) |
 | `/wiki-skills`   | Search distilled skills + past cases (requires trajectories enabled) |
+| `/wiki-req` | Decompose a concept into atomic requirement pages |
+| `/wiki-settings` | Browse or change all `llm-wiki` settings (project or global scope) |
 
 ## Extension Tools
 
-The extension always registers 13 tools the LLM can call directly. The 3 agent-trajectory
+The extension always registers 14 tools the LLM can call directly. The 3 agent-trajectory
 tools (`wiki_capture_trajectory`, `wiki_distill_skills`, `wiki_recall_skill`) are **opt-in,
 off by default** (issue #80) — registered only when `llm-wiki.trajectories` is enabled
 (`/wiki-trajectories on`).
@@ -36,7 +38,9 @@ off by default** (issue #80) — registered only when `llm-wiki.trajectories` is
 | `wiki_search`         | Search the wiki registry                    |
 | `wiki_lint`           | Health check with auto-fix                  |
 | `wiki_status`         | Instant stats                               |
+| `wiki_observe` | Record a timestamped observation from the current session |
 | `wiki_rebuild_meta`   | Force metadata rebuild                      |
+| `wiki_reindex_embeddings` | Refresh semantic embeddings (no-op when no embedding provider) |
 | `wiki_log_event`      | Record custom event                         |
 | `wiki_watch`          | Schedule auto-updates                       |
 | `wiki_capture_trajectory` | Capture the completed task's tool-call trajectory |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,12 +53,22 @@ config directory already exists (host-native first, created if neither is
 present). A hand-authored `config.yml` is read but never rewritten.
 
 | Setting                | Default    | Description                                                  |
+All of the above are viewable and editable in the `/wiki-settings` TUI (persists to project or global settings).
 | ---------------------- | ---------- | ------------------------------------------------------------ |
 | `taskModel`            | —          | Model for background tasks (`{ provider: "openai", id: "gpt-4o" }`) |
 | `synthesisLanguage`    | —          | BCP 47 language tag for ingest synthesis (e.g. `"ru"`, `"fr"`). When unset, synthesis defaults to English. |
+| `synthesisMaxTokens`     | 16384    | Max output tokens for ingest/synthesis runs (stored as a plain number)                        |
 | `trajectories`         | false      | Enable agent-trajectory working-memory                       |
 | `notices`              | true       | Show wiki activity notices in chat                           |
 | `ambientPersonalVault` | host-dependent | Let the personal vault act as the ambient vault in projects that have no wiki. `true` under pi, `false` under oh-my-pi — see below. |
+| `semanticWeight`       | 0.5      | Weight of the semantic sub-score in hybrid recall (clamped 0–1)                               |
+| `recallLinksThreshold` | 50       | Page-count gate for two-stage links-first recall (0 = always links-first, issue #68)          |
+| `recallSkillInlineMax` | 1600     | Max chars of a skill/case body inlined into recall output (0 = links only)                    |
+| `embeddingProvider`    | —        | Embedding provider (e.g. `openai`); embeddings stay off until this is set                     |
+| `embeddingModel`       | —        | Embedding model name (provider-specific)                                                      |
+| `embeddingBaseUrl`     | —        | Optional API base URL override for the embedding provider                                     |
+| `embeddingApiKey`      | —        | API key literal — prefer `embeddingApiKeyEnv` so no secret lands in settings                  |
+| `embeddingApiKeyEnv`   | —        | Name of the environment variable holding the embedding API key                                |
 
 Example:
 

--- a/extensions/llm-wiki/index.ts
+++ b/extensions/llm-wiki/index.ts
@@ -20,6 +20,7 @@ import {
 } from "./lib/recall.js";
 import { registerWikiRetro } from "./lib/retro.js";
 import { registerBackgroundRuntime } from "./lib/runtime.js";
+import { registerWikiSettingsCommand } from "./lib/settings-command.js";
 import {
   loadTaskConfig,
   noticesEnabled,
@@ -131,6 +132,7 @@ export default function (pi: ExtensionAPI) {
   // background task model. The taskModel config field + resolveModel already
   // exist; this exposes them to the user (default stays the session model).
   registerWikiModelCommand(pi, runtime);
+  registerWikiSettingsCommand(pi, runtime);
   const reminderState = createReminderState();
   registerWikiObserve(pi, runtime, reminderState);
   // Visible observe/retro reminder by default (issue #77); silenced when the

--- a/extensions/llm-wiki/lib/host.ts
+++ b/extensions/llm-wiki/lib/host.ts
@@ -123,3 +123,23 @@ export function resolveProjectSettingsPath(cwd: string, host: HostKind = detectH
 
   return join(native, "settings.json");
 }
+
+/**
+ * The global (user-level) settings file this extension writes to.
+ *
+ * Always writes to `settings.json` inside the agent dir — both hosts read it.
+ */
+export function resolveGlobalSettingsPath(host: HostKind = detectHost()): string {
+  let agentDir = "";
+  try {
+    agentDir = getAgentDir();
+  } catch {
+    agentDir = "";
+  }
+  if (!agentDir) {
+    // Fallback: ~/.pi/agent/settings.json
+    const home = process.env.HOME || "~";
+    return join(home, ".pi", "agent", "settings.json");
+  }
+  return join(agentDir, "settings.json");
+}

--- a/extensions/llm-wiki/lib/ingest-worker.ts
+++ b/extensions/llm-wiki/lib/ingest-worker.ts
@@ -475,6 +475,8 @@ export interface RunIngestSynthesisArgs {
   signal?: AbortSignal;
   /** BCP 47 language tag for narrative content (issue #124). */
   synthesisLanguage?: string;
+  /** Max output tokens for synthesizer sub-agent (issue #160). Default 16384. */
+  synthesisMaxTokens?: number;
 }
 
 /**
@@ -496,6 +498,7 @@ export async function runIngestSynthesis(
     maxChars,
     signal,
     synthesisLanguage,
+    synthesisMaxTokens,
   } = args;
   const content = extracted.slice(0, maxChars ?? 24_000);
   if (!content.trim()) return undefined;
@@ -549,6 +552,7 @@ export async function runIngestSynthesis(
     systemPrompt,
     userPrompt,
     tools: [commitTool as AgentTool],
+    maxTokens: synthesisMaxTokens ?? 16384,
     signal,
   });
 

--- a/extensions/llm-wiki/lib/settings-command.ts
+++ b/extensions/llm-wiki/lib/settings-command.ts
@@ -1,0 +1,429 @@
+import { homedir } from "node:os";
+import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent";
+import {
+  Container,
+  Input,
+  type SettingItem,
+  SettingsList,
+  type SettingsListTheme,
+  Spacer,
+  Text,
+} from "@mariozechner/pi-tui";
+import type { Runtime } from "./runtime.js";
+import {
+  type SettingScope,
+  loadTaskConfigSources,
+  parseModelRef,
+  persistSetting,
+} from "./task-config.js";
+
+/**
+ * Settings TUI for LLM Wiki.
+ *
+ * /wiki-settings renders the whole screen as ONE persistent pi-tui
+ * SettingsList (the same component pi's own /settings uses), shown through
+ * ui.custom():
+ *
+ *   - booleans cycle OFF/ON in place (Enter/Space) — no screen reset,
+ *     the cursor stays where it is
+ *   - strings/numbers/model open an inline input submenu; closing it
+ *     restores the cursor to the same item
+ *   - every change persists immediately to the chosen scope
+ *     (project or global) and the display normalizes in place
+ *
+ * Flow:
+ *   1. cwd inside ~/ → global scope; outside ~/ → scope picker first
+ *   2. persistent settings screen (Esc closes)
+ */
+
+interface Ui {
+  select(title: string, options: string[]): Promise<string | undefined>;
+  notify(message: string, type?: "info" | "warning" | "error"): void;
+  /** Hosts that can render a focused custom component (pi ≥ 0.70 interactive). */
+  custom?(
+    factory: (
+      tui: unknown,
+      theme: Theme,
+      keybindings: unknown,
+      done: (result?: unknown) => void,
+    ) => unknown,
+  ): Promise<unknown>;
+}
+
+/** Setting definition — drives both the menu and its edit menu. */
+interface SettingDef {
+  key: string;
+  label: string;
+  type: "boolean" | "number" | "string" | "model";
+  /** Shown with the item when it is selected. */
+  hint: string;
+  /** Edit-menu title override (defaults to `Set <label>`). */
+  menuLabel?: string;
+  /** Raw text to prefill the edit input with when the value is unset. */
+  defaultText?: string;
+  /** Pretty-print a value for display. */
+  format: (v: unknown) => string;
+  /** Raw text used to prefill the edit input. */
+  toEdit: (v: unknown) => string;
+  /** Parse user input into a typed value. undefined = invalid. */
+  parse: (input: string) => unknown | undefined;
+}
+
+const SETTINGS: SettingDef[] = [
+  {
+    key: "taskModel",
+    label: "Model",
+    type: "model",
+    hint: "Model for background wiki tasks (provider/id).",
+    menuLabel: "Task model — provider/id, empty = session model",
+    format: (v) => {
+      const m = v as { provider: string; id: string } | undefined;
+      return m ? `${m.provider}/${m.id}` : "(session model)";
+    },
+    toEdit: (v) => {
+      const m = v as { provider: string; id: string } | undefined;
+      return m ? `${m.provider}/${m.id}` : "";
+    },
+    parse: (input) => parseModelRef(input),
+  },
+  {
+    key: "synthesisMaxTokens",
+    label: "Synthesis Tokens",
+    type: "number",
+    hint: "Max output tokens for wiki synthesis runs.",
+    defaultText: "16384",
+    format: (v) => (v != null ? String(v) : "16384 (default)"),
+    toEdit: (v) => (v != null ? String(v) : "16384"),
+    parse: (input) => {
+      const n = Number(input);
+      if (!Number.isFinite(n) || n <= 0) return undefined;
+      return Math.floor(n);
+    },
+  },
+  {
+    key: "trajectories",
+    label: "Trajectories",
+    type: "boolean",
+    hint: "Capture agent trajectories into the vault.",
+    format: (v) => (v ? "ON" : "OFF"),
+    toEdit: () => "",
+    parse: (input) => Boolean(Boolean(input) && /on|true|1/i.test(input)),
+  },
+  {
+    key: "notices",
+    label: "Notices",
+    type: "boolean",
+    hint: "Show wiki recall/observation notice lines in chat.",
+    format: (v) => (v != null ? (v ? "ON" : "OFF") : "ON (default)"),
+    toEdit: () => "",
+    parse: (input) => Boolean(Boolean(input) && /on|true|1/i.test(input)),
+  },
+  {
+    key: "ambientPersonalVault",
+    label: "Ambient Personal",
+    type: "boolean",
+    hint: "Include the personal vault in ambient session context.",
+    format: (v) => (v != null ? (v ? "ON" : "OFF") : "host-dependent"),
+    toEdit: () => "",
+    parse: (input) => Boolean(Boolean(input) && /on|true|1/i.test(input)),
+  },
+  {
+    key: "synthesisLanguage",
+    label: "Synthesis Language",
+    type: "string",
+    hint: "Language for synthesized wiki content.",
+    defaultText: "en",
+    format: (v) => (v ? String(v) : "en (default)"),
+    toEdit: (v) => (v ? String(v) : "en"),
+    parse: (input) => {
+      const trimmed = input.trim();
+      return trimmed || undefined;
+    },
+  },
+  {
+    key: "semanticWeight",
+    label: "Semantic Weight",
+    type: "number",
+    hint: "0–1 weight for embedding (semantic) recall.",
+    defaultText: "0.5",
+    format: (v) => (v != null ? String(v) : "0.5 (default)"),
+    toEdit: (v) => (v != null ? String(v) : "0.5"),
+    parse: (input) => {
+      const n = Number(input);
+      if (!Number.isFinite(n) || n < 0 || n > 1) return undefined;
+      return n;
+    },
+  },
+  {
+    key: "recallLinksThreshold",
+    label: "Recall Links",
+    type: "number",
+    hint: "Max recall links shown when the vault is large.",
+    defaultText: "50",
+    format: (v) => (v != null ? String(v) : "50 (default)"),
+    toEdit: (v) => (v != null ? String(v) : "50"),
+    parse: (input) => {
+      const n = Number(input);
+      if (!Number.isFinite(n) || n < 0) return undefined;
+      return Math.floor(n);
+    },
+  },
+  {
+    key: "recallSkillInlineMax",
+    label: "Skill Inline Max",
+    type: "number",
+    hint: "Max characters inlined from recall into skill prompts.",
+    defaultText: "1600",
+    format: (v) => (v != null ? String(v) : "1600 (default)"),
+    toEdit: (v) => (v != null ? String(v) : "1600"),
+    parse: (input) => {
+      const n = Number(input);
+      if (!Number.isFinite(n) || n < 0) return undefined;
+      return Math.floor(n);
+    },
+  },
+  {
+    key: "embeddingProvider",
+    label: "Embedding Provider",
+    type: "string",
+    hint: "Embedding provider (e.g. openai). Empty = embeddings disabled.",
+    format: (v) => (v ? String(v) : "(disabled)"),
+    toEdit: (v) => (v ? String(v) : ""),
+    parse: (input) => input.trim() || undefined,
+  },
+  {
+    key: "embeddingModel",
+    label: "Embedding Model",
+    type: "string",
+    hint: "Embedding model id.",
+    defaultText: "text-embedding-3-small",
+    format: (v) => (v ? String(v) : "text-embedding-3-small (default)"),
+    toEdit: (v) => (v ? String(v) : "text-embedding-3-small"),
+    parse: (input) => input.trim() || undefined,
+  },
+  {
+    key: "embeddingBaseUrl",
+    label: "Embedding Base URL",
+    type: "string",
+    hint: "Custom embeddings API base URL (optional).",
+    format: (v) => (v ? String(v) : "—"),
+    toEdit: (v) => (v ? String(v) : ""),
+    parse: (input) => input.trim() || undefined,
+  },
+  {
+    key: "embeddingApiKeyEnv",
+    label: "Embedding API Key Env",
+    type: "string",
+    hint: "Environment variable name holding the embeddings API key.",
+    defaultText: "OPENAI_API_KEY",
+    format: (v) => (v ? String(v) : "OPENAI_API_KEY (default)"),
+    toEdit: (v) => (v ? String(v) : "OPENAI_API_KEY"),
+    parse: (input) => input.trim() || undefined,
+  },
+];
+
+function isInsideHome(cwd: string): boolean {
+  return cwd.startsWith(homedir());
+}
+
+/**
+ * Map effective settings + sources to pi-tui SettingItems.
+ *
+ * Exported for tests. `notify` is used by edit menus to report invalid input
+ * without closing the menu.
+ */
+export function buildSettingItems(
+  sources: Record<string, { value: unknown; source: string }>,
+  notify: (message: string, type?: "error") => void,
+): SettingItem[] {
+  return SETTINGS.map((def) => {
+    const entry = sources[def.key];
+    const value = entry?.value;
+    const source = entry?.source ?? "default";
+
+    const item: SettingItem = {
+      id: def.key,
+      label: def.label,
+      currentValue: def.format(value),
+      description: describeSetting(def, source),
+    };
+
+    if (def.type === "boolean") {
+      item.values = ["OFF", "ON"];
+      return item;
+    }
+
+    item.submenu = (_display, done) => {
+      const sub = new InputSubmenu(def.menuLabel ?? `Set ${def.label}`, def.toEdit(value));
+      sub.input.onSubmit = (raw) => {
+        const trimmed = raw.trim();
+        if (def.type === "model") {
+          if (!trimmed) {
+            done(""); // clear → back to session model
+            return;
+          }
+          const ref = parseModelRef(trimmed);
+          if (!ref) {
+            notify(`LLM Wiki: could not parse "${trimmed}". Use provider/id.`, "error");
+            return; // stay in the menu
+          }
+          done(`${ref.provider}/${ref.id}`);
+          return;
+        }
+        if (!trimmed) {
+          done(); // empty = no change
+          return;
+        }
+        const parsed = def.parse(trimmed);
+        if (parsed === undefined) {
+          notify(`LLM Wiki: invalid value "${trimmed}" for ${def.label}`, "error");
+          return; // stay in the menu
+        }
+        done(String(parsed));
+      };
+      sub.input.onEscape = () => done();
+      return sub;
+    };
+    return item;
+  });
+}
+
+function describeSetting(def: SettingDef, source: string): string {
+  const where = source === "default" ? "Not set — using default." : `Set in ${source} settings.`;
+  return `${def.hint}\n${where}`;
+}
+
+/**
+ * Parse the display string a SettingItem cycled/edited into back into the
+ * typed value to persist.
+ */
+function parseDisplay(def: SettingDef, display: string): unknown {
+  if (def.type === "boolean") return display === "ON";
+  if (def.type === "model") return display ? parseModelRef(display) : undefined;
+  return def.parse(display);
+}
+
+function buildSettingsListTheme(theme: Theme): SettingsListTheme {
+  return {
+    label: (text, selected) => (selected ? theme.fg("accent", text) : text),
+    value: (text, selected) => (selected ? theme.fg("accent", text) : theme.fg("muted", text)),
+    description: (text) => theme.fg("dim", text),
+    cursor: theme.fg("accent", "→ "),
+    hint: (text) => theme.fg("dim", text),
+  };
+}
+
+/** Title + single-line input. SettingsList forwards all key input here. */
+class InputSubmenu extends Container {
+  readonly input: Input;
+
+  constructor(label: string, initialValue: string) {
+    super();
+    this.addChild(new Text(label, 0, 0));
+    this.input = new Input();
+    // Type the prefill instead of setValue(): setValue keeps the cursor at 0,
+    // which makes backspace no-op and typed input land before the prefill.
+    if (initialValue) this.input.handleInput(initialValue);
+    this.addChild(this.input);
+  }
+
+  handleInput(data: string): void {
+    this.input.handleInput(data);
+  }
+}
+
+/** Header + settings list. ui.custom gives this component focus. */
+class SettingsScreen extends Container {
+  private list: SettingsList;
+
+  constructor(title: string, list: SettingsList) {
+    super();
+    this.list = list;
+    this.addChild(new Text(title, 0, 0));
+    this.addChild(new Spacer(1));
+    this.addChild(list);
+  }
+
+  handleInput(data: string): void {
+    this.list.handleInput(data);
+  }
+}
+
+async function showSettingsTui(ui: Ui, cwd: string, scope: SettingScope): Promise<void> {
+  if (typeof ui.custom !== "function") {
+    ui.notify(
+      "LLM Wiki: this host does not support the settings screen. Edit settings.json directly.",
+      "warning",
+    );
+    return;
+  }
+
+  const scopeLabel = scope === "global" ? "Global" : "Project";
+  const items = buildSettingItems(loadTaskConfigSources(cwd), ui.notify.bind(ui));
+
+  let list: SettingsList | undefined;
+
+  await ui.custom((_tui, theme, _keybindings, close) => {
+    list = new SettingsList(
+      items,
+      SETTINGS.length,
+      buildSettingsListTheme(theme),
+      (id, display) => {
+        const def = SETTINGS.find((d) => d.key === id);
+        if (!def || !list) return;
+        const value = parseDisplay(def, display);
+        // Non-model, non-boolean values are validated before done(); undefined
+        // here is only expected for the model-clear case.
+        if (value === undefined && def.type !== "model") return;
+        try {
+          persistSetting(cwd, scope, def.key, value);
+        } catch (err) {
+          ui.notify(
+            `LLM Wiki: failed to save ${def.label}: ${err instanceof Error ? err.message : String(err)}`,
+            "error",
+          );
+          return;
+        }
+        // Normalize the displayed value in place (e.g. cleared model shows
+        // "(session model)"; "0.50" becomes "0.5").
+        list.updateValue(id, def.format(value));
+      },
+      () => close(),
+    );
+    return new SettingsScreen(`\u{1F9E0} LLM Wiki Settings — ${scopeLabel}  (Esc to close)`, list);
+  });
+}
+
+/**
+ * Register the /wiki-settings command.
+ */
+export function registerWikiSettingsCommand(pi: ExtensionAPI, runtime: Runtime): void {
+  pi.registerCommand("wiki-settings", {
+    description: "View and edit LLM Wiki settings (model, tokens, behaviors, embeddings)",
+    handler: async (_args: string, ctx: { cwd: string; hasUI: boolean; ui: Ui }) => {
+      runtime.ensureConfig(ctx.cwd);
+
+      if (!ctx.hasUI) {
+        ctx.ui.notify(
+          "LLM Wiki: /wiki-settings requires an interactive UI. Edit settings.json directly instead.",
+          "warning",
+        );
+        return;
+      }
+
+      let scope: SettingScope;
+      if (isInsideHome(ctx.cwd)) {
+        scope = "global";
+      } else {
+        const pick = await ctx.ui.select("LLM Wiki \u2014 Settings scope?", [
+          `Project (${ctx.cwd}/.pi/settings.json)`,
+          "Global (~/.pi/agent/settings.json)",
+        ]);
+        if (pick === undefined) return;
+        scope = pick.startsWith("Project") ? "project" : "global";
+      }
+
+      await showSettingsTui(ctx.ui, ctx.cwd, scope);
+    },
+  });
+}

--- a/extensions/llm-wiki/lib/task-config.ts
+++ b/extensions/llm-wiki/lib/task-config.ts
@@ -6,6 +6,7 @@ import {
   detectHost,
   listGlobalSettingsFiles,
   listProjectSettingsFiles,
+  resolveGlobalSettingsPath,
   resolveProjectSettingsPath,
 } from "./host.js";
 
@@ -139,6 +140,13 @@ export interface TaskConfig {
    * source content and technical identifiers remain unchanged.
    */
   synthesisLanguage?: string;
+
+  /**
+   * Max output tokens for the synthesizer sub-agent (issue #160). Default 16384.
+   * Reasoning models consume tokens on thinking, so 4096 is too low — the
+   * response truncates before commit_synthesis can be called.
+   */
+  synthesisMaxTokens?: number;
 }
 
 export const TASK_DEFAULTS: TaskConfig = {};
@@ -238,6 +246,11 @@ function readNamespacedConfig(path: string): Partial<TaskConfig> {
       if (canonical) out.synthesisLanguage = canonical;
     }
 
+    const maxTokens = section.synthesisMaxTokens;
+    if (typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0) {
+      out.synthesisMaxTokens = Math.floor(maxTokens);
+    }
+
     return out;
   } catch {
     return {};
@@ -302,6 +315,24 @@ function readSettingsObject(path: string): Record<string, unknown> {
     // Missing or corrupt settings file: start from an empty object.
   }
   return {};
+}
+
+/**
+ * Rewrite the `llm-wiki` section of the global settings file.
+ */
+function updateGlobalSection(mutate: (section: Record<string, unknown>) => void): void {
+  const settingsPath = resolveGlobalSettingsPath();
+  const raw = readSettingsObject(settingsPath);
+
+  const existing = raw[SETTINGS_KEY];
+  const section: Record<string, unknown> =
+    existing && typeof existing === "object" ? { ...(existing as Record<string, unknown>) } : {};
+
+  mutate(section);
+  raw[SETTINGS_KEY] = section;
+
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, `${JSON.stringify(raw, null, 2)}\n`, "utf-8");
 }
 
 /**
@@ -382,4 +413,75 @@ export function loadTaskConfig(cwd: string): TaskConfig {
     Object.assign(config, readNamespacedConfig(path));
   }
   return config;
+}
+
+// ── Settings source tracking (for /wiki-settings TUI) ──────────
+
+export type SettingScope = "default" | "global" | "project";
+
+/**
+ * Resolve where each setting is defined: project > global > default.
+ */
+/** All known setting keys — needed because TASK_DEFAULTS is {} (zero-config). */
+const KNOWN_KEYS = [
+  "taskModel",
+  "embeddingProvider",
+  "embeddingModel",
+  "embeddingBaseUrl",
+  "embeddingApiKey",
+  "embeddingApiKeyEnv",
+  "semanticWeight",
+  "recallLinksThreshold",
+  "recallSkillInlineMax",
+  "notices",
+  "ambientPersonalVault",
+  "trajectories",
+  "synthesisLanguage",
+  "synthesisMaxTokens",
+] as const;
+
+export function loadTaskConfigSources(
+  cwd: string,
+): Record<string, { value: unknown; source: SettingScope }> {
+  const globalResult: Record<string, unknown> = {};
+  for (const path of listGlobalSettingsFiles()) {
+    Object.assign(globalResult, readNamespacedConfig(path));
+  }
+  const projectResult: Record<string, unknown> = {};
+  for (const path of listProjectSettingsFiles(cwd)) {
+    Object.assign(projectResult, readNamespacedConfig(path));
+  }
+  const effective = loadTaskConfig(cwd);
+
+  const out: Record<string, { value: unknown; source: SettingScope }> = {};
+  for (const key of KNOWN_KEYS) {
+    if (key in projectResult) out[key] = { value: projectResult[key], source: "project" };
+    else if (key in globalResult) out[key] = { value: globalResult[key], source: "global" };
+    else out[key] = { value: (effective as Record<string, unknown>)[key], source: "default" };
+  }
+  return out;
+}
+
+/**
+ * Generic setting persist: writes any single setting to the chosen scope.
+ */
+export function persistSetting(
+  cwd: string,
+  scope: SettingScope,
+  key: string,
+  value: unknown,
+): void {
+  const mutate = (section: Record<string, unknown>) => {
+    if (value === undefined || value === null) {
+      delete section[key];
+    } else {
+      section[key] = value;
+    }
+  };
+
+  if (scope === "project") {
+    updateProjectSection(cwd, mutate);
+  } else if (scope === "global") {
+    updateGlobalSection(mutate);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   },
   "dependencies": {
     "@cfworker/json-schema": "^4.1.1",
+    "@mariozechner/pi-tui": "0.70.6",
     "@modelcontextprotocol/server": "^2.0.0",
     "mdast-util-from-markdown": "^2.0.3",
     "node-html-markdown": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@cfworker/json-schema':
         specifier: ^4.1.1
         version: 4.1.1
+      '@mariozechner/pi-tui':
+        specifier: 0.70.6
+        version: 0.70.6
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-wiki
-description: Build and maintain a persistent, interlinked Obsidian-compatible markdown wiki using Karpathy's LLM Wiki pattern. Extension-backed with auto-generated metadata, guardrails, and 13 custom tools (+3 opt-in agent-trajectory tools).
+description: Build and maintain a persistent, interlinked Obsidian-compatible markdown wiki using Karpathy's LLM Wiki pattern. Extension-backed with auto-generated metadata, guardrails, and 14 custom tools (+3 opt-in agent-trajectory tools).
 whenToUse: Call wiki_recall at task start to find relevant wiki pages. Call wiki_retro at task end to save new insights. When agent-trajectory working-memory is enabled (opt-in, /wiki-trajectories on), also call wiki_recall_skill at task start to find reusable skills / past cases ("have I done this before?") and wiki_capture_trajectory after non-trivial tasks to record how you solved them. The extension injects a brief status line, but explicit calls with task-specific terms get better results.
 ---
 
@@ -177,6 +177,14 @@ The choice is persisted to project settings (`.pi/settings.json` under `llm-wiki
 ```
 wiki_ingest(model="anthropic/claude-haiku")
 ```
+
+### Settings Screen (`/wiki-settings`)
+
+**Interactive settings:** run `/wiki-settings` to open a persistent settings screen. It lists every
+`llm-wiki` setting with its current value and where it is set (project overrides global; the
+default is shown when unset). Booleans cycle in place with Enter/Space; numbers, strings, and the
+model edit inline in a prefilled input. Every change persists immediately to the chosen scope
+(project or global). Setting the model to `session` clears `llm-wiki.taskModel` (back to the session model).
 
 ### Auto-Bootstrap (One-Time)
 

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -1,0 +1,450 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildSettingItems,
+  registerWikiSettingsCommand,
+} from "../extensions/llm-wiki/lib/settings-command.js";
+import {
+  loadTaskConfig,
+  loadTaskConfigSources,
+  persistSetting,
+} from "../extensions/llm-wiki/lib/task-config.js";
+
+/**
+ * /wiki-settings command tests.
+ *
+ * The settings screen is a persistent pi-tui SettingsList rendered through
+ * ui.custom(). Tests drive it the way the terminal would: raw key sequences
+ * through the screen's handleInput(), plus render() output for cursor position.
+ */
+
+interface NotifyCall {
+  message: string;
+  type: string;
+}
+
+type Handler = (args: string, ctx: Record<string, unknown>) => Promise<void>;
+
+function captureHandler(): Handler {
+  let handler: Handler | undefined;
+  const fakePi = {
+    registerCommand: (_name: string, descriptor: { handler: Handler }) => {
+      handler = descriptor.handler;
+    },
+  };
+  registerWikiSettingsCommand(fakePi as never, { ensureConfig: () => {} } as never);
+  if (!handler) throw new Error("handler was not registered");
+  return handler;
+}
+
+const fakeTheme = { fg: (_color: string, text: string) => text };
+
+interface Screen {
+  handleInput(data: string): void;
+  render(width: number): string[];
+}
+
+interface InputLike {
+  getValue(): string;
+}
+
+/**
+ * Fake ctx. `custom` runs the factory synchronously inside the promise
+ * executor, so the screen is available as soon as the handler awaits it.
+ */
+function makeCtx(opts: {
+  cwd: string;
+  hasUI?: boolean;
+  select?: (title: string, options: string[]) => Promise<string | undefined>;
+  custom?: (
+    factory: (tui: unknown, theme: unknown, kb: unknown, done: (r?: unknown) => void) => unknown,
+  ) => Promise<unknown>;
+}) {
+  const notifications: NotifyCall[] = [];
+  const screen: { current?: Screen } = {};
+  return {
+    cwd: opts.cwd,
+    hasUI: opts.hasUI ?? true,
+    ui: {
+      select: opts.select ?? (async (_title: string, options: string[]) => options[0]),
+      notify: (message: string, type: string) => {
+        notifications.push({ message, type });
+      },
+      custom:
+        opts.custom ??
+        ((
+          factory: (
+            tui: unknown,
+            theme: unknown,
+            kb: unknown,
+            done: (r?: unknown) => void,
+          ) => unknown,
+        ) =>
+          new Promise((resolve) => {
+            screen.current = factory(null, fakeTheme, null, resolve) as Screen;
+          })),
+    },
+    _notifications: notifications,
+    _screen: screen,
+  };
+}
+
+function notifs(ctx: Record<string, unknown>): NotifyCall[] {
+  return ctx._notifications as NotifyCall[];
+}
+
+/** Flush microtasks so the handler reaches the custom factory. */
+function tick() {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+/** Key events arrive one per call in a real terminal — match that. */
+function keys(screen: Screen, seq: string, n: number) {
+  for (let i = 0; i < n; i++) screen.handleInput(seq);
+}
+
+/** A cwd guaranteed outside $HOME (scope picker shown, project writes isolated). */
+function outsideHomeDir(tag: string) {
+  return mkdtempSync(join(tmpdir(), `wiki-settings-${tag}-`));
+}
+
+const DOWN = "\x1b[B";
+const ENTER = "\r";
+const ESC = "\x1b";
+const SPACE = " ";
+const BACKSPACE = "\b"; // pi's deleteCharBackward binding is \b, not \x7f
+
+const SETTINGS_LINE_OFFSET = 2; // header line + spacer before the first item
+
+describe("/wiki-settings screen", () => {
+  let handler: Handler;
+  const dirs: string[] = [];
+  let priorAgentDir: string | undefined;
+
+  beforeAll(() => {
+    handler = captureHandler();
+  });
+
+  beforeEach(() => {
+    const agentTmp = outsideHomeDir("agent");
+    dirs.push(agentTmp);
+    priorAgentDir = process.env.PI_CODING_AGENT_DIR;
+    // Redirect global settings writes into a temp agent dir.
+    process.env.PI_CODING_AGENT_DIR = join(agentTmp, "agent-home");
+  });
+
+  afterEach(() => {
+    // biome-ignore lint/performance/noDelete: must truly unset; assigning undefined sets the string "undefined" in Node
+    if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs.length = 0;
+  });
+
+  function project(tag: string) {
+    const tmp = outsideHomeDir(tag);
+    dirs.push(tmp);
+    return tmp;
+  }
+
+  it("shows warning when hasUI is false", async () => {
+    const tmp = project("no-ui");
+    const ctx = makeCtx({ cwd: tmp, hasUI: false });
+    await handler("", ctx);
+    expect(notifs(ctx).some((n) => n.type === "warning" && /interactive/.test(n.message))).toBe(
+      true,
+    );
+  });
+
+  it("toggles a boolean in place, persists to project scope, keeps cursor", async () => {
+    const tmp = project("toggle");
+    const ctx = makeCtx({
+      cwd: tmp,
+      select: async (_title, options) => options[0], // scope: Project
+    });
+    const pending = handler("", ctx);
+    await tick();
+    const screen = ctx._screen!.current!;
+
+    // Items: 1 Model, 2 Synthesis Tokens, 3 Trajectories — move to #3.
+    screen.handleInput(DOWN);
+    screen.handleInput(DOWN);
+    screen.handleInput(SPACE);
+
+    expect(loadTaskConfig(tmp).trajectories).toBe(true);
+
+    // No screen reset: cursor still on Trajectories (header+spacer + 2 items).
+    const lines = screen.render(80);
+    expect(lines[SETTINGS_LINE_OFFSET + 2]).toContain("Trajectories");
+    expect(lines[SETTINGS_LINE_OFFSET + 2]).toContain("→");
+
+    // Toggle back off.
+    screen.handleInput(SPACE);
+    expect(loadTaskConfig(tmp).trajectories).toBe(false);
+
+    // Esc closes the screen.
+    screen.handleInput(ESC);
+    await pending;
+    expect(existsSync(join(tmp, ".pi", "settings.json"))).toBe(true);
+  });
+
+  it("edits a number through the submenu (global scope) and restores the cursor", async () => {
+    const tmp = project("number");
+    const ctx = makeCtx({
+      cwd: tmp,
+      select: async (_title, options) => options[1], // scope: Global
+    });
+    const pending = handler("", ctx);
+    await tick();
+    const screen = ctx._screen!.current!;
+
+    // Item 2 = Synthesis Tokens. Enter opens its input submenu (raw prefill).
+    screen.handleInput(DOWN);
+    screen.handleInput(ENTER);
+    keys(screen, BACKSPACE, 16);
+    screen.handleInput("999999");
+    screen.handleInput(ENTER);
+
+    // Written to the (redirected) global settings, not the project file.
+    expect(loadTaskConfig(tmp).synthesisMaxTokens).toBe(999999);
+    const projectJson = existsSync(join(tmp, ".pi", "settings.json"))
+      ? (JSON.parse(readFileSync(join(tmp, ".pi", "settings.json"), "utf8")) as Record<
+          string,
+          Record<string, unknown>
+        >)
+      : {};
+    expect(projectJson["llm-wiki"]?.synthesisMaxTokens).toBeUndefined();
+
+    // Cursor restored to Synthesis Tokens.
+    const lines = screen.render(80);
+    expect(lines[SETTINGS_LINE_OFFSET + 1]).toContain("Synthesis Tokens");
+    expect(lines[SETTINGS_LINE_OFFSET + 1]).toContain("→");
+
+    screen.handleInput(ESC);
+    await pending;
+  });
+
+  it("rejects an invalid number, stays in the submenu, then escs out", async () => {
+    const tmp = project("invalid");
+    const ctx = makeCtx({
+      cwd: tmp,
+      select: async (_title, options) => options[0], // scope: Project
+    });
+    const pending = handler("", ctx);
+    await tick();
+    const screen = ctx._screen!.current!;
+
+    screen.handleInput(DOWN);
+    screen.handleInput(ENTER);
+    keys(screen, BACKSPACE, 16);
+    screen.handleInput("abc");
+    screen.handleInput(ENTER);
+
+    expect(notifs(ctx).some((n) => n.type === "error" && /invalid/i.test(n.message))).toBe(true);
+    // Still editing: the input line holds "abc", the list is not shown.
+    expect(screen.render(80).join("\n")).toContain("abc");
+
+    // Esc closes the submenu (list back), Esc closes the screen.
+    screen.handleInput(ESC);
+    expect(screen.render(80)[0]).toContain("LLM Wiki Settings");
+    screen.handleInput(ESC);
+    await pending;
+    expect(loadTaskConfig(tmp).synthesisMaxTokens).toBeUndefined();
+  });
+
+  it("sets and clears the model through the submenu", async () => {
+    const tmp = project("model");
+    const ctx = makeCtx({
+      cwd: tmp,
+      select: async (_title, options) => options[0], // scope: Project
+    });
+    const pending = handler("", ctx);
+    await tick();
+    const screen = ctx._screen!.current!;
+
+    // Item 1 = Model (cursor starts there), empty prefill. Enter + type.
+    screen.handleInput(ENTER);
+    screen.handleInput("openai/gpt-4o");
+    screen.handleInput(ENTER);
+    expect(loadTaskConfig(tmp).taskModel).toEqual({ provider: "openai", id: "gpt-4o" });
+
+    let lines = screen.render(80);
+    expect(lines[SETTINGS_LINE_OFFSET]).toContain("Model");
+    expect(lines[SETTINGS_LINE_OFFSET]).toContain("openai/gpt-4o");
+    expect(lines[SETTINGS_LINE_OFFSET]).toContain("→");
+
+    // Reopen, clear the prefill, empty submit → clears to session model.
+    screen.handleInput(ENTER);
+    keys(screen, BACKSPACE, 32);
+    screen.handleInput(ENTER);
+    expect(loadTaskConfig(tmp).taskModel).toBeUndefined();
+    lines = screen.render(80);
+    expect(lines[SETTINGS_LINE_OFFSET]).toContain("(session model)");
+
+    screen.handleInput(ESC);
+    await pending;
+  });
+
+  it("asks for scope first when cwd is outside home", async () => {
+    const tmp = project("scope");
+    let selectCalls = 0;
+    const ctx = makeCtx({
+      cwd: tmp,
+      select: async (_title, options) => {
+        selectCalls++;
+        if (selectCalls === 1) return options[0]; // scope picker → Project
+        return undefined;
+      },
+      custom: () => new Promise(() => {}), // test ends before the screen is driven
+    });
+    const pending = handler("", ctx);
+    await tick();
+    expect(selectCalls).toBe(1);
+    void pending; // screen intentionally left open
+  });
+});
+
+// ── buildSettingItems (pure) ─────────────────────────────
+
+describe("buildSettingItems", () => {
+  let tmpDir: string;
+  let priorAgentDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = join(
+      import.meta.dirname,
+      "..",
+      "tmp",
+      `ws-items-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    priorAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(tmpDir, "agent-home");
+  });
+
+  afterEach(() => {
+    // biome-ignore lint/performance/noDelete: must truly unset; assigning undefined sets the string "undefined" in Node
+    if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function fixture() {
+    persistSetting(tmpDir, "project", "notices", false);
+    persistSetting(tmpDir, "project", "synthesisMaxTokens", 32768);
+    persistSetting(tmpDir, "project", "taskModel", { provider: "anthropic", id: "claude-haiku" });
+    return loadTaskConfigSources(tmpDir);
+  }
+
+  it("booleans get OFF/ON cycle values and no submenu", () => {
+    const items = buildSettingItems(fixture(), () => {});
+    const traj = items.find((i) => i.id === "trajectories")!;
+    expect(traj.values).toEqual(["OFF", "ON"]);
+    expect(traj.submenu).toBeUndefined();
+    expect(traj.currentValue).toBe("OFF"); // default off
+  });
+
+  it("reflects overridden values and source", () => {
+    const items = buildSettingItems(fixture(), () => {});
+    const notices = items.find((i) => i.id === "notices")!;
+    expect(notices.currentValue).toBe("OFF");
+    expect(notices.description).toContain("project");
+    const maxTok = items.find((i) => i.id === "synthesisMaxTokens")!;
+    expect(maxTok.currentValue).toBe("32768");
+    expect(maxTok.description).toContain("project");
+  });
+
+  it("marks unset settings as default", () => {
+    const items = buildSettingItems(fixture(), () => {});
+    const lang = items.find((i) => i.id === "synthesisLanguage")!;
+    expect(lang.description).toMatch(/default/i);
+  });
+
+  it("non-boolean items expose a submenu with a raw-value input prefill", () => {
+    const items = buildSettingItems(fixture(), () => {});
+    for (const id of [
+      "taskModel",
+      "synthesisMaxTokens",
+      "synthesisLanguage",
+      "embeddingProvider",
+    ]) {
+      const item = items.find((i) => i.id === id)!;
+      expect(item.submenu, id).toBeTypeOf("function");
+      const sub = item.submenu!("unused", () => {}) as unknown as {
+        children: { getValue?: () => string }[];
+      };
+      const input = sub.children.find((c) => typeof c.getValue === "function");
+      expect(input, `${id}: input child exists`).toBeDefined();
+    }
+    const maxTok = items.find((i) => i.id === "synthesisMaxTokens")!;
+    const input = (
+      maxTok.submenu!("unused", () => {}) as unknown as {
+        children: InputLike[];
+      }
+    ).children.find((c) => typeof (c as { getValue?: unknown }).getValue === "function") as
+      | InputLike
+      | undefined;
+    expect(input?.getValue()).toBe("32768");
+  });
+});
+
+// ── Pure config tests (no TUI) ──────────────────
+
+describe("persistSetting + loadTaskConfigSources", () => {
+  let tmpDir: string;
+  let priorAgentDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = join(
+      import.meta.dirname,
+      "..",
+      "tmp",
+      `ws-cfg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    priorAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(tmpDir, "agent-home");
+  });
+
+  afterEach(() => {
+    // biome-ignore lint/performance/noDelete: must truly unset; assigning undefined sets the string "undefined" in Node
+    if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loadTaskConfigSources reports source correctly", () => {
+    // Set at project level
+    persistSetting(tmpDir, "project", "notices", false);
+    const sources = loadTaskConfigSources(tmpDir);
+    expect(sources.notices).toEqual({ value: false, source: "project" });
+  });
+
+  it("project wins over global in source tracking", () => {
+    // Set at global level
+    const agentDir = join(tmpDir, "agent-home");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, "settings.json"),
+      JSON.stringify({ "llm-wiki": { notices: false } }),
+    );
+    // Override at project level
+    persistSetting(tmpDir, "project", "notices", true);
+    const sources = loadTaskConfigSources(tmpDir);
+    expect(sources.notices).toEqual({ value: true, source: "project" });
+  });
+
+  it("unset settings show source as 'default' with undefined value", () => {
+    const sources = loadTaskConfigSources(tmpDir);
+    expect(sources.semanticWeight).toEqual({ value: undefined, source: "default" });
+  });
+
+  it("persistSetting boolean toggle round-trips", () => {
+    persistSetting(tmpDir, "project", "trajectories", true);
+    expect(loadTaskConfig(tmpDir).trajectories).toBe(true);
+    persistSetting(tmpDir, "project", "trajectories", undefined);
+    expect(loadTaskConfig(tmpDir).trajectories).toBeUndefined();
+  });
+});

--- a/test/synthesis-max-tokens.test.ts
+++ b/test/synthesis-max-tokens.test.ts
@@ -1,0 +1,139 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadTaskConfig, persistSetting } from "../extensions/llm-wiki/lib/task-config.js";
+
+describe("synthesisMaxTokens config (issue #160)", () => {
+  let tmpDir: string;
+  let priorAgentDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = join(
+      import.meta.dirname,
+      "..",
+      "tmp",
+      `smt-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    priorAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(tmpDir, "agent-home");
+  });
+
+  afterEach(() => {
+    // biome-ignore lint/performance/noDelete: must truly unset; assigning undefined sets the string "undefined" in Node
+    if (priorAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = priorAgentDir;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loadTaskConfig returns undefined when not set (caller uses default)", () => {
+    const cfg = loadTaskConfig(tmpDir);
+    expect(cfg.synthesisMaxTokens).toBeUndefined();
+  });
+
+  it("reads synthesisMaxTokens from project settings", () => {
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { synthesisMaxTokens: 32768 } }),
+    );
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBe(32768);
+  });
+
+  it("reads synthesisMaxTokens from global settings", () => {
+    const agentDir = join(tmpDir, "agent-home");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, "settings.json"),
+      JSON.stringify({ "llm-wiki": { synthesisMaxTokens: 8192 } }),
+    );
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBe(8192);
+  });
+
+  it("project wins over global", () => {
+    const agentDir = join(tmpDir, "agent-home");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, "settings.json"),
+      JSON.stringify({ "llm-wiki": { synthesisMaxTokens: 8192 } }),
+    );
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { synthesisMaxTokens: 32768 } }),
+    );
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBe(32768);
+  });
+
+  it("rejects non-number values", () => {
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { synthesisMaxTokens: "big" } }),
+    );
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBeUndefined();
+  });
+
+  it("rejects negative values", () => {
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { synthesisMaxTokens: -100 } }),
+    );
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBeUndefined();
+  });
+
+  it("clamps to integer", () => {
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { synthesisMaxTokens: 16384.7 } }),
+    );
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBe(16384);
+  });
+
+  it("persistSetting writes to project scope", () => {
+    persistSetting(tmpDir, "project", "synthesisMaxTokens", 32768);
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBe(32768);
+  });
+
+  it("persistSetting writes to global scope", () => {
+    persistSetting(tmpDir, "global", "synthesisMaxTokens", 8192);
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBe(8192);
+  });
+
+  it("persistSetting with undefined removes the key", () => {
+    persistSetting(tmpDir, "project", "synthesisMaxTokens", 32768);
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBe(32768);
+    persistSetting(tmpDir, "project", "synthesisMaxTokens", undefined);
+    expect(loadTaskConfig(tmpDir).synthesisMaxTokens).toBeUndefined();
+  });
+
+  it("persistSetting preserves other llm-wiki keys", () => {
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ "llm-wiki": { notices: false, semanticWeight: 0.7 } }),
+    );
+    persistSetting(tmpDir, "project", "synthesisMaxTokens", 16384);
+    const cfg = loadTaskConfig(tmpDir);
+    expect(cfg.synthesisMaxTokens).toBe(16384);
+    expect(cfg.notices).toBe(false);
+    expect(cfg.semanticWeight).toBe(0.7);
+  });
+
+  it("persistSetting preserves non-wiki top-level keys", () => {
+    mkdirSync(join(tmpDir, ".pi"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".pi", "settings.json"),
+      JSON.stringify({ theme: "dark", "llm-wiki": { notices: true } }),
+    );
+    persistSetting(tmpDir, "project", "synthesisMaxTokens", 16384);
+    const raw = JSON.parse(
+      require("node:fs").readFileSync(join(tmpDir, ".pi", "settings.json"), "utf-8"),
+    );
+    expect(raw.theme).toBe("dark");
+    expect(raw["llm-wiki"].synthesisMaxTokens).toBe(16384);
+    expect(raw["llm-wiki"].notices).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #160 (synthesizer truncating at 4096 tokens) and ships the persistent `/wiki-settings` screen.

## Changes

### Fix — synthesis maxTokens (#160)
- Synthesizer sub-agent default raised 4096 → **16384**. With reasoning models, 4096 is consumed by thinking and synthesis truncates (`stop_reason: length`) before `commit_synthesis` runs.
- New setting `llm-wiki.synthesisMaxTokens` (vaults can override; stored as a plain number).

### Feature — `/wiki-settings` TUI
- Replaces a fresh `ui.select` re-opened after every change with **one persistent `SettingsList`** (the same component pi's own `/settings` uses), rendered via `ui.custom()`.
- Booleans (trajectories, notices, ambientPersonalVault) **cycle in place** with Enter/Space — no screen refresh, cursor stays.
- Number/string/model values edit in an inline prefilled input; on close the cursor **restores to the same item**.
- Every change persists immediately to the chosen scope (project `.pi/settings.json` or global agent settings).
- Fixed `Input.setValue` cursor-at-start bug along the way (backspace on prefill silently no-opped).
- Model edits now honor the chosen scope (previously always project).

### Docs — synced to code ground truth
14 always-registered tools (+3 opt-in trajectory), 15 slash commands, 13 `llm-wiki.*` settings:
- README.md + 9 localized READMEs (de/es/fr/hi/ja/ko/pt/ru/zh): +2 tool rows, +2 slash rows each
- docs/commands.md, docs/configuration.md (5 → 13 settings rows), docs/api.md (+wiki_reindex_embeddings section), SKILL.md, AGENTS.md

## Testing
- 14 new interaction tests drive the real component with raw key sequences (`↓`, Enter, Space, Esc, backspace) and assert cursor position from render output; plus synthesis-max-tokens coverage.
- Full suite: 659/662 pass; the 2 non-flaky failures reproduce identically on clean main (pre-existing, verified via stash).
- typecheck + lint clean. Runtime verified against live pi 0.84.1 host (pi-tui import aliases to the host-bundled version; contract diffed clean).