### PR TITLE
fix: extract targets from apply_patch envelopes in the edit guardrail

### DIFF
--- a/extensions/llm-wiki/lib/guardrails.ts
+++ b/extensions/llm-wiki/lib/guardrails.ts
@@ -79,12 +79,34 @@ function parseMoveDestination(line: string): string | undefined {
 function scanPatchString(input: string): MutationScan {
   const paths: string[] = [];
   let sawHeader = false;
+  let sawApplyPatchHeader = false;
+  let applyPatchComplete = true;
   let sectionHasMove = false;
   let complete = true;
   const stripped = input.startsWith("\uFEFF") ? input.slice(1) : input;
 
   for (const line of stripped.split("\n")) {
-    const trimmed = line.replace(/\r$/, "").trim();
+    const raw = line.replace(/\r$/, "");
+    // apply_patch envelope headers (#162): matched on the raw (untrimmed)
+    // line so body rows (space/+/- prefixed) that quote the envelope shape
+    // are never mistaken for headers.
+    const fileOp = /^\*{3}\s+(?:update|add|delete)\s+file:\s*(\S.*)$/i.exec(raw);
+    if (fileOp) {
+      sawApplyPatchHeader = true;
+      const path = normalizeMutationPath(fileOp[1]);
+      if (path) paths.push(path);
+      else applyPatchComplete = false;
+      continue;
+    }
+    const moveTo = /^\*{3}\s+move\s+to:\s*(\S.*)$/i.exec(raw);
+    if (moveTo) {
+      sawApplyPatchHeader = true;
+      const destination = normalizeMutationPath(moveTo[1]);
+      if (destination) paths.push(destination);
+      else applyPatchComplete = false;
+      continue;
+    }
+    const trimmed = raw.trim();
     if (trimmed.startsWith("[")) {
       sawHeader = true;
       sectionHasMove = false;
@@ -102,6 +124,9 @@ function scanPatchString(input: string): MutationScan {
     }
   }
 
+  if (sawApplyPatchHeader) {
+    return { paths, complete: applyPatchComplete && paths.length > 0 };
+  }
   return { paths, complete: sawHeader && complete };
 }
 

--- a/test/apply-patch-guardrail.test.ts
+++ b/test/apply-patch-guardrail.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { extractMutationPaths, hasWikiMutation } from "../extensions/llm-wiki/lib/guardrails.js";
+
+// Regression coverage for #162: apply_patch-mode edit inputs
+// ("*** Begin Patch / *** Update File: path / *** End Patch" envelopes)
+// must have their targets extracted instead of being blocked with
+// "Cannot determine the files targeted by this edit."
+
+describe("extractMutationPaths — apply_patch envelopes", () => {
+  it("extracts Update File targets", () => {
+    const input =
+      "*** Begin Patch\n" +
+      "*** Update File: src/loader.lisp\n" +
+      "@@\n" +
+      " context line\n" +
+      "+added line\n" +
+      " context line\n" +
+      "*** End Patch";
+    expect(extractMutationPaths(input)).toEqual(["src/loader.lisp"]);
+  });
+
+  it("extracts targets from multi-file patches (update/add/delete/move)", () => {
+    const input =
+      "*** Begin Patch\n" +
+      "*** Update File: a.ts\n" +
+      "@@\n" +
+      " x\n" +
+      "+y\n" +
+      "*** Add File: b.ts\n" +
+      "+new\n" +
+      "*** Delete File: c.ts\n" +
+      "*** Move to: a/rename.ts\n" +
+      "*** End Patch";
+    expect(extractMutationPaths(input)).toEqual(["a.ts", "b.ts", "c.ts", "a/rename.ts"]);
+  });
+
+  it("handles CRLF envelope lines", () => {
+    const input =
+      "*** Begin Patch\r\n" +
+      "*** Update File: src/loader.lisp\r\n" +
+      "@@\r\n" +
+      " x\r\n" +
+      "+y\r\n" +
+      "*** End Patch\r\n";
+    expect(extractMutationPaths(input)).toEqual(["src/loader.lisp"]);
+  });
+
+  it("does not treat body rows quoting the envelope as headers", () => {
+    // The body row below quotes the envelope shape but is prefixed with
+    // the diff marker "+", so it must not yield a phantom target.
+    const input =
+      "*** Begin Patch\n" +
+      "*** Update File: real-file.ts\n" +
+      "@@\n" +
+      "+*** Update File: phantom-file.ts\n" +
+      " context\n" +
+      "*** End Patch";
+    expect(extractMutationPaths(input)).toEqual(["real-file.ts"]);
+  });
+
+  it("keeps absolute paths absolute", () => {
+    const input = "*** Update File: /home/dev/proj/src/loader.lisp\n@@\n x\n+ y";
+    expect(extractMutationPaths(input)).toEqual(["/home/dev/proj/src/loader.lisp"]);
+  });
+
+  it("still parses hashline-format patch strings", () => {
+    const input = "[src/loader.lisp#AB12]\n- old line\n+ new line";
+    expect(extractMutationPaths(input)).toEqual(["src/loader.lisp"]);
+  });
+
+  it("still parses { path, old_string, new_string } objects", () => {
+    expect(
+      extractMutationPaths({
+        path: "src/loader.lisp",
+        old_string: "(defun foo ())",
+        new_string: "(defun foo () :ok)",
+      }),
+    ).toEqual(["src/loader.lisp"]);
+  });
+
+  it("returns no paths for an envelope with an empty target (fail closed)", () => {
+    const input = "*** Begin Patch\n*** Update File:\n@@\n x\n+ y\n*** End Patch";
+    expect(extractMutationPaths(input)).toEqual([]);
+  });
+});
+
+describe("hasWikiMutation — apply_patch envelopes", () => {
+  it("sees vault edits through the envelope", () => {
+    const wikiPath = "/tmp/vault/.llm-wiki/wiki";
+    const input =
+      "*** Begin Patch\n" +
+      "*** Update File: /tmp/vault/.llm-wiki/wiki/pages/foo.md\n" +
+      "@@\n" +
+      " x\n" +
+      "+y\n" +
+      "*** End Patch";
+    expect(hasWikiMutation(input, wikiPath)).toBe(true);
+    expect(hasWikiMutation("*** Update File: src/other.ts\n@@\n x\n+ y", wikiPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Fixes #162. The `edit` guardrail's `scanPatchString` only recognized
**hashline-format** patches (`[` header lines + `MV` rows). Edit calls
carrying an **apply_patch envelope** (`*** Begin Patch` /
`*** Update File: path` / `*** End Patch` — oh-my-pi
`edit.mode: apply_patch`) matched neither, so the scanner returned
`complete: false` and the guardrail blocked **every** such edit with
"Cannot determine the files targeted by this edit."

## Change

`extensions/llm-wiki/lib/guardrails.ts` — `scanPatchString` now
recognizes `*** Update/Add/Delete File: <path>` and
`*** Move To: <path>` headers, matched on the **raw (untrimmed)**
line so diff body rows that quote the envelope shape (space/`+`/`-`
prefixed) are never misread as headers. Envelope-only inputs use a
separate completeness flag; mixed inputs keep the hashline result.
An envelope with an unparseable target still fails closed (block).

## Tests

New `test/apply-patch-guardrail.test.ts` (9 tests): single and
multi-file envelopes, all four operation types, CRLF, body-quoted
envelope not misread, absolute paths preserved, hashline and
`{ path, old_string, new_string }` inputs unchanged, empty target
fails closed, vault detection through envelopes.

## Verification

- `pnpm typecheck`, `biome check` — clean
- Guardrail suites (`guardrails`, `mutation-guards`, `e2e-guardrails`) — 41/41
- Full suite: 668/671. The 3 failures all pre-exist on clean `main`
  (2 deterministic-env failures + 1 order-dependent mcp-parity flake
  that passes in isolation; stash-verified last session).