### PR TITLE
fix(ingest): drop unfilled placeholder sections from entity/concept pages (#170)

### DIFF
--- a/extensions/llm-wiki/lib/ingest-worker.ts
+++ b/extensions/llm-wiki/lib/ingest-worker.ts
@@ -186,42 +186,22 @@ function getHeadings(lang?: string): Record<string, string> {
   };
 }
 
-function buildEntityPageBody(
-  title: string,
-  description: string,
-  sourceId: string,
-  lang?: string,
-): string {
+function buildEntityPageBody(title: string, description: string, sourceId: string): string {
   const desc = description.trim() || "One-line description.";
-  const h = getHeadings(lang);
   return `# ${title}
 
 ${desc}
-
-## ${h.overview}
-
-[Key facts]
 
 ## Links
 
 - [${sourceId}](/sources/${sourceId}.md)`;
 }
 
-function buildConceptPageBody(
-  title: string,
-  definition: string,
-  sourceId: string,
-  lang?: string,
-): string {
+function buildConceptPageBody(title: string, definition: string, sourceId: string): string {
   const def = definition.trim() || "One-line definition.";
-  const h = getHeadings(lang);
   return `# ${title}
 
 ${def}
-
-## ${h.definition}
-
-[Clear explanation]
 
 ## Links
 
@@ -399,7 +379,7 @@ export function commitSynthesis(
           created: date,
           updated: date,
         },
-        buildEntityPageBody(e.title, e.description, sourceId, lang),
+        buildEntityPageBody(e.title, e.description, sourceId),
         [{ id: sourceId, resource: `/sources/${sourceId}.md` }],
       );
       writeKnowledgeDocumentFile(pagePath, entityDoc);
@@ -425,7 +405,7 @@ export function commitSynthesis(
           created: date,
           updated: date,
         },
-        buildConceptPageBody(c.title, c.definition, sourceId, lang),
+        buildConceptPageBody(c.title, c.definition, sourceId),
         [{ id: sourceId, resource: `/sources/${sourceId}.md` }],
       );
       writeKnowledgeDocumentFile(pagePath, conceptDoc);

--- a/test/ingest-worker.test.ts
+++ b/test/ingest-worker.test.ts
@@ -108,6 +108,27 @@ describe("commitSynthesis", () => {
     expect(res.contradictions).toBe(1);
   });
 
+  it("creates entity/concept pages without unfilled placeholder sections (issue #170)", () => {
+    const paths = getVaultPaths(wikiDir);
+    const res = commitSynthesis(paths, "SRC-001", MANIFEST, DATA, "2026-06-06");
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const entity = readFileSync(join(paths.wiki, "entities", "google-brain.md"), "utf-8");
+    const concept = readFileSync(join(paths.wiki, "concepts", "transformer.md"), "utf-8");
+    // No unfilled placeholder sections left behind.
+    expect(entity).not.toContain("[Key facts]");
+    expect(entity).not.toContain("## Overview");
+    expect(concept).not.toContain("[Clear explanation]");
+    expect(concept).not.toContain("## Definition");
+    // The one-liner still leads the page, exactly once.
+    expect(entity).toContain("Research lab");
+    expect(concept).toContain("Attention-based seq model");
+    // Source link preserved.
+    expect(entity).toContain("[SRC-001](/sources/SRC-001.md)");
+    expect(concept).toContain("[SRC-001](/sources/SRC-001.md)");
+  });
+
   it("links (does not overwrite) pages that already exist", () => {
     const paths = getVaultPaths(wikiDir);
     const existing = join(paths.wiki, "entities", "google-brain.md");


### PR DESCRIPTION
## Summary

Fixes #170 — entity and concept pages created during background ingest always contained unfilled placeholder sections (`## Overview` / `[Key facts]`, `## Definition` / `[Clear explanation]`).

The sub-agent's only job is to call `commit_synthesis` once, so no subsequent pass ever fills those sections. They persisted in every ingest-created entity/concept page.

## Approach

Removed the stub sections from `buildEntityPageBody` / `buildConceptPageBody` (issue option b). The one-line description/definition already leads the page, so the sections added no information — extending `CommitSynthesisSchema` with richer fields (option a) would be 3x the work for marginal gain and wouldn't fix existing pages either.

Also dropped the now-unused `lang` parameter from both builders and their two call sites in `commitSynthesis`.

Untouched by design: `buildPageBody` in `tools.ts` — the manual `wiki_create_page` placeholders are intentional (the agent fills them on the next turn).

## Verification

TDD:
- New regression test in `test/ingest-worker.test.ts` asserts ingest-created pages contain no placeholder stubs, no empty Overview/Definition sections, the one-liner still leads, and the source link is preserved.
- Test failed against unmodified code (entity page contained `## Overview` / `[Key facts]`), green after the fix.
- `pnpm typecheck` ✅, `pnpm lint` ✅, ingest-worker suite 10/10 ✅.
- Full suite: one pre-existing flake (mcp-parity / personal-wiki-paths rotate between runs; passes solo and fails on clean `main` too — verified via stash).

E2E against a real vault:
- `captureText` → fresh source packet → `wiki_ingest` (background sub-agent) → 4 entities + 3 concepts.
- All 7 generated pages verified stub-free on disk; lint clean for the new pages.

Note: pages created by ingest runs before this fix still carry the stubs (no retroactive migration); a one-off vault cleanup pass is a separate concern.
