### PR TITLE
host corners (part 1 of #149) + hermetic test global settings

### DIFF
--- a/extensions/llm-wiki/lib/host.ts
+++ b/extensions/llm-wiki/lib/host.ts
@@ -63,7 +63,7 @@ export function detectHost(): HostKind {
     if (segments.includes(".pi")) return "pi";
   }
 
-  if (process.env.OMP_PROFILE !== undefined) return "omp";
+  if (process.env.OMP_PROFILE) return "omp";
   return "pi";
 }
 

--- a/test/setup-env.ts
+++ b/test/setup-env.ts
@@ -1,0 +1,21 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeAll } from "vitest";
+
+/**
+ * Hermeticity guard for the global settings layer.
+ *
+ * `loadTaskConfig` (and friends) resolve the user-level layer through
+ * `getAgentDir()`, which honours `PI_CODING_AGENT_DIR`. Test files that
+ * manage their own agent directory (host-compat, runtime, model-selection,
+ * settings-command, synthesis-max-tokens) overwrite this per-test; running
+ * their save/afterAll before this hook keeps that cycle intact. Files that
+ * do not manage it (e.g. visible-activity, ambient-gate) would otherwise
+ * read the DEVELOPER'S real `~/.pi/agent` or `~/.omp/agent` settings, whose
+ * `llm-wiki` section (written legitimately by /wiki-settings) leaks plain
+ * values into assertions. CI never trips this because runner HOME is empty;
+ * this makes local runs behave the same.
+ */
+beforeAll(() => {
+  process.env.PI_CODING_AGENT_DIR = join(tmpdir(), "llm-wiki-test-agent-home");
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    setupFiles: ["./test/setup-env.ts"],
     globals: true,
     include: ["test/**/*.test.ts"],
     environment: "node",


### PR DESCRIPTION
Part 1 of #149 (notes 2-4 deferred, see below).

**Host:** detectHost() tier 3 now uses truthiness for OMP_PROFILE. A set-but-empty OMP_PROFILE env var previously passed the \!== undefined check and misclassified the host as omp.

**Test hermeticity (latent red, exposed by the leak itself):** the global settings layer resolves through getAgentDir(), which honours PI_CODING_AGENT_DIR. Test files that don't manage that env (visible-activity, ambient-gate) were reading the developer's real agent-dir settings. The moment /wiki-settings legitimately wrote an llm-wiki section there, two asserts turned red locally while CI stayed green (fresh runner HOME). A new test/setup-env.ts setupFile points PI_CODING_AGENT_DIR at a throwaway tmp dir for every test file; the five files that already save/restore per test are unaffected (their beforeEach runs after it).

Deferred #149 notes: (2) path-anchored marker sniff — corner-class, LLM_WIKI_HOST escape hatch overrides first anyway; (3) config.yaml outranking config.yml — speculative entry, no known producer; (4) write-to-foreign-dir — already documented in resolveProjectSettingsPath's docstring.

Local: tsc + biome + full suite 51 files / 671 tests green.