### PR TITLE
settings: editable Scope row in /wiki-settings + trajectories reload note

### DIFF
--- a/extensions/llm-wiki/lib/settings-command.ts
+++ b/extensions/llm-wiki/lib/settings-command.ts
@@ -12,9 +12,11 @@ import {
 import type { Runtime } from "./runtime.js";
 import {
   type SettingScope,
+  loadTaskConfig,
   loadTaskConfigSources,
   parseModelRef,
   persistSetting,
+  trajectoriesEnabled,
 } from "./task-config.js";
 
 /**
@@ -335,11 +337,13 @@ class InputSubmenu extends Container {
 /** Header + settings list. ui.custom gives this component focus. */
 class SettingsScreen extends Container {
   private list: SettingsList;
+  private titleText: Text;
 
   constructor(title: string, list: SettingsList) {
     super();
     this.list = list;
-    this.addChild(new Text(title, 0, 0));
+    this.titleText = new Text(title, 0, 0);
+    this.addChild(this.titleText);
     this.addChild(new Spacer(1));
     this.addChild(list);
   }
@@ -347,6 +351,16 @@ class SettingsScreen extends Container {
   handleInput(data: string): void {
     this.list.handleInput(data);
   }
+
+  /** Update the header line in place (scope changes re-target it live). */
+  setTitle(title: string): void {
+    this.titleText.setText(title);
+  }
+}
+
+/** Build the header title for the scope currently being written to. */
+function scopeTitle(scope: SettingScope): string {
+  return `\u{1F9E0} LLM Wiki Settings \u2014 ${scope === "global" ? "Global" : "Project"} (Esc to close)`;
 }
 
 async function showSettingsTui(ui: Ui, cwd: string, scope: SettingScope): Promise<void> {
@@ -358,25 +372,53 @@ async function showSettingsTui(ui: Ui, cwd: string, scope: SettingScope): Promis
     return;
   }
 
-  const scopeLabel = scope === "global" ? "Global" : "Project";
-  const items = buildSettingItems(loadTaskConfigSources(cwd), ui.notify.bind(ui));
+  // The editable Scope row re-targets where subsequent writes land; the
+  // picker / inside-home heuristic only chooses the starting value.
+  let writeScope = scope;
+  const scopeItem: SettingItem = {
+    id: "scope",
+    label: "Scope",
+    currentValue: writeScope === "global" ? "Global" : "Project",
+    values: ["Global", "Project"],
+    description:
+      "Where edits are written. Global \u2192 ~/.pi/agent/settings.json \u00b7 Project \u2192 .pi/settings.json (this folder).",
+  };
+  const items = [scopeItem, ...buildSettingItems(loadTaskConfigSources(cwd), ui.notify.bind(ui))];
+  // Tracks the effective value so the reload note fires on actual changes.
+  let prevTrajectories = trajectoriesEnabled(loadTaskConfig(cwd));
 
   let list: SettingsList | undefined;
+  let screenRef: SettingsScreen | undefined;
 
   await ui.custom((_tui, theme, _keybindings, close) => {
     list = new SettingsList(
       items,
-      SETTINGS.length,
+      items.length,
       buildSettingsListTheme(theme),
       (id, display) => {
+        if (!list) return;
+        // Scope row: re-target writes; nothing is persisted for it.
+        if (id === "scope") {
+          writeScope = display === "Global" ? "global" : "project";
+          list.updateValue("scope", display);
+          screenRef?.setTitle(scopeTitle(writeScope));
+          ui.notify(
+            `LLM Wiki: writing to ${
+              writeScope === "global"
+                ? "Global (~/.pi/agent/settings.json)"
+                : "Project (.pi/settings.json)"
+            }`,
+          );
+          return;
+        }
         const def = SETTINGS.find((d) => d.key === id);
-        if (!def || !list) return;
+        if (!def) return;
         const value = parseDisplay(def, display);
         // Non-model, non-boolean values are validated before done(); undefined
         // here is only expected for the model-clear case.
         if (value === undefined && def.type !== "model") return;
         try {
-          persistSetting(cwd, scope, def.key, value);
+          persistSetting(cwd, writeScope, def.key, value);
         } catch (err) {
           ui.notify(
             `LLM Wiki: failed to save ${def.label}: ${err instanceof Error ? err.message : String(err)}`,
@@ -387,10 +429,22 @@ async function showSettingsTui(ui: Ui, cwd: string, scope: SettingScope): Promis
         // Normalize the displayed value in place (e.g. cleared model shows
         // "(session model)"; "0.50" becomes "0.5").
         list.updateValue(id, def.format(value));
+        // trajectories gates tool registration at startup, so a live toggle
+        // cannot add/remove the 3 tools mid-session \u2014 say so on real changes.
+        if (def.key === "trajectories") {
+          const next = Boolean(value);
+          if (next !== prevTrajectories) {
+            prevTrajectories = next;
+            ui.notify(
+              "LLM Wiki: trajectory tools register at startup \u2014 new value applies after a reload",
+            );
+          }
+        }
       },
       () => close(),
     );
-    return new SettingsScreen(`\u{1F9E0} LLM Wiki Settings — ${scopeLabel}  (Esc to close)`, list);
+    screenRef = new SettingsScreen(scopeTitle(writeScope), list);
+    return screenRef;
   });
 }
 

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -168,17 +168,18 @@ describe("/wiki-settings screen", () => {
     await tick();
     const screen = ctx._screen!.current!;
 
-    // Items: 1 Model, 2 Synthesis Tokens, 3 Trajectories — move to #3.
+    // Items: 0 Scope, 1 Model, 2 Synthesis Tokens, 3 Trajectories — move to #3.
+    screen.handleInput(DOWN);
     screen.handleInput(DOWN);
     screen.handleInput(DOWN);
     screen.handleInput(SPACE);
 
     expect(loadTaskConfig(tmp).trajectories).toBe(true);
 
-    // No screen reset: cursor still on Trajectories (header+spacer + 2 items).
+    // No screen reset: cursor still on Trajectories (header+spacer + 3 items).
     const lines = screen.render(80);
-    expect(lines[SETTINGS_LINE_OFFSET + 2]).toContain("Trajectories");
-    expect(lines[SETTINGS_LINE_OFFSET + 2]).toContain("→");
+    expect(lines[SETTINGS_LINE_OFFSET + 3]).toContain("Trajectories");
+    expect(lines[SETTINGS_LINE_OFFSET + 3]).toContain("→");
 
     // Toggle back off.
     screen.handleInput(SPACE);
@@ -202,6 +203,7 @@ describe("/wiki-settings screen", () => {
 
     // Item 2 = Synthesis Tokens. Enter opens its input submenu (raw prefill).
     screen.handleInput(DOWN);
+    screen.handleInput(DOWN);
     screen.handleInput(ENTER);
     keys(screen, BACKSPACE, 16);
     screen.handleInput("999999");
@@ -217,10 +219,10 @@ describe("/wiki-settings screen", () => {
       : {};
     expect(projectJson["llm-wiki"]?.synthesisMaxTokens).toBeUndefined();
 
-    // Cursor restored to Synthesis Tokens.
+    // Cursor restored to Synthesis Tokens (item row 2).
     const lines = screen.render(80);
-    expect(lines[SETTINGS_LINE_OFFSET + 1]).toContain("Synthesis Tokens");
-    expect(lines[SETTINGS_LINE_OFFSET + 1]).toContain("→");
+    expect(lines[SETTINGS_LINE_OFFSET + 2]).toContain("Synthesis Tokens");
+    expect(lines[SETTINGS_LINE_OFFSET + 2]).toContain("→");
 
     screen.handleInput(ESC);
     await pending;
@@ -236,6 +238,7 @@ describe("/wiki-settings screen", () => {
     await tick();
     const screen = ctx._screen!.current!;
 
+    screen.handleInput(DOWN);
     screen.handleInput(DOWN);
     screen.handleInput(ENTER);
     keys(screen, BACKSPACE, 16);
@@ -264,16 +267,17 @@ describe("/wiki-settings screen", () => {
     await tick();
     const screen = ctx._screen!.current!;
 
-    // Item 1 = Model (cursor starts there), empty prefill. Enter + type.
+    // Item 1 = Model (cursor starts on the Scope row). Enter + type.
+    screen.handleInput(DOWN);
     screen.handleInput(ENTER);
     screen.handleInput("openai/gpt-4o");
     screen.handleInput(ENTER);
     expect(loadTaskConfig(tmp).taskModel).toEqual({ provider: "openai", id: "gpt-4o" });
 
     let lines = screen.render(80);
-    expect(lines[SETTINGS_LINE_OFFSET]).toContain("Model");
-    expect(lines[SETTINGS_LINE_OFFSET]).toContain("openai/gpt-4o");
-    expect(lines[SETTINGS_LINE_OFFSET]).toContain("→");
+    expect(lines[SETTINGS_LINE_OFFSET + 1]).toContain("Model");
+    expect(lines[SETTINGS_LINE_OFFSET + 1]).toContain("openai/gpt-4o");
+    expect(lines[SETTINGS_LINE_OFFSET + 1]).toContain("→");
 
     // Reopen, clear the prefill, empty submit → clears to session model.
     screen.handleInput(ENTER);
@@ -281,7 +285,7 @@ describe("/wiki-settings screen", () => {
     screen.handleInput(ENTER);
     expect(loadTaskConfig(tmp).taskModel).toBeUndefined();
     lines = screen.render(80);
-    expect(lines[SETTINGS_LINE_OFFSET]).toContain("(session model)");
+    expect(lines[SETTINGS_LINE_OFFSET + 1]).toContain("(session model)");
 
     screen.handleInput(ESC);
     await pending;
@@ -303,6 +307,102 @@ describe("/wiki-settings screen", () => {
     await tick();
     expect(selectCalls).toBe(1);
     void pending; // screen intentionally left open
+  });
+
+  it("shows a Scope row first, and cycling it re-targets where writes land", async () => {
+    const tmp = project("scope-cycle");
+    const ctx = makeCtx({
+      cwd: tmp,
+      select: async (_title, options) => options[0], // scope picker → Project
+    });
+    const pending = handler("", ctx);
+    await tick();
+    const screen = ctx._screen!.current!;
+
+    // Scope row is the first item, starting at Project.
+    let lines = screen.render(80);
+    expect(lines[SETTINGS_LINE_OFFSET]).toContain("Scope");
+    expect(lines[SETTINGS_LINE_OFFSET]).toContain("Project");
+
+    // Cycle Scope → Global (cursor starts on the Scope row).
+    screen.handleInput(SPACE);
+    lines = screen.render(80);
+    expect(lines[SETTINGS_LINE_OFFSET]).toContain("Global");
+
+    // Move to Notices (row 4) and toggle — the write must land in the
+    // (redirected) global file, not the project file.
+    screen.handleInput(DOWN);
+    screen.handleInput(DOWN);
+    screen.handleInput(DOWN);
+    screen.handleInput(DOWN);
+    screen.handleInput(SPACE);
+
+    expect(loadTaskConfig(tmp).notices).toBe(false);
+    const agentSettings = JSON.parse(
+      readFileSync(join(process.env.PI_CODING_AGENT_DIR!, "settings.json"), "utf8"),
+    ) as Record<string, Record<string, unknown>>;
+    expect(agentSettings["llm-wiki"]?.notices).toBe(false);
+    if (existsSync(join(tmp, ".pi", "settings.json"))) {
+      const projectJson = JSON.parse(
+        readFileSync(join(tmp, ".pi", "settings.json"), "utf8"),
+      ) as Record<string, Record<string, unknown>>;
+      expect(projectJson["llm-wiki"]?.notices).toBeUndefined();
+    }
+
+    screen.handleInput(ESC);
+    await pending;
+  });
+
+  it("scopes inside home to Global without asking", async () => {
+    const priorHome = process.env.HOME;
+    const fakeHome = outsideHomeDir("fakehome");
+    dirs.push(fakeHome);
+    process.env.HOME = fakeHome;
+    try {
+      const tmp = join(fakeHome, "proj");
+      mkdirSync(tmp, { recursive: true });
+      let pickerShown = false;
+      const ctx = makeCtx({
+        cwd: tmp,
+        select: async () => {
+          pickerShown = true;
+          return "Global";
+        },
+      });
+      const pending = handler("", ctx);
+      await tick();
+      const screen = ctx._screen!.current!;
+      const lines = screen.render(80);
+      expect(lines[SETTINGS_LINE_OFFSET]).toContain("Global"); // scope row, silent Global
+      expect(pickerShown).toBe(false);
+      screen.handleInput(ESC);
+      await pending;
+    } finally {
+      if (priorHome === undefined) delete process.env.HOME;
+      else process.env.HOME = priorHome;
+    }
+  });
+
+  it("notes that changing trajectories applies after a reload", async () => {
+    const tmp = project("traj-note");
+    const ctx = makeCtx({
+      cwd: tmp,
+      select: async (_title, options) => options[0], // scope: Project
+    });
+    const pending = handler("", ctx);
+    await tick();
+    const screen = ctx._screen!.current!;
+
+    screen.handleInput(DOWN);
+    screen.handleInput(DOWN);
+    screen.handleInput(DOWN);
+    screen.handleInput(SPACE); // Trajectories ON
+
+    expect(loadTaskConfig(tmp).trajectories).toBe(true);
+    expect(notifs(ctx).some((n) => /reload/i.test(n.message))).toBe(true);
+
+    screen.handleInput(ESC);
+    await pending;
   });
 });
 

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir, homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -378,6 +378,7 @@ describe("/wiki-settings screen", () => {
       screen.handleInput(ESC);
       await pending;
     } finally {
+      // biome-ignore lint/performance/noDelete: must truly unset; assigning undefined sets the string "undefined" in Node
       if (priorHome === undefined) delete process.env.HOME;
       else process.env.HOME = priorHome;
     }


### PR DESCRIPTION
## Summary
- **Scope row**: the /wiki-settings screen now opens with an editable **Scope** row (Global / Project). The inside-home heuristic and the outside-home picker only choose the *starting* value; cycling the row with Space re-targets where subsequent writes land — header line and a toast announce the active target. Fixes the silent scoping that made home-dir sessions land in **global** without ever asking.
- **Trajectories reload note**: toggling Trajectories now says "trajectory tools register at startup — new value applies after a reload". Everything else already applies from the next turn on, because the runtime re-reads config per turn (turn_start); only tool registration is a startup memo.
- Viewport row count now accounts for the extra row.
- Tests: real pi-tui driven through handleInput key sequences; HOME is redirected in a temp dir for the inside-home case.