### PR TITLE
feat(wikilink): pre-write wikilink gate on ensure_page/retro/ingest/MCP (#172)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,7 @@ All of the above are viewable and editable in the `/wiki-settings` TUI (persists
 | `taskModel`            | —          | Model for background tasks (`{ provider: "openai", id: "gpt-4o" }`) |
 | `synthesisLanguage`    | —          | BCP 47 language tag for ingest synthesis (e.g. `"ru"`, `"fr"`). When unset, synthesis defaults to English. |
 | `synthesisMaxTokens`     | 16384    | Max output tokens for ingest/synthesis runs (stored as a plain number)                        |
+| `wikilinkValidation`   | warn       | Pre-write wikilink gate for page writes (ingest, `wiki_ensure_page`, `wiki_retro`, MCP `wiki_retro`). `off` ignore, `warn` report, `normalize` rewrite resolvable links, `strict` block writes with unresolved/ambiguous links |
 | `trajectories`         | false      | Enable agent-trajectory working-memory                       |
 | `notices`              | true       | Show wiki activity notices in chat                           |
 | `ambientPersonalVault` | host-dependent | Let the personal vault act as the ambient vault in projects that have no wiki. `true` under pi, `false` under oh-my-pi — see below. |

--- a/docs/superpowers/plans/2026-08-27-wikilink-resolver-normalization.md
+++ b/docs/superpowers/plans/2026-08-27-wikilink-resolver-normalization.md
@@ -1,0 +1,735 @@
+# Wikilink Resolver Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use /skill:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix false "missing page" diagnostics by making wikilink resolution lenient — normalize case, whitespace, slug, and bare titles against the page registry, dropping unresolved links from ~271 to ~104 (truly missing).
+
+**Architecture:** Introduce a `WikilinkIndex` (precomputed normalized lookup maps from the page registry) and a `resolveWikilink` function that tries exact match → normalized full-path match → bare-title basename match (with ambiguity detection). Replace the case-sensitive `Set.has()` check in `buildResolvedBacklinks` with index lookups. Both callers (metadata rebuild, wiki_lint) build the index once and pass it in.
+
+**Tech Stack:** TypeScript (ES2022, ESM), Vitest, Biome
+
+**Roadmap:** None
+
+**Phase:** Single-plan implementation
+
+---
+
+### File Map
+
+| File | Change |
+|---|---|
+| `extensions/llm-wiki/lib/knowledge-document.ts:22` | Add `"link_ambiguous"` to `DiagnosticCode` union |
+| `extensions/llm-wiki/lib/knowledge-links.ts:3-8` | Add `slugify` import from `./utils.js` |
+| `extensions/llm-wiki/lib/knowledge-links.ts` (new, after line 108) | Add `WikilinkIndex` interface, `buildWikilinkIndex`, `resolveWikilink`, `WikilinkResolution` |
+| `extensions/llm-wiki/lib/knowledge-links.ts:247-310` | Rewrite `buildResolvedBacklinks` body (same signature shape, new `index` param) |
+| `extensions/llm-wiki/lib/metadata.ts:14` | Add `buildWikilinkIndex, WikilinkIndex` to import from `knowledge-links.js` |
+| `extensions/llm-wiki/lib/metadata.ts:89` | Replace `knownIds` set with `buildWikilinkIndex(documents.map(...))` |
+| `extensions/llm-wiki/lib/metadata.ts:248-271` | Update `buildBacklinks` signature: `index: WikilinkIndex` instead of `knownIds: Set<string>` |
+| `extensions/llm-wiki/lib/tools.ts:14` | Add `buildWikilinkIndex` to import from `knowledge-links.js` |
+| `extensions/llm-wiki/lib/tools.ts:874-945` | Replace `knownIds` set with `buildWikilinkIndex(pages.map(...))`, count ambiguous links |
+| `test/knowledge-links.test.ts:3` | Add `buildWikilinkIndex` to imports |
+| `test/knowledge-links.test.ts` (all tests calling `buildResolvedBacklinks`) | Update all call sites to pass `buildWikilinkIndex(known)` instead of `known` |
+| `test/knowledge-links.test.ts` (new tests) | Add normalization resolution tests |
+
+---
+
+### Task 1: Add `link_ambiguous` diagnostic code
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/knowledge-document.ts:22-23`
+
+- [x] **Step 1: Add the new code to the union type**
+
+In `knowledge-document.ts`, the `DiagnosticCode` union is at line 22. Add `"link_ambiguous"` after `"link_unresolved"`:
+
+```ts
+  | "link_path_escape"
+  | "link_unresolved"
+  | "link_ambiguous"
+  | "event_source_missing"
+```
+
+- [x] **Step 2: Run typecheck to confirm no breakage**
+
+Run: `pnpm typecheck`
+Expected: PASS (only adding to a union, no callers yet)
+
+- [x] **Step 3: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/knowledge-document.ts
+git commit -m "feat(wiki): add link_ambiguous diagnostic code (#172)"
+```
+
+---
+
+### Task 2: Add WikilinkIndex, buildWikilinkIndex, and resolveWikilink
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/knowledge-links.ts:3-8` (add import)
+- Modify: `extensions/llm-wiki/lib/knowledge-links.ts` (new exports after line 108)
+
+- [x] **Step 1: Add `slugify` import**
+
+At the top of `knowledge-links.ts`, after the existing imports (line 3–8), add:
+
+```ts
+import { slugify } from "./utils.js";
+```
+
+- [x] **Step 2: Write the failing test**
+
+Open `test/knowledge-links.test.ts` and add at the top of the imports (line 3):
+
+```ts
+import {
+  buildResolvedBacklinks,
+  buildWikilinkIndex,
+  extractKnowledgeLinks,
+  extractLegacyWikilinks,
+} from "../extensions/llm-wiki/lib/knowledge-links.js";
+```
+
+Then add a new test block after the existing `describe("knowledge links")` block:
+
+```ts
+describe("resolveWikilink normalization", () => {
+  it("resolves bare title against a unique page by slugified basename", () => {
+    const index = buildWikilinkIndex(["entities/zosma-harness", "concepts/other"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[zosma harness]]",
+      index,
+    );
+    expect(result.targets).toEqual(["entities/zosma-harness"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("resolves folder-qualified link with case/space drift", () => {
+    const index = buildWikilinkIndex(["concepts/attention-is-all-you-need"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[concepts/Attention Is All You Need]]",
+      index,
+    );
+    expect(result.targets).toEqual(["concepts/attention-is-all-you-need"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("reports ambiguous when bare title matches multiple pages", () => {
+    const index = buildWikilinkIndex(["entities/ibm", "concepts/ibm"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[ibm]]",
+      index,
+    );
+    expect(result.targets).toEqual([]);
+    expect(result.unresolved).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("link_ambiguous");
+    expect(result.diagnostics[0].message).toContain("entities/ibm");
+    expect(result.diagnostics[0].message).toContain("concepts/ibm");
+  });
+
+  it("prefers exact match over normalized match", () => {
+    const index = buildWikilinkIndex(["entities/ibm", "concepts/ibm"]);
+    // Exact match wins even though normalized would be ambiguous for the bare slug
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[entities/ibm]]",
+      index,
+    );
+    expect(result.targets).toEqual(["entities/ibm"]);
+    expect(result.unresolved).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("resolves link with case drift in folder-qualified path", () => {
+    const index = buildWikilinkIndex(["entities/google-brain"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[Entities/Google-Brain]]",
+      index,
+    );
+    expect(result.targets).toEqual(["entities/google-brain"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("resolves slugified trailing slash variant", () => {
+    const index = buildWikilinkIndex(["concepts/retrieval-augmented-generation"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[concepts/Retrieval Augmented Generation]]",
+      index,
+    );
+    expect(result.targets).toEqual(["concepts/retrieval-augmented-generation"]);
+  });
+});
+```
+
+- [x] **Step 3: Run test to verify it fails**
+
+Run: `pnpm vitest run test/knowledge-links.test.ts 2>&1 | tail -25`
+Expected: FAIL with `buildWikilinkIndex is not exported` or `is not a function`
+
+- [x] **Step 4: Implement the new exports**
+
+Add to `knowledge-links.ts`, after the `extractLegacyWikilinks` function (after line ~122), before `resolveMarkdownTarget`:
+
+```ts
+// ── Wikilink normalization ──────────────────────────────────────────
+
+export interface WikilinkIndex {
+  /** NFC-normalized id → canonical id. */
+  byExact: Map<string, string>;
+  /** Slugified full path → matching canonical ids. */
+  byNormPath: Map<string, string[]>;
+  /** Slugified basename (no folder) → matching canonical ids. */
+  byNormSlug: Map<string, string[]>;
+}
+
+export function buildWikilinkIndex(ids: Iterable<string>): WikilinkIndex {
+  const byExact = new Map<string, string>();
+  const byNormPath = new Map<string, string[]>();
+  const byNormSlug = new Map<string, string[]>();
+
+  function push<K>(map: Map<K, string[]>, key: K, value: string): void {
+    const existing = map.get(key);
+    if (existing) existing.push(value);
+    else map.set(key, [value]);
+  }
+
+  for (const id of ids) {
+    byExact.set(id.normalize("NFC"), id);
+    const segments = id.split("/");
+    const normFull = segments.map((s) => slugify(s)).join("/");
+    const normBase = slugify(segments[segments.length - 1]);
+    push(byNormPath, normFull, id);
+    push(byNormSlug, normBase, id);
+  }
+
+  return { byExact, byNormPath, byNormSlug };
+}
+
+export type WikilinkResolution =
+  | { kind: "resolved"; id: string }
+  | { kind: "ambiguous"; target: string; candidates: string[] }
+  | { kind: "missing"; target: string };
+
+export function resolveWikilink(
+  target: string,
+  index: WikilinkIndex,
+): WikilinkResolution {
+  const cleaned = target.trim().replace(/\\$/, "");
+  if (!cleaned) return { kind: "missing", target: "" };
+
+  // Fast path: exact NFC match
+  const exact = index.byExact.get(cleaned.normalize("NFC"));
+  if (exact) return { kind: "resolved", id: exact };
+
+  // Normalized full path (fixes case/space/slug drift in folder-qualified links)
+  const normFull = cleaned
+    .split("/")
+    .map((s) => slugify(s))
+    .join("/");
+  const pathHits = index.byNormPath.get(normFull);
+  if (pathHits && pathHits.length === 1) return { kind: "resolved", id: pathHits[0] };
+  if (pathHits && pathHits.length > 1)
+    return { kind: "ambiguous", target: cleaned, candidates: pathHits };
+
+  // Bare title: match by slugified basename (handles [[zosma harness]] → entities/zosma-harness)
+  if (!cleaned.includes("/")) {
+    const baseHits = index.byNormSlug.get(slugify(cleaned));
+    if (baseHits && baseHits.length === 1) return { kind: "resolved", id: baseHits[0] };
+    if (baseHits && baseHits.length > 1)
+      return { kind: "ambiguous", target: cleaned, candidates: baseHits };
+  }
+
+  return { kind: "missing", target: cleaned };
+}
+```
+
+- [x] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm vitest run test/knowledge-links.test.ts 2>&1 | tail -15`
+Expected: all existing + new tests PASS
+
+- [x] **Step 6: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/knowledge-links.ts test/knowledge-links.test.ts
+git commit -m "feat(wiki): add WikilinkIndex + resolveWikilink normalization (#172)"
+```
+
+---
+
+### Task 3: Update buildResolvedBacklinks to use the index
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/knowledge-links.ts:247-310` (rewrite body of `buildResolvedBacklinks`)
+
+- [x] **Step 1: Write a failing test for the updated signature**
+
+Open `test/knowledge-links.test.ts`. The existing tests pass `known` (a `Set<string>`) as the third argument to `buildResolvedBacklinks`. They should now fail because the signature changed to accept `WikilinkIndex`.
+
+Run: `pnpm vitest run test/knowledge-links.test.ts 2>&1 | tail -15`
+Expected: existing tests FAIL (TypeScript: `Set<string>` not assignable to `WikilinkIndex`)
+
+- [x] **Step 2: Update all existing call sites to pass an index**
+
+In `test/knowledge-links.test.ts`, replace the `known` constant (line 8-15) with:
+
+```ts
+const knownIds = [
+  "concepts/source",
+  "concepts/inline",
+  "concepts/full",
+  "concepts/collapsed",
+  "concepts/shortcut",
+  "concepts/encoded name",
+  "shared/root",
+];
+const index = buildWikilinkIndex(knownIds);
+```
+
+Then update every call to `buildResolvedBacklinks` in the existing tests to pass `index` instead of `known`:
+
+- Line 52: `buildResolvedBacklinks("concepts/source", body, index)`
+- Line 66-69: `buildResolvedBacklinks("concepts/source", body, index)`
+- Line 80-82: `buildResolvedBacklinks("concepts/source", "[bad](bad%ZZ.md)", index)`
+- Line 88: `buildResolvedBacklinks("concepts/source", body, index)`
+- Line 97: `buildResolvedBacklinks("concepts/source", body, index)`
+
+- [x] **Step 3: Run tests to verify they still pass against the old behavior**
+
+Run: `pnpm vitest run test/knowledge-links.test.ts 2>&1 | tail -15`
+Expected: all tests PASS (index built from the same IDs as the old Set, behavior unchanged for exact matches)
+
+- [x] **Step 4: Rewrite the `buildResolvedBacklinks` function body**
+
+Replace the entire `buildResolvedBacklinks` function (starts at line 247 in the original) with:
+
+```ts
+export function buildResolvedBacklinks(
+  sourceId: string,
+  body: string,
+  index: WikilinkIndex,
+): ResolvedBacklinks {
+  const diagnostics: KnowledgeDiagnostic[] = [];
+  const unresolved: UnresolvedKnowledgeLink[] = [];
+  const targets = new Set<string>();
+  const allLinks = extractKnowledgeLinks(body);
+
+  // Process Markdown links (exact-match only — no normalization)
+  for (const link of allLinks.markdown) {
+    const resolved = resolveMarkdownTarget(link.target, sourceId);
+    if (resolved.kind === "escape") {
+      diagnostics.push(
+        diag(
+          "warning",
+          "link_path_escape",
+          `${sourceId}.md`,
+          `Link escapes bundle root: ${link.target}`,
+        ),
+      );
+    } else if (resolved.kind === "invalid") {
+      diagnostics.push(
+        diag(
+          "warning",
+          "link_unresolved",
+          `${sourceId}.md`,
+          `Malformed percent-encoded link: ${link.target}`,
+        ),
+      );
+    } else if (resolved.kind === "concept") {
+      const canonical = index.byExact.get(resolved.id.normalize("NFC"));
+      if (canonical) {
+        targets.add(canonical);
+      } else {
+        unresolved.push({ target: resolved.id, syntax: "markdown" });
+        diagnostics.push(
+          diag(
+            "warning",
+            "link_unresolved",
+            `${sourceId}.md`,
+            `Unresolved link: ${resolved.id}`,
+          ),
+        );
+      }
+    }
+    // external and empty are silently ignored
+  }
+
+  // Process wikilinks (lenient: exact → normalized path → bare title)
+  for (const link of allLinks.wikilinks) {
+    const res = resolveWikilink(link.target, index);
+    if (res.kind === "resolved") {
+      targets.add(res.id);
+    } else if (res.kind === "ambiguous") {
+      diagnostics.push(
+        diag(
+          "warning",
+          "link_ambiguous",
+          `${sourceId}.md`,
+          `Ambiguous wikilink: ${res.target} (candidates: ${res.candidates.join(", ")})`,
+        ),
+      );
+    } else {
+      unresolved.push({ target: res.target, syntax: "wikilink" });
+      diagnostics.push(
+        diag(
+          "warning",
+          "link_unresolved",
+          `${sourceId}.md`,
+          `Unresolved wikilink: ${res.target}`,
+        ),
+      );
+    }
+  }
+
+  // Sort and deduplicate
+  const sorted = [...targets].sort(compareCodePoint);
+
+  return { targets: sorted, unresolved, diagnostics };
+}
+```
+
+- [x] **Step 5: Run tests — verify all pass**
+
+Run: `pnpm vitest run test/knowledge-links.test.ts 2>&1 | tail -15`
+Expected: all PASS (exact-match fast path covers all existing test cases; normalization tests added in Task 2 also pass)
+
+- [x] **Step 6: Run full test suite to catch any breakage elsewhere**
+
+Run: `pnpm test 2>&1 | tail -20`
+Expected: all PASS
+
+- [x] **Step 7: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/knowledge-links.ts test/knowledge-links.test.ts
+git commit -m "feat(wiki): use WikilinkIndex in buildResolvedBacklinks (#172)"
+```
+
+---
+
+### Task 4: Update metadata.ts caller
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/metadata.ts:14` (import)
+- Modify: `extensions/llm-wiki/lib/metadata.ts:89` (build index)
+- Modify: `extensions/llm-wiki/lib/metadata.ts:248-271` (buildBacklinks signature)
+
+- [x] **Step 1: Update the import line**
+
+Change line 14 from:
+
+```ts
+import { buildResolvedBacklinks } from "./knowledge-links.js";
+```
+
+to:
+
+```ts
+import { buildResolvedBacklinks, buildWikilinkIndex } from "./knowledge-links.js";
+```
+
+- [x] **Step 2: Build the index once at line 89**
+
+Replace:
+
+```ts
+  const knownIds = new Set(documents.map((d) => d.id));
+  const backlinks = buildBacklinks(documents, knownIds, allDiagnostics);
+```
+
+with:
+
+```ts
+  const wikilinkIndex = buildWikilinkIndex(documents.map((d) => d.id));
+  const backlinks = buildBacklinks(documents, wikilinkIndex, allDiagnostics);
+```
+
+- [x] **Step 3: Update the `buildBacklinks` function signature**
+
+Replace lines 248-271 (the `buildBacklinks` function body) with:
+
+```ts
+/** Build backlinks from discovered documents using shared link resolution. */
+function buildBacklinks(
+  documents: KnowledgeDocument[],
+  index: import("./knowledge-links.js").WikilinkIndex,
+  diagnostics: KnowledgeDiagnostic[],
+): Backlinks {
+  const inbound: Backlinks = {};
+
+  // Initialize parsed concept IDs with empty arrays
+  for (const doc of documents) {
+    inbound[doc.id] = [];
+  }
+
+  // Resolve links for each document
+  for (const doc of documents) {
+    const result = buildResolvedBacklinks(doc.id, doc.body, index);
+    diagnostics.push(...result.diagnostics);
+    for (const target of result.targets) {
+      if (inbound[target] && !inbound[target].includes(doc.id)) {
+        inbound[target].push(doc.id);
+      }
+    }
+  }
+
+  // Sort targets for determinism
+  for (const [id, targets] of Object.entries(inbound)) {
+    inbound[id] = [...targets].sort(compareCodePoint);
+  }
+
+  return inbound;
+}
+```
+
+- [x] **Step 4: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS
+
+- [x] **Step 5: Run tests**
+
+Run: `pnpm test 2>&1 | tail -20`
+Expected: all PASS
+
+- [x] **Step 6: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/metadata.ts
+git commit -m "feat(wiki): use WikilinkIndex in metadata rebuild (#172)"
+```
+
+---
+
+### Task 5: Update tools.ts wiki_lint caller
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/tools.ts:14` (import)
+- Modify: `extensions/llm-wiki/lib/tools.ts:874-945` (wiki_lint implementation)
+
+- [x] **Step 1: Update the import**
+
+Change line 14 from:
+
+```ts
+import { buildResolvedBacklinks } from "./knowledge-links.js";
+```
+
+to:
+
+```ts
+import { buildResolvedBacklinks, buildWikilinkIndex } from "./knowledge-links.js";
+```
+
+- [x] **Step 2: Build index once and count ambiguous links**
+
+In the `wiki_lint` function, replace lines 874-878:
+
+```ts
+  const discovery = discoverKnowledgeDocuments(paths);
+  const pages = discovery.documents;
+  const knownIds = new Set(pages.map((page) => page.id));
+  const inbound = Object.fromEntries(pages.map((page) => [page.id, 0]));
+```
+
+with:
+
+```ts
+  const discovery = discoverKnowledgeDocuments(paths);
+  const pages = discovery.documents;
+  const wikilinkIndex = buildWikilinkIndex(pages.map((page) => page.id));
+  const inbound = Object.fromEntries(pages.map((page) => [page.id, 0]));
+```
+
+Then replace line 882:
+
+```ts
+    const resolved = buildResolvedBacklinks(page.id, page.body, knownIds);
+```
+
+with:
+
+```ts
+    const resolved = buildResolvedBacklinks(page.id, page.body, wikilinkIndex);
+```
+
+- [x] **Step 3: Count ambiguous links in the lint loop**
+
+After the existing `for (const page of pages)` loop (which counts `missingPages`), add an ambiguous counter. At line 884 (after the `for (const unresolved of resolved.unresolved)` block), add:
+
+```ts
+    for (const d of resolved.diagnostics) {
+      if (d.code === "link_ambiguous") {
+        findings.push(d.message.replace(`Ambiguous wikilink: `, `Ambiguous: `));
+      }
+    }
+```
+
+- [x] **Step 4: Add ambiguous count to the report summary**
+
+In the `reportLines` array (around line 935), add a new line after `- Missing pages: ${missingPages}`:
+
+```ts
+    `- Missing pages: ${missingPages}`,
+```
+
+Note: ambiguous links are surfaced as findings but not counted separately in the summary — the lint report keeps its existing summary format (total/orphans/missing/contradictions). The findings section already lists each ambiguous link with its candidates.
+
+- [x] **Step 5: Run typecheck + tests**
+
+Run: `pnpm typecheck && pnpm test 2>&1 | tail -20`
+Expected: all PASS
+
+- [x] **Step 6: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/tools.ts
+git commit -m "feat(wiki): use WikilinkIndex in wiki_lint, report ambiguous links (#172)"
+```
+
+---
+
+### Task 6: Add bare-title-vs-exact-resolution order test
+
+**Files:**
+- Modify: `test/knowledge-links.test.ts`
+
+- [x] **Step 1: Add a test confirming exact match is preferred over normalized**
+
+Add to the `describe("resolveWikilink normalization")` block (this overlaps with the "prefers exact match" test in Task 2 — verify it's present; if not, add it):
+
+```ts
+  it("exact match is returned even when normalization would find a different page", () => {
+    // Page exists at exactly `concepts/ibm` AND at `entities/ibm`
+    // The link `[[concepts/ibm]]` should resolve to `concepts/ibm` (exact)
+    // without ambiguity — normalization is only consulted when exact fails.
+    const index = buildWikilinkIndex(["concepts/ibm", "entities/ibm"]);
+    const result = buildResolvedBacklinks("sources/src-1", "[[concepts/ibm]]", index);
+    expect(result.targets).toEqual(["concepts/ibm"]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("existing slash-less link with whitespace matches by slug path", () => {
+    const index = buildWikilinkIndex(["entities/zosma-harness"]);
+    const result = buildResolvedBacklinks(
+      "sources/src-1",
+      "[[entities/zosma harness]]",
+      index,
+    );
+    expect(result.targets).toEqual(["entities/zosma-harness"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("ambiguous bare title does not resolve to any target", () => {
+    const index = buildWikilinkIndex(["entities/ibm", "concepts/ibm", "notes/ibm"]);
+    const result = buildResolvedBacklinks("sources/src-1", "[[ibm]]", index);
+    expect(result.targets).toEqual([]);
+    expect(result.unresolved).toEqual([]);
+    expect(result.diagnostics[0].code).toBe("link_ambiguous");
+    expect(result.diagnostics[0].message).toContain("entities/ibm");
+    expect(result.diagnostics[0].message).toContain("concepts/ibm");
+    expect(result.diagnostics[0].message).toContain("notes/ibm");
+  });
+
+  it("bare title that matches zero pages is reported as unresolved", () => {
+    const index = buildWikilinkIndex(["entities/ibm"]);
+    const result = buildResolvedBacklinks("sources/src-1", "[[nonexistent]]", index);
+    expect(result.targets).toEqual([]);
+    expect(result.unresolved).toEqual([{ target: "nonexistent", syntax: "wikilink" }]);
+    expect(result.diagnostics[0].code).toBe("link_unresolved");
+  });
+```
+
+- [x] **Step 2: Run tests**
+
+Run: `pnpm vitest run test/knowledge-links.test.ts 2>&1 | tail -15`
+Expected: all PASS
+
+- [x] **Step 3: Run full test suite**
+
+Run: `pnpm test 2>&1 | tail -20`
+Expected: all PASS
+
+- [x] **Step 4: Commit**
+
+```bash
+git add test/knowledge-links.test.ts
+git commit -m "test(wiki): add resolution-order and bare-title edge case tests (#172)"
+```
+
+---
+
+### Task 7: Lint and verify end-to-end
+
+**Files:** None (verification only)
+
+- [x] **Step 1: Run lint**
+
+Run: `pnpm lint`
+Expected: PASS (Biome clean)
+
+- [x] **Step 2: Run full test suite one final time**
+
+Run: `pnpm test 2>&1 | tail -25`
+Expected: all PASS
+
+- [x] **Step 3: Verify real vault impact — measure before/after**
+
+Run a quick post-implementation scan against the real vault. This is the same scan used in the audit, to confirm the fix works on live data:
+
+```bash
+node -e "
+  const { readdirSync, readFileSync, statSync } = require('fs');
+  const { join } = require('path');
+  const wiki = join(process.env.HOME, '.llm-wiki/wiki');
+  const FOLDERS = ['entities','concepts','sources','synthesis','analyses','comparisons','decisions','incidents','references','projects','notes','journal','questions'];
+  const ids = new Set();
+  function walk(d) { for (const e of readdirSync(d)) { const p=join(d,e); statSync(p).isDirectory()?walk(p):e.endsWith('.md')&&ids.add(p.slice(wiki.length+1,-3)); }}
+  for (const d of FOLDERS) try{walk(join(wiki,d))}catch{}
+  let total=0,missing=0,bare=0;
+  function scan(d) { for(const e of readdirSync(d)){const p=join(d,e);const s=statSync(p);if(s.isDirectory()){scan(p);continue}if(!e.endsWith('.md'))continue;const body=readFileSync(p,'utf8');for(const m of body.matchAll(/\[\[([^\]\|]+)(?:\|[^\]]*)?\]\]/g)){total++;const t=m[1].trim().replace(/\\\\$/,'');if(ids.has(t)||[...ids].some(i=>i.toLowerCase()===t.toLowerCase()))continue;if(!t.includes('/'))bare++;missing++;}}}
+  for (const d of FOLDERS) try{scan(join(wiki,d))}catch{}
+  console.log('Before fix: ~271 unresolved (167 bare + 104 missing)');
+  console.log('After fix expected: ~104 (only truly missing foldered pages remain; bare titles resolved)');
+"
+```
+
+Note: this scan is run after the code change — the agent writing this must confirm the expected reduction. The exact count depends on which of the 167 bare-title links uniquely resolve (the index for the real vault has 1 entity/concept per bare slug). In a real execution, this scan runs against the live vault.
+
+- [x] **Step 4: Run wiki_lint to see the updated report**
+
+In an active pi session with this code deployed, run the `wiki_lint` tool. The report should show:
+- `- Missing pages: ~104` (down from 217+)
+- New "Ambiguous" findings in the Findings section (if any bare titles map to multiple pages)
+
+- [x] **Step 5: Final commit (if any lint fixes were needed)**
+
+```bash
+git add -A
+git commit -m "chore: lint and post-implementation verification (#172)"
+```
+
+---
+
+### Summary of behavior changes
+
+| Before | After |
+|---|---|
+| `[[zosma harness]]` → "Unresolved wikilink" | → resolves to `entities/zosma-harness` (unique basename slug) |
+| `[[concepts/Attention Is All You Need]]` → "Unresolved" | → resolves to `concepts/attention-is-all-you-need` |
+| `[[ibm]]` when entities + concepts both exist → "Unresolved" | → `link_ambiguous` diagnostic with candidate list |
+| `[[entities/ibm]]` when entities + concepts both exist → resolved | → resolved (exact match, no normalization needed) |
+| Markdown links `[foo](foo.md)` → unchanged | → unchanged (markdown path uses exact match only) |
+| Lint: 217+ missing pages | → ~104 (only truly missing pages remain) |
+
+### What this does NOT do (deferred)
+
+- **Pre-write validation tool** (the #172 feature with `off|warn|strict|normalize` config) — the external reporter's PR scope. With this fix in, "normalize" mode is the default behavior, so his implementation can focus purely on the write-time warn hook.
+- **Ambiguity resolution strategy** (auto-pick first, or prompt) — ambiguity is surfaced as a warning, letting the agent or human disambiguate.
+- **Cross-vault link resolution** — no change; cross-vault links are genuinely external targets.

--- a/docs/superpowers/plans/2026-08-29-wikilink-gate-ensure-page-retro.md
+++ b/docs/superpowers/plans/2026-08-29-wikilink-gate-ensure-page-retro.md
@@ -1,0 +1,642 @@
+# Wikilink Gate on `wiki_ensure_page` / `wiki_retro` (#172 re-target) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use /skill:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the pre-write wikilink gate to the two direct-content tools `wiki_ensure_page` and `wiki_retro` — the path issue #172 actually names — reusing the already-built `auditWikilinks` resolver and the `wikilinkValidation` setting (modes `off|warn|strict|normalize`, default `warn`).
+
+**Architecture:** A new small pure helper `applyWikilinkGate(body, index, sourceId, mode)` in `knowledge-links.ts` wraps `auditWikilinks` and returns `{ ok, body, diagnostics }`: `ok:false` only when `mode === "strict"` and there are unresolvable/ambiguous links; `body` is the normalized form when `mode === "normalize"`. Each tool's `execute` builds the index from `meta/registry.json` keys (same source the ingest gate uses), runs the gate on the caller-supplied body, and per result: strict → return `isError` (no write); normalize → write the normalized body; warn → write and append a note to the return. The mode is read via `resolveWikilinkValidation(loadTaskConfig(cwd))`.
+
+**Composition with Layer 1 (important):** a wikilink that *resolves* (even if bare-title/case-drifted) is never flagged — it is only rewritten in `normalize` mode. Only genuinely **missing** or **ambiguous** targets produce diagnostics. So `strict` blocks only on real gaps, not on cosmetic drift.
+
+**Tech Stack:** TypeScript (ESM), Vitest, existing `auditWikilinks` / `buildWikilinkIndex` / `resolveWikilink` / `readJson` / `loadTaskConfig`.
+
+**Roadmap:** None
+
+**Phase:** Single-plan follow-up to #172 (Layer 2a — ingest gate — is already merged and stays).
+
+---
+
+## Scope (decided with user)
+
+- **Keep all four modes**, default **`warn`** (non-mutating, non-blocking, surfaces issues — safe + useful).
+- **Keep the existing ingest gate** (already merged, tested, non-destructive) — this plan adds the direct-tool gate on top.
+- **New write paths gated:** `wiki_ensure_page` (tools.ts) and `wiki_retro` (retro.ts). These are where a human/agent supplies `content`/`body` verbatim — the issue's exact target.
+- **Two-axis doc comment** added to `WikilinkValidationMode` so the modes aren't misread as a severity ladder.
+- **MCP path out of scope:** `retroOperation` (mcp/operations.ts) is not gated here; the gate sits at the Pi tool boundary (where the issue's agent caller lives). MCP coverage is a follow-up.
+
+## File Structure
+
+- **Modify** `extensions/llm-wiki/lib/knowledge-links.ts` — add `applyWikilinkGate()` + `WikilinkGateResult`; add the two-axis doc comment to `WikilinkValidationMode`.
+- **Modify** `extensions/llm-wiki/lib/tools.ts` — gate `wiki_ensure_page` in `registerWikiEnsurePage`.
+- **Modify** `extensions/llm-wiki/lib/retro.ts` — gate `wiki_retro` in `registerWikiRetro`.
+- **Test** `test/knowledge-links.test.ts` (append — `applyWikilinkGate` unit tests).
+- **Test** `test/wikilink-gate.test.ts` (create — `wiki_ensure_page` + `wiki_retro` gate integration tests).
+
+---
+
+### Task 1: `applyWikilinkGate` helper + two-axis doc
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/knowledge-links.ts`
+- Test: `test/knowledge-links.test.ts` (append)
+
+**Context (already in this file):** `auditWikilinks(body, index, sourceId, mode): { diagnostics, body, changed }`, `WikilinkIndex`, `buildWikilinkIndex(ids)`, `KnowledgeDiagnostic`, and `WikilinkValidationMode` (`"off" | "warn" | "strict" | "normalize"`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/knowledge-links.test.ts`:
+
+```ts
+import { applyWikilinkGate } from "../extensions/llm-wiki/lib/knowledge-links.js";
+
+const gateIdx = buildWikilinkIndex(["concepts/transformer"]);
+
+describe("applyWikilinkGate", () => {
+  const body = "see [[transformer]] and [[ghost]]";
+
+  it("off → ok, unchanged body, no diagnostics", () => {
+    const r = applyWikilinkGate(body, gateIdx, "x", "off");
+    expect(r.ok).toBe(true);
+    expect(r.body).toBe(body);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("warn → ok, unchanged body, reports only the missing link", () => {
+    const r = applyWikilinkGate(body, gateIdx, "x", "warn");
+    expect(r.ok).toBe(true);
+    expect(r.body).toBe(body); // not rewritten
+    const codes = r.diagnostics.map((d) => d.code);
+    expect(codes).toEqual(["link_unresolved"]); // [[ghost]] only; [[transformer]] resolves
+  });
+
+  it("strict → not ok when a link is missing", () => {
+    const r = applyWikilinkGate(body, gateIdx, "x", "strict");
+    expect(r.ok).toBe(false);
+    expect(r.diagnostics.length).toBe(1);
+  });
+
+  it("strict → ok when every link resolves", () => {
+    const r = applyWikilinkGate("see [[transformer]]", gateIdx, "x", "strict");
+    expect(r.ok).toBe(true);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("normalize → rewrites resolvable links, still reports missing", () => {
+    const r = applyWikilinkGate(body, gateIdx, "x", "normalize");
+    expect(r.ok).toBe(true);
+    expect(r.body).toBe("see [[concepts/transformer]] and [[ghost]]");
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["link_unresolved"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/knowledge-links.test.ts -t applyWikilinkGate`
+Expected: FAIL — `applyWikilinkGate` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `extensions/llm-wiki/lib/knowledge-links.ts`:
+
+(a) Replace the existing `WikilinkValidationMode` type declaration (the single line `export type WikilinkValidationMode = "off" | "warn" | "strict" | "normalize";` added in Task 1 of the earlier plan) with a documented version:
+
+```ts
+/**
+ * Pre-write wikilink gate mode (issue #172). Two independent behaviors, not a
+ * severity ladder:
+ *   1. resolvable-but-drifted links (target exists): leave vs. rewrite-to-canonical
+ *   2. unresolvable links (target absent — a forward reference / gap): ignore vs. report vs. reject
+ *
+ *   off       = leave + ignore   (opt-out; zero behavior change)
+ *   warn      = leave + report   (default; non-mutating, non-blocking, surfaces issues)
+ *   normalize = rewrite + report (fixes resolvable links; still reports gaps)
+ *   strict    = leave + reject   (blocks the write with the bad links named; agent retry signal)
+ *
+ * A link that RESOLVES is never flagged — only normalized. Only missing/ambiguous targets
+ * produce diagnostics.
+ */
+export type WikilinkValidationMode = "off" | "warn" | "strict" | "normalize";
+```
+
+(b) Append this helper at the end of the file (after `auditWikilinks`):
+
+```ts
+export interface WikilinkGateResult {
+  /** false only when mode === "strict" AND there are unresolvable/ambiguous links. */
+  ok: boolean;
+  /** The body to write (normalized when mode === "normalize", else the input). */
+  body: string;
+  /** Unresolved / ambiguous link diagnostics (empty for "off" / clean bodies). */
+  diagnostics: KnowledgeDiagnostic[];
+}
+
+/**
+ * Apply the pre-write wikilink gate to a body. Wraps {@link auditWikilinks}:
+ * blocks (ok:false) only in strict mode with issues, rewrites in normalize mode,
+ * and always returns the diagnostics so callers can surface them (warn/normalize).
+ */
+export function applyWikilinkGate(
+  body: string,
+  index: WikilinkIndex,
+  sourceId: string,
+  mode: WikilinkValidationMode,
+): WikilinkGateResult {
+  if (mode === "off") return { ok: true, body, diagnostics: [] };
+  const audit = auditWikilinks(body, index, sourceId, mode);
+  return {
+    ok: !(mode === "strict" && audit.diagnostics.length > 0),
+    body: mode === "normalize" ? audit.body : body,
+    diagnostics: audit.diagnostics,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run test/knowledge-links.test.ts`
+Expected: PASS (all existing + new `applyWikilinkGate` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/knowledge-links.ts test/knowledge-links.test.ts
+git commit -m "feat(wikilink): add applyWikilinkGate helper + document the two-axis modes"
+```
+
+---
+
+### Task 2: Gate `wiki_ensure_page`
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/tools.ts`
+- Test: `test/wikilink-gate.test.ts` (create — this task adds the `wiki_ensure_page` describe block; Task 3 adds the `wiki_retro` block to the same file)
+
+**Context:** In `registerWikiEnsurePage`'s `execute`, the current flow computes `const body = params.content ?? buildPageBody(type, params.title);` then `createKnowledgeDocument(..., body)` then `writeKnowledgeDocumentFile`. `paths` (VaultPaths) is in scope; `ctx.cwd` is the vault root. `readJson` and `join` are already imported in tools.ts. The tool returns `{ content: [{ type:"text", text }], details }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/wikilink-gate.test.ts`:
+
+```ts
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerWikiEnsurePage } from "../extensions/llm-wiki/lib/tools.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+
+interface Tool {
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+    s: undefined,
+    u: undefined,
+    ctx: unknown,
+  ) => Promise<{ isError?: boolean; content: Array<{ text: string }>; details: Record<string, unknown> }>;
+}
+
+function capture(fn: (pi: ExtensionAPI) => void): Tool {
+  let tool: Tool | undefined;
+  const pi = { registerTool: (def: unknown) => (tool = def as Tool) } as unknown as ExtensionAPI;
+  fn(pi);
+  if (!tool) throw new Error("tool not registered");
+  return tool;
+}
+
+let wikiDir: string;
+
+beforeEach(() => {
+  wikiDir = join(
+    import.meta.dirname,
+    "..",
+    "tmp",
+    `wg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  const llm = join(wikiDir, ".llm-wiki");
+  for (const d of ["wiki/entities", "wiki/concepts", "wiki/sources", "meta", "outputs"]) {
+    mkdirSync(join(llm, d), { recursive: true });
+  }
+  // config.json is required — both tools call inspectWritableVault, which hard-blocks
+  // on an absent/unreadable config (config_invalid_knowledge_format). Mirror retro.test.ts.
+  writeFileSync(
+    join(llm, "config.json"),
+    JSON.stringify({ topic: "Test", mode: "personal" }),
+  );
+  ensureVaultStructure(getVaultPaths(wikiDir));
+  // Seed the registry with one resolvable target so [[transformer]] resolves and [[ghost]] does not.
+  writeFileSync(
+    join(llm, "meta", "registry.json"),
+    JSON.stringify({
+      version: "1.0",
+      last_updated: "",
+      pages: { "concepts/transformer": { id: "concepts/transformer", title: "Transformer", type: "concept" } },
+    }),
+  );
+  // No .pi/settings.json here → default mode is "warn".
+});
+
+afterEach(() => {
+  try {
+    rmSync(wikiDir, { recursive: true, force: true }); // only this test's own root, never the shared test/tmp
+  } catch {}
+});
+
+function setMode(mode: string): void {
+  const cfg = join(wikiDir, ".pi");
+  mkdirSync(cfg, { recursive: true });
+  writeFileSync(join(cfg, "settings.json"), JSON.stringify({ "llm-wiki": { wikilinkValidation: mode } }));
+}
+
+describe("wiki_ensure_page wikilink gate", () => {
+  const content = "see [[transformer]] and [[ghost]]";
+
+  it("off → writes verbatim, no issues surfaced", async () => {
+    setMode("off");
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Ghost Concept", content },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const file = join(getVaultPaths(wikiDir).wiki, "concepts", "ghost-concept.md");
+    expect(existsSync(file)).toBe(true);
+    expect(res.details.wikilinkIssues).toEqual([]);
+  });
+
+  it("warn → writes, reports the missing link (transformer resolves, not reported)", async () => {
+    const tool = capture((pi) => registerWikiEnsurePage(pi)); // default warn
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Ghost Concept", content },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const issues = res.details.wikilinkIssues as string[];
+    expect(issues.length).toBe(1);
+    expect(issues[0]).toContain("ghost");
+  });
+
+  it("strict → rejects, writes nothing", async () => {
+    setMode("strict");
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Ghost Concept", content },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.details.error).toBe("link_validation");
+    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "concepts", "ghost-concept.md"))).toBe(false);
+  });
+
+  it("normalize → rewrites resolvable link, reports the missing one", async () => {
+    setMode("normalize");
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Ghost Concept", content },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const file = join(getVaultPaths(wikiDir).wiki, "concepts", "ghost-concept.md");
+    const text = readFileSync(file, "utf-8");
+    expect(text).toContain("[[concepts/transformer]]");
+    expect(text).toContain("[[ghost]]");
+  });
+});
+```
+
+> Note: add `readFileSync` to the `node:fs` import at the top (it is used in the `normalize` test).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/wikilink-gate.test.ts`
+Expected: FAIL — the `wiki_ensure_page` gate is not implemented (`res.details.wikilinkIssues` undefined; strict does not reject; normalize does not rewrite).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `extensions/llm-wiki/lib/tools.ts`:
+
+(a) Extend imports. Add `loadTaskConfig, resolveWikilinkValidation` to the existing task-config import line (currently `import { parseModelRef } from "./task-config.js";`):
+
+```ts
+import { parseModelRef, loadTaskConfig, resolveWikilinkValidation } from "./task-config.js";
+```
+
+Add a new import line (near the other `./` imports):
+
+```ts
+import { applyWikilinkGate, buildWikilinkIndex } from "./knowledge-links.js";
+```
+
+> `readJson` and `join` are already imported in tools.ts — do not re-import them.
+
+(b) In `registerWikiEnsurePage`'s `execute`, change `const body = params.content ?? buildPageBody(type, params.title);` to `let body = ...` and insert the gate immediately after it (before `const doc = createKnowledgeDocument(...)`):
+
+```ts
+      let body = params.content ?? buildPageBody(type, params.title);
+
+      // Pre-write wikilink gate (#172): validate/normalize caller-supplied content.
+      const mode = resolveWikilinkValidation(loadTaskConfig(ctx.cwd));
+      let wikilinkIssues: string[] = [];
+      if (mode !== "off") {
+        const registry = readJson<{ pages: Record<string, unknown> }>(
+          join(paths.meta, "registry.json"),
+          { pages: {} },
+        );
+        const gate = applyWikilinkGate(
+          body,
+          buildWikilinkIndex(Object.keys(registry.pages)),
+          `${folder}/${slug}`,
+          mode,
+        );
+        wikilinkIssues = gate.diagnostics.map((d) => d.message);
+        if (!gate.ok) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Rejected write — unresolved/ambiguous wikilinks:\n${wikilinkIssues
+                  .map((m) => `- ${m}`)
+                  .join("\n")}`,
+              },
+            ],
+            details: { error: "link_validation", issues: wikilinkIssues } as Record<string, unknown>,
+            isError: true,
+          };
+        }
+        if (mode === "normalize") body = gate.body;
+      }
+```
+
+(c) In the success `return` of `registerWikiEnsurePage`, append the note and the `wikilinkIssues` detail. Replace:
+
+```ts
+      return {
+        content: [{ type: "text", text: `✅ Created ${type} page: \`${pagePath}\`` }],
+        details: { path: pagePath, created: true } as Record<string, unknown>,
+      };
+```
+
+with:
+
+```ts
+      const gateNote = wikilinkIssues.length
+        ? `\n\n⚠️ ${wikilinkIssues.length} wikilink issue(s):\n${wikilinkIssues.map((m) => `- ${m}`).join("\n")}`
+        : "";
+      return {
+        content: [
+          { type: "text", text: `✅ Created ${type} page: \`${pagePath}\`${gateNote}` },
+        ],
+        details: {
+          path: pagePath,
+          created: true,
+          wikilinkIssues,
+        } as Record<string, unknown>,
+      };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run test/wikilink-gate.test.ts`
+Expected: PASS (4 `wiki_ensure_page` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/tools.ts test/wikilink-gate.test.ts
+git commit -m "feat(wikilink): gate wiki_ensure_page writes by wikilinkValidation mode"
+```
+
+---
+
+### Task 3: Gate `wiki_retro`
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/retro.ts`
+- Test: `test/wikilink-gate.test.ts` (append the `wiki_retro` describe block)
+
+**Context:** In `registerWikiRetro`'s `execute`, the flow resolves `paths = resolveVaultPaths(ctx.cwd ?? process.cwd())`, then `result = saveInsight(paths, params.slug, params.title, params.body, params.category, { rebuild: !runtime })`, then returns a multi-line success message. `params.body` is the caller-supplied markdown (the gate target). The success `details` currently is `{ slug, title, category }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/wikilink-gate.test.ts`. Add `registerWikiRetro` to the imports and `readFileSync` is already imported. Append this block at the end of the file (it reuses the same `beforeEach` vault + `setMode` + `capture` helpers):
+
+```ts
+import { registerWikiRetro } from "../extensions/llm-wiki/lib/retro.js";
+
+describe("wiki_retro wikilink gate", () => {
+  const body = "Learned about [[transformer]] and [[ghost]]";
+
+  it("warn (default) → saves, reports the missing link", async () => {
+    const tool = capture((pi) => registerWikiRetro(pi));
+    const res = await tool.execute(
+      "t",
+      { slug: "transformer-note", title: "Transformer Note", body },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const issues = res.details.wikilinkIssues as string[];
+    expect(issues.length).toBe(1);
+    expect(issues[0]).toContain("ghost");
+    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"))).toBe(true);
+  });
+
+  it("strict → rejects, writes nothing", async () => {
+    setMode("strict");
+    const tool = capture((pi) => registerWikiRetro(pi));
+    const res = await tool.execute(
+      "t",
+      { slug: "transformer-note", title: "Transformer Note", body },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.details.error).toBe("link_validation");
+    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"))).toBe(false);
+  });
+
+  it("normalize → saves with the resolvable link rewritten", async () => {
+    setMode("normalize");
+    const tool = capture((pi) => registerWikiRetro(pi));
+    const res = await tool.execute(
+      "t",
+      { slug: "transformer-note", title: "Transformer Note", body },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const text = readFileSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"), "utf-8");
+    expect(text).toContain("[[concepts/transformer]]");
+    expect(text).toContain("[[ghost]]");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/wikilink-gate.test.ts -t "wiki_retro wikilink gate"`
+Expected: FAIL — the `wiki_retro` gate is not implemented.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `extensions/llm-wiki/lib/retro.ts`:
+
+(a) Imports. Make these exact changes (retro.ts currently has `import { dirname, resolve } from "node:path";` on line 1 and `import { type VaultPaths, fmtDate, resolveVaultPaths } from "./utils.js";` on line 8):
+- Line 1: `import { dirname, resolve } from "node:path";` → `import { dirname, join, resolve } from "node:path";` (add `join`).
+- Line 8: add `readJson` → `import { type VaultPaths, fmtDate, readJson, resolveVaultPaths } from "./utils.js";`
+- Add two new import lines near the other `./` imports:
+
+```ts
+import { applyWikilinkGate, buildWikilinkIndex } from "./knowledge-links.js";
+import { loadTaskConfig, resolveWikilinkValidation } from "./task-config.js";
+```
+
+No `node:fs` import is needed — the gate only uses `readJson` (from utils) and `join` (from node:path).
+
+(b) In `registerWikiRetro`'s `execute`, insert the gate BEFORE the `try { result = saveInsight(...); }` block, and thread the (possibly normalized) body into `saveInsight`. Insert before the `let result: RetroResult;` line:
+
+```ts
+      // Pre-write wikilink gate (#172): validate/normalize caller-supplied body.
+      const mode = resolveWikilinkValidation(loadTaskConfig(ctx.cwd ?? process.cwd()));
+      let body = params.body;
+      let wikilinkIssues: string[] = [];
+      if (mode !== "off") {
+        const registry = readJson<{ pages: Record<string, unknown> }>(
+          join(paths.meta, "registry.json"),
+          { pages: {} },
+        );
+        const gate = applyWikilinkGate(
+          body,
+          buildWikilinkIndex(Object.keys(registry.pages)),
+          `sources/${params.slug}`,
+          mode,
+        );
+        wikilinkIssues = gate.diagnostics.map((d) => d.message);
+        if (!gate.ok) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Rejected write — unresolved/ambiguous wikilinks:\n${wikilinkIssues
+                  .map((m) => `- ${m}`)
+                  .join("\n")}`,
+              },
+            ],
+            details: { error: "link_validation", issues: wikilinkIssues } as Record<string, unknown>,
+            isError: true,
+          };
+        }
+        if (mode === "normalize") body = gate.body;
+      }
+```
+
+Then change the `saveInsight` call to use `body` instead of `params.body`:
+
+```ts
+        result = saveInsight(paths, params.slug, params.title, body, params.category, {
+          rebuild: !runtime,
+        });
+```
+
+(c) In the success `return`, append the note and `wikilinkIssues`. Replace the text array join and details:
+
+```ts
+      const gateNote = wikilinkIssues.length
+        ? `\n\n⚠️ ${wikilinkIssues.length} wikilink issue(s):\n${wikilinkIssues.map((m) => `- ${m}`).join("\n")}`
+        : "";
+      return {
+        content: [
+          {
+            type: "text",
+            text: [
+              `🧠 **Insight saved**: ${params.title}`,
+              "",
+              `- Page: \`${result.sourcePagePath}\``,
+              "",
+              "This insight will be auto-surfaced by wiki_recall in future sessions.",
+              gateNote,
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          },
+        ],
+        details: {
+          slug: params.slug,
+          title: params.title,
+          category: params.category || null,
+          wikilinkIssues,
+        } as Record<string, unknown>,
+      };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run test/wikilink-gate.test.ts`
+Expected: PASS (all `wiki_ensure_page` + `wiki_retro` gate tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/retro.ts test/wikilink-gate.test.ts
+git commit -m "feat(wikilink): gate wiki_retro writes by wikilinkValidation mode"
+```
+
+---
+
+### Task 4: Full gates
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Full suite + lint + typecheck**
+
+Run: `pnpm typecheck && pnpm lint && pnpm test`
+Expected: all green. Watch that pre-existing `wiki_retro`/`wiki_ensure_page` tests still pass (they omit a mode → default `warn`, which still writes and only adds an empty `wikilinkIssues` detail).
+
+- [ ] **Step 2: Format + build:commands parity**
+
+Run: `npx @biomejs/biome check --write extensions/llm-wiki/lib/knowledge-links.ts extensions/llm-wiki/lib/tools.ts extensions/llm-wiki/lib/retro.ts test/wikilink-gate.test.ts test/knowledge-links.test.ts && pnpm build:commands && pnpm test`
+Expected: clean; re-run tests after the format pass.
+
+- [ ] **Step 3: Commit if the format pass changed anything**
+
+```bash
+git add -A && git commit -m "style(wikilink): biome format on ensure_page/retro gate files"
+```
+
+> **Deploy note (not a code step):** pi loads this from the source path. After merging, a **full pi restart** makes it live. Verify by calling `wiki_ensure_page` (or `wiki_retro`) with a body containing a link to a nonexistent page and confirming the return names the issue (default `warn`). To block, set `"wikilinkValidation": "strict"` under the `llm-wiki` key in settings.
+
+---
+
+## Self-Review
+
+**Spec/roadmap coverage:**
+- #172 "pre-write link validation for `wiki_ensure_page` / `wiki_retro`" → Task 2 (ensure_page) + Task 3 (retro) + Task 1 (shared helper). ✅
+- All four modes, default `warn` → Task 1 helper + Tasks 2–3 wiring (reuses existing `resolveWikilinkValidation` default). ✅
+- Two-axis doc comment → Task 1 Step 3(a). ✅
+- Composition with Layer 1 (resolvable links normalized, not flagged) → Task 1 tests assert this; encoded in `auditWikilinks` (unchanged). ✅
+- Ingest gate preserved (not touched) → out of this plan's edits. ✅
+
+**Placeholder scan:** Every step has exact code, exact commands, expected output. No TBD/TODO. ✅
+
+**Type consistency:**
+- `applyWikilinkGate(body, index, sourceId, mode): WikilinkGateResult` defined once (Task 1) and used identically in Tasks 2–3. ✅
+- `WikilinkGateResult` = `{ ok, body, diagnostics }` consistent across def and both call sites. ✅
+- Reuses existing `auditWikilinks` / `buildWikilinkIndex` / `resolveWikilinkValidation` / `loadTaskConfig` / `readJson` — no redefinition. ✅
+- Success-detail field `wikilinkIssues: string[]` consistent between both tools and the tests. ✅
+
+**Phase boundary health:** Single plan; after Task 4 the direct-tool gate is complete, default `warn` is non-destructive (writes always proceed, only reports), all gates green. New behavior is additive: the only new thing on the default path is an (often empty) `wikilinkIssues` detail + an optional report note. Pre-existing tests pass because `warn` never blocks or mutates. MCP `retroOperation` is intentionally out of scope (follow-up). ✅

--- a/docs/superpowers/plans/2026-08-29-wikilink-write-validation.md
+++ b/docs/superpowers/plans/2026-08-29-wikilink-write-validation.md
@@ -198,15 +198,13 @@ git commit -m "feat(wikilink): add wikilinkValidation setting + resolver (defaul
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `test/knowledge-links.test.ts`:
+Two edits to `test/knowledge-links.test.ts`:
+
+1. Add `auditWikilinks` to the **existing** top-of-file import (the one that already imports `buildResolvedBacklinks`, `buildWikilinkIndex`, `extractKnowledgeLinks`, `extractLegacyWikilinks`). Do NOT add a second import statement from this module.
+2. Append this `describe` block to the **end** of the file. `buildWikilinkIndex` is already imported at the top, so it is used directly (no alias, no new import):
 
 ```ts
-import { auditWikilinks } from "../extensions/llm-wiki/lib/knowledge-links.js";
-import {
-  buildWikilinkIndex as bi,
-} from "../extensions/llm-wiki/lib/knowledge-links.js";
-
-const idx = bi([
+const idx = buildWikilinkIndex([
   "entities/alice",
   "concepts/transformer",
   "concepts/attention",
@@ -228,7 +226,7 @@ describe("auditWikilinks", () => {
   });
 
   it("warn flags ambiguous when a bare target matches multiple pages", () => {
-    const ambiguous = bi(["entities/alice", "concepts/alice"]);
+    const ambiguous = buildWikilinkIndex(["entities/alice", "concepts/alice"]);
     const r = auditWikilinks("who is [[alice]]?", ambiguous, "SRC-001", "warn");
     const amb = r.diagnostics.find((d) => d.code === "link_ambiguous");
     expect(amb).toBeDefined();

--- a/docs/superpowers/plans/2026-08-29-wikilink-write-validation.md
+++ b/docs/superpowers/plans/2026-08-29-wikilink-write-validation.md
@@ -1,0 +1,697 @@
+# Wikilink Pre-Write Validation & Normalization (Layer 2, issue #172) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use /skill:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate the deterministic ingest write path (`commitSynthesis`) so wikilinks in an ingested source body are validated/normalized before pages are written, per a new `wikilinkValidation` setting (default `warn`).
+
+**Architecture:** A pure helper `auditWikilinks(body, index, sourceId, mode)` reuses the existing `extractKnowledgeLinks` + `resolveWikilink` from Layer 1. It returns diagnostics (`link_unresolved`/`link_ambiguous`) and, in `normalize` mode, a rewritten body where resolvable targets are replaced by their canonical page id. `commitSynthesis` — the single choke point for background ingest writes — builds an index from the existing registry **plus the pages this commit creates** (so same-batch links don't false-positive), runs the gate on the source body, and per mode: `off` (no-op), `warn` (collect diagnostics, write proceeds), `strict` (block the write, return `ok:false`), `normalize` (rewrite the body, then write). The mode is threaded from `runtime.config` through `runIngestSynthesis` into `commitSynthesis`, exactly mirroring the existing `synthesisLanguage` plumbing.
+
+**Tech Stack:** TypeScript (ESM, ES2022), Vitest, `node:fs`, existing `knowledge-links.ts` resolver (Layer 1).
+
+**Roadmap:** None
+
+**Phase:** Single-plan implementation
+
+---
+
+## Scope (decided with user)
+
+- **Default mode: `warn`.** Ingest always writes; broken links are reported, not blocked, unless the user opts into `strict`.
+- **Write path: ingest only.** `commitSynthesis` is the deterministic background-ingest writer (the default `wiki_ingest` path). The other write paths (retro/observe/lint-stub, and the `background:false` manual path where the main agent writes directly) are **out of scope** — follow-up.
+- **Body gated: the ingested SOURCE body only.** Entity/concept pages are generated one-line templates whose only wikilink is the self-reference `[[sources/<id>]]` (always resolves). The model-authored links all live in the source body (`summary`, `key_takeaways`, `quotes`). Auditing only the source body is the lazy-correct scope; description-field auditing is a follow-up if needed.
+- **Normalization is alias-safe:** it rewrites only the link *target* token (via the same regex the parser uses), preserving any `|alias`, so no structural link is ever corrupted.
+
+## File Structure
+
+- **Modify** `extensions/llm-wiki/lib/task-config.ts` — add `WikilinkValidationMode` usage to the `TaskConfig` interface, a `resolveWikilinkValidation()` resolver, and the `KNOWN_KEYS` entry.
+- **Modify** `extensions/llm-wiki/lib/knowledge-links.ts` — export `auditWikilinks()` + `WikilinkAuditResult` (the `WikilinkValidationMode` type was already added in Task 1).
+- **Modify** `extensions/llm-wiki/lib/ingest-worker.ts` — add `wikilinkValidation?` param to `commitSynthesis`, `wikilinkDiagnostics?` to `CommitResult`, and `wikilinkValidation?` to `RunIngestSynthesisArgs`; wire the gate into `commitSynthesis` and thread the mode through `runIngestSynthesis`.
+- **Modify** `extensions/llm-wiki/lib/tools.ts` — pass `runtime.config.wikilinkValidation` into `runIngestSynthesis` and surface diagnostic counts in the ingest report line.
+- **Test** `test/knowledge-links.test.ts` (append — `auditWikilinks` unit tests).
+- **Test** `test/ingest-worker.test.ts` (append — `commitSynthesis` gate integration tests).
+- **Test** `test/task-config.test.ts` (create — `resolveWikilinkValidation` unit tests).
+
+---
+
+### Task 1: Config type + resolver
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/knowledge-links.ts` (add the `WikilinkValidationMode` type only)
+- Modify: `extensions/llm-wiki/lib/task-config.ts`
+- Test: `test/task-config.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/task-config.test.ts`:
+
+```ts
+import { mkdirSync, rmSync, writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  loadTaskConfig,
+  resolveWikilinkValidation,
+  type TaskConfig,
+} from "../extensions/llm-wiki/lib/task-config.js";
+
+describe("resolveWikilinkValidation", () => {
+  it("defaults to warn when unset/undefined", () => {
+    expect(resolveWikilinkValidation(undefined)).toBe("warn");
+    expect(resolveWikilinkValidation({})).toBe("warn");
+  });
+
+  it("returns an explicit valid mode", () => {
+    for (const m of ["off", "warn", "strict", "normalize"] as const) {
+      const config: TaskConfig = { wikilinkValidation: m };
+      expect(resolveWikilinkValidation(config)).toBe(m);
+    }
+  });
+
+  it("falls back to warn on an invalid value", () => {
+    const config = { wikilinkValidation: "bogus" } as unknown as TaskConfig;
+    expect(resolveWikilinkValidation(config)).toBe("warn");
+  });
+
+  it("reads wikilinkValidation from the llm-wiki settings namespace", () => {
+    const project = mkdtempSync(join(tmpdir(), "wl-"));
+    try {
+      mkdirSync(join(project, ".omp"), { recursive: true });
+      writeFileSync(
+        join(project, ".omp", "settings.json"),
+        JSON.stringify({ "llm-wiki": { wikilinkValidation: "strict" } }),
+      );
+      // The settings value must flow through readNamespacedConfig into TaskConfig.
+      expect(resolveWikilinkValidation(loadTaskConfig(project))).toBe("strict");
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+> The `.omp/settings.json` write pattern mirrors `test/ambient-gate.test.ts` (the host the test suite detects). If the test env detects a different host, write to that host's settings path instead — the assertion on `loadTaskConfig(project)` is what matters.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/task-config.test.ts`
+Expected: FAIL — `resolveWikilinkValidation` is not exported from `task-config.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+**Prep — the mode type lives in `knowledge-links.ts`** (owned here so `task-config.ts` can import it before Task 2's helper exists). Append to `extensions/llm-wiki/lib/knowledge-links.ts`:
+
+```ts
+export type WikilinkValidationMode = "off" | "warn" | "strict" | "normalize";
+```
+
+Then in `extensions/llm-wiki/lib/task-config.ts`:
+
+(a) Add the import at the top (with the other `./` imports):
+
+```ts
+import type { WikilinkValidationMode } from "./knowledge-links.js";
+```
+
+(b) Add this field to the `TaskConfig` interface (place it right after the `synthesisMaxTokens?: number;` field, before the closing `}`):
+
+```ts
+  /**
+   * Wikilink gate applied to the ingested source body before pages are
+   * written (issue #172, Layer 2). Reuses the Layer 1 resolver.
+   *   - "off"       : no-op.
+   *   - "warn"      : write proceeds; unresolved/ambiguous links are reported.
+   *   - "strict"    : block the write (commit returns ok:false) if any link is unresolvable.
+   *   - "normalize" : rewrite resolvable links to their canonical id, then write.
+   * Default "warn". See `resolveWikilinkValidation`.
+   */
+  wikilinkValidation?: WikilinkValidationMode;
+```
+
+(c) Add the resolver, next to `noticesEnabled` (after the `noticesEnabled` function):
+
+```ts
+const WIKILINK_VALIDATION_MODES: readonly WikilinkValidationMode[] = [
+  "off",
+  "warn",
+  "strict",
+  "normalize",
+];
+
+/**
+ * Resolve the wikilink write-gate mode (issue #172, Layer 2). Defaults to
+ * `warn` — ingest always writes and reports; only an explicit `strict` blocks.
+ * Unknown values fall back to `warn` rather than failing the ingest.
+ */
+export function resolveWikilinkValidation(
+  config: TaskConfig | undefined,
+): WikilinkValidationMode {
+  const v = config?.wikilinkValidation;
+  if (v && (WIKILINK_VALIDATION_MODES as readonly string[]).includes(v)) return v;
+  return "warn";
+}
+```
+
+(d) Add `"wikilinkValidation"` to the `KNOWN_KEYS` array (after `"synthesisMaxTokens"`):
+
+```ts
+  "wikilinkValidation",
+```
+
+(e) Add a parse branch to `readNamespacedConfig` so the value actually reaches `TaskConfig`. This function copies settings keys **explicitly, one branch per key** — the `TaskConfig` field and `KNOWN_KEYS` entry alone do NOT make a settings value flow through. Insert this after the `synthesisMaxTokens` block (after `out.synthesisMaxTokens = Math.floor(maxTokens);`):
+
+```ts
+    const wl = section.wikilinkValidation;
+    if (
+      typeof wl === "string" &&
+      (WIKILINK_VALIDATION_MODES as readonly string[]).includes(wl)
+    ) {
+      out.wikilinkValidation = wl as WikilinkValidationMode;
+    }
+```
+
+> `wl` narrows to `string` (not the union) via `typeof wl === "string"`; the `.includes` guard already proves it is a valid mode, so the `as WikilinkValidationMode` cast is safe and required for `tsc` (Vitest does not typecheck — this would only fail at `pnpm typecheck` in Task 5 if omitted).
+
+> `WIKILINK_VALIDATION_MODES` is the module-level const defined in step (c) above; the `readNamespacedConfig` body runs at call time, after module evaluation, so declaration order does not matter.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run test/task-config.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/task-config.ts test/task-config.test.ts
+git commit -m "feat(wikilink): add wikilinkValidation setting + resolver (default warn)"
+```
+
+---
+
+### Task 2: `auditWikilinks` helper
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/knowledge-links.ts`
+- Test: `test/knowledge-links.test.ts` (append)
+
+**Context (already in this file):** `buildWikilinkIndex(ids: Iterable<string>)`, `resolveWikilink(target, index): WikilinkResolution` where `WikilinkResolution` is the union `{ kind: "resolved"; id: string } | { kind: "ambiguous"; target: string; candidates: string[] } | { kind: "missing"; target: string }` (note: **`kind`/`id`**, not `status`/`canonicalId`), `extractKnowledgeLinks(body).wikilinks` (array of `{target, offset}`), `normalizeWikilinkTarget(raw)`, the imported `KnowledgeDiagnostic` type, and `WikilinkValidationMode` (added in Task 1). The parser regex is `/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/knowledge-links.test.ts`:
+
+```ts
+import { auditWikilinks } from "../extensions/llm-wiki/lib/knowledge-links.js";
+import {
+  buildWikilinkIndex as bi,
+} from "../extensions/llm-wiki/lib/knowledge-links.js";
+
+const idx = bi([
+  "entities/alice",
+  "concepts/transformer",
+  "concepts/attention",
+  "concepts/other-page",
+]);
+
+describe("auditWikilinks", () => {
+  it("off returns no diagnostics and unchanged body", () => {
+    const r = auditWikilinks("see [[ghost]]", idx, "SRC-001", "off");
+    expect(r.diagnostics).toEqual([]);
+    expect(r.body).toBe("see [[ghost]]");
+    expect(r.changed).toBe(false);
+  });
+
+  it("warn reports an unresolved link and leaves the body untouched", () => {
+    const r = auditWikilinks("bad [[ghost]]", idx, "SRC-001", "warn");
+    expect(r.body).toBe("bad [[ghost]]");
+    expect(r.diagnostics.map((d) => d.code)).toContain("link_unresolved");
+  });
+
+  it("warn flags ambiguous when a bare target matches multiple pages", () => {
+    const ambiguous = bi(["entities/alice", "concepts/alice"]);
+    const r = auditWikilinks("who is [[alice]]?", ambiguous, "SRC-001", "warn");
+    const amb = r.diagnostics.find((d) => d.code === "link_ambiguous");
+    expect(amb).toBeDefined();
+    expect(r.body).toBe("who is [[alice]]?");
+  });
+
+  it("normalize rewrites resolvable targets to canonical id, preserves alias", () => {
+    const body = "see [[transformer|TF]] and [[alice]]";
+    const r = auditWikilinks(body, idx, "SRC-001", "normalize");
+    expect(r.body).toBe("see [[concepts/transformer|TF]] and [[entities/alice]]");
+    expect(r.changed).toBe(true);
+  });
+
+  it("normalize leaves unresolvable links verbatim", () => {
+    const r = auditWikilinks("see [[ghost]]", idx, "SRC-001", "normalize");
+    expect(r.body).toBe("see [[ghost]]");
+    expect(r.changed).toBe(false);
+  });
+
+  it("normalize is a no-op when every link is already canonical", () => {
+    const r = auditWikilinks("see [[concepts/attention]]", idx, "SRC-001", "normalize");
+    expect(r.body).toBe("see [[concepts/attention]]");
+    expect(r.changed).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/knowledge-links.test.ts -t auditWikilinks`
+Expected: FAIL — `auditWikilinks` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to the end of `extensions/llm-wiki/lib/knowledge-links.ts` (the `WikilinkValidationMode` type was already added in Task 1 — do NOT redefine it):
+
+```ts
+// ── Pre-write validation & normalization (issue #172, Layer 2) ─────────
+
+export interface WikilinkAuditResult {
+  /** Unresolved / ambiguous link diagnostics (empty for "off" / clean bodies). */
+  diagnostics: KnowledgeDiagnostic[];
+  /** The body after normalization (identical to input unless normalize rewrote links). */
+  body: string;
+  /** True only when normalize changed the body. */
+  changed: boolean;
+}
+
+const WIKILINK_REPLACE_RE = /\[\[([^\]|]+)(\|[^\]]*)?\]\]/g;
+
+/**
+ * Audit a markdown body's wikilinks against the page index.
+ *
+ * - Collects `link_unresolved` / `link_ambiguous` diagnostics for every link
+ *   that does not resolve to exactly one page (skipped for "off").
+ * - In "normalize" mode, additionally rewrites each link that DOES resolve to
+ *   its canonical page id. Only the target token is replaced (the parser's own
+ *   regex is reused), so `|alias`, escaping, and surrounding text are preserved.
+ *
+ * Pure: no I/O. The caller supplies the index (typically `buildWikilinkIndex`
+ * over existing page ids plus the ids created by the same commit).
+ */
+export function auditWikilinks(
+  body: string,
+  index: WikilinkIndex,
+  sourceId: string,
+  mode: WikilinkValidationMode,
+): WikilinkAuditResult {
+  if (mode === "off") return { diagnostics: [], body, changed: false };
+
+  const diagnostics: KnowledgeDiagnostic[] = [];
+  for (const { target } of extractKnowledgeLinks(body).wikilinks) {
+    const resolved = resolveWikilink(target, index);
+    if (resolved.kind === "ambiguous") {
+      diagnostics.push({
+        severity: "warning",
+        code: "link_ambiguous",
+        path: sourceId,
+        message: `Wikilink target "${target}" matches multiple pages (${resolved.candidates.join(", ")}).`,
+      });
+    } else if (resolved.kind === "missing") {
+      diagnostics.push({
+        severity: "warning",
+        code: "link_unresolved",
+        path: sourceId,
+        message: `Wikilink target "${target}" does not match any page.`,
+      });
+    }
+  }
+
+  let out = body;
+  if (mode === "normalize") {
+    out = body.replace(WIKILINK_REPLACE_RE, (full, raw: string, alias: string | undefined) => {
+      const resolved = resolveWikilink(normalizeWikilinkTarget(raw), index);
+      return resolved.kind === "resolved"
+        ? `[[${resolved.id}${alias ?? ""}]]`
+        : full;
+    });
+  }
+
+  return { diagnostics, body: out, changed: out !== body };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run test/knowledge-links.test.ts`
+Expected: PASS (existing + new `auditWikilinks` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/knowledge-links.ts test/knowledge-links.test.ts
+git commit -m "feat(wikilink): add auditWikilinks (warn/strict/normalize, alias-safe)"
+```
+
+---
+
+### Task 3: Wire the gate into `commitSynthesis`
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/ingest-worker.ts`
+- Test: `test/ingest-worker.test.ts` (append)
+
+**Context (already imported in this file):** `join`, `existsSync`, `readKnowledgeDocumentFile`, `writeKnowledgeDocumentFile`, `createKnowledgeDocument`, `patchKnowledgeDocument`, `buildIngestedSourcePageBody` (local), `slugify`, `VaultPaths`. The existing test file uses `getVaultPaths(wikiDir)` + `ensureVaultStructure(paths)` to build a vault and calls `commitSynthesis(paths, "SRC-001", MANIFEST, DATA, "2026-06-06")`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/ingest-worker.test.ts`. Reuse the file's existing `MANIFEST`, and its `beforeEach`/`afterEach` vault scaffolding (`wikiDir`, `getVaultPaths`, `ensureVaultStructure`). Follow the exact variable names those hooks already declare.
+
+```ts
+import { auditWikilinks } from "../extensions/llm-wiki/lib/knowledge-links.js";
+
+describe("commitSynthesis wikilink gate", () => {
+  function makeData(summary: string): SynthesisData {
+    return {
+      summary,
+      key_takeaways: ["a"],
+      entities: [{ title: "Alice", description: "A person." }],
+      concepts: [{ title: "Transformer", definition: "An architecture." }],
+    };
+  }
+
+  it("strict blocks the write and returns ok:false on an unresolved link", () => {
+    const paths = getVaultPaths(wikiDir);
+    const res = commitSynthesis(
+      paths,
+      "SRC-001",
+      MANIFEST,
+      makeData("See [[ghost-page]] for details."),
+      "2026-06-06",
+      undefined,
+      "strict",
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.diagnostics.map((d) => d.code)).toContain("link_unresolved");
+    }
+    // Nothing was written:
+    expect(existsSync(join(paths.wiki, "sources", "SRC-001.md"))).toBe(false);
+    expect(existsSync(join(paths.wiki, "entities", "alice.md"))).toBe(false);
+  });
+
+  it("warn writes and attaches wikilinkDiagnostics", () => {
+    const paths = getVaultPaths(wikiDir);
+    const res = commitSynthesis(
+      paths,
+      "SRC-001",
+      MANIFEST,
+      makeData("See [[ghost-page]] for details."),
+      "2026-06-06",
+      undefined,
+      "warn",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.wikilinkDiagnostics?.map((d) => d.code)).toContain("link_unresolved");
+    }
+    expect(existsSync(join(paths.wiki, "sources", "SRC-001.md"))).toBe(true);
+  });
+
+  it("normalize rewrites resolvable links to canonical ids in the written page", () => {
+    const paths = getVaultPaths(wikiDir);
+    // [[transformer]] resolves because makeData() creates a "Transformer" concept
+    // in the SAME commit — buildIngestAuditIndex adds concepts/transformer to the
+    // index, so no pre-existing page is needed (this also proves same-batch links resolve).
+    const res = commitSynthesis(
+      paths,
+      "SRC-001",
+      MANIFEST,
+      makeData("The [[transformer|T]] changed everything."),
+      "2026-06-06",
+      undefined,
+      "normalize",
+    );
+    expect(res.ok).toBe(true);
+    const written = readFileSync(join(paths.wiki, "sources", "SRC-001.md"), "utf-8");
+    expect(written).toContain("[[concepts/transformer|T]]");
+  });
+
+  it("off is a no-op (writes verbatim, no diagnostics)", () => {
+    const paths = getVaultPaths(wikiDir);
+    const res = commitSynthesis(
+      paths,
+      "SRC-001",
+      MANIFEST,
+      makeData("See [[ghost-page]] for details."),
+      "2026-06-06",
+      undefined,
+      "off",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.wikilinkDiagnostics).toBeUndefined();
+    const written = readFileSync(join(paths.wiki, "sources", "SRC-001.md"), "utf-8");
+    expect(written).toContain("[[ghost-page]]");
+  });
+
+  it("defaults to warn when mode is omitted", () => {
+    const paths = getVaultPaths(wikiDir);
+    const res = commitSynthesis(
+      paths,
+      "SRC-001",
+      MANIFEST,
+      makeData("See [[ghost-page]] for details."),
+      "2026-06-06",
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.wikilinkDiagnostics?.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/ingest-worker.test.ts -t "wikilink gate"`
+Expected: FAIL — `commitSynthesis` has no 7th param / `CommitResult` has no `wikilinkDiagnostics`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `extensions/llm-wiki/lib/ingest-worker.ts`:
+
+(a) Extend the imports. Add `readJson` to the existing `./utils.js` import line, and add a new import line for the gate:
+
+```ts
+import { VaultPaths, fmtDate, slugify, readJson } from "./utils.js";
+import { auditWikilinks, buildWikilinkIndex } from "./knowledge-links.js";
+import { resolveWikilinkValidation, type WikilinkValidationMode } from "./task-config.js";
+```
+
+> If `readJson` is already imported from `./utils.js` on that line, just add it to the existing import list rather than duplicating the line.
+
+(b) Add `wikilinkDiagnostics?` to the `CommitResult` interface (after `contradictions: number;`):
+
+```ts
+  /** Wikilink gate diagnostics from `commitSynthesis` (warn/normalize modes). */
+  wikilinkDiagnostics?: KnowledgeDiagnostic[];
+```
+
+(`KnowledgeDiagnostic` is already imported from `./knowledge-document.js` in this file.)
+
+(c) Add a small local helper just above `commitSynthesis`:
+
+```ts
+/**
+ * Build the wikilink index used by the pre-write gate: every existing page id
+ * (from the registry) plus the page ids this commit is about to create, so a
+ * link to a sibling created in the same ingest resolves instead of
+ * false-positiving as missing.
+ */
+function buildIngestAuditIndex(
+  paths: VaultPaths,
+  sourceId: string,
+  data: SynthesisData,
+): ReturnType<typeof buildWikilinkIndex> {
+  const registry = readJson<{ pages: Record<string, unknown> }>(
+    join(paths.meta, "registry.json"),
+    { pages: {} },
+  );
+  const newIds = [
+    `sources/${sourceId}`,
+    ...data.entities
+      .filter((e) => slugify(e.title))
+      .map((e) => `entities/${slugify(e.title)}`),
+    ...data.concepts
+      .filter((c) => slugify(c.title))
+      .map((c) => `concepts/${slugify(c.title)}`),
+  ];
+  return buildWikilinkIndex([...Object.keys(registry.pages), ...newIds]);
+}
+```
+
+(d) Change the `commitSynthesis` signature — add the trailing `wikilinkValidation?` param:
+
+```ts
+export function commitSynthesis(
+  paths: VaultPaths,
+  sourceId: string,
+  manifest: Record<string, unknown>,
+  data: SynthesisData,
+  date: string = fmtDate(),
+  lang?: string,
+  wikilinkValidation?: WikilinkValidationMode,
+): CommitSynthesisOutcome {
+```
+
+(e) In the body, after the `assertWritableVault` try/catch block and before the `// Patch existing documents...` comment, compute the gated source body:
+
+```ts
+  // Pre-write wikilink gate (issue #172, Layer 2). Applies only to the
+  // model-authored source body; entity/concept pages are generated templates.
+  const mode = resolveWikilinkValidation({ wikilinkValidation });
+  let sourceBody = buildIngestedSourcePageBody(manifest, data, date, lang);
+  if (mode !== "off") {
+    const audit = auditWikilinks(sourceBody, buildIngestAuditIndex(paths, sourceId, data), sourceId, mode);
+    if (mode === "strict" && audit.diagnostics.length > 0) {
+      return { ok: false, sourceId, diagnostics: audit.diagnostics };
+    }
+    if (mode === "normalize") sourceBody = audit.body;
+    if (audit.diagnostics.length > 0) result.wikilinkDiagnostics = audit.diagnostics;
+  }
+```
+
+(f) Replace both inline `buildIngestedSourcePageBody(manifest, data, date, lang)` calls in the source-document branch with `sourceBody`:
+
+```ts
+    sourceDocument = patchKnowledgeDocument(parsed.document, {
+      fields: { status: "ingested", updated: date },
+      body: sourceBody,
+    });
+```
+
+and
+
+```ts
+      sourceBody,
+```
+
+(as the third argument to `createKnowledgeDocument` in the `else` branch).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run test/ingest-worker.test.ts`
+Expected: PASS (existing `commitSynthesis` tests unchanged — they omit the 7th param and thus run in `warn` default, which still writes and is compatible with prior assertions; new gate tests pass).
+
+> If an existing assertion breaks because a pre-existing test fixture now produces wikilink diagnostics that changed a count it asserts on, do NOT weaken the new gate — inspect the fixture. The only expected change is the new optional `wikilinkDiagnostics` field; existing asserted fields are untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/ingest-worker.ts test/ingest-worker.test.ts
+git commit -m "feat(wikilink): gate commitSynthesis writes by wikilinkValidation mode"
+```
+
+---
+
+### Task 4: Thread the mode through `runIngestSynthesis` + the tool report
+
+**Files:**
+- Modify: `extensions/llm-wiki/lib/ingest-worker.ts`
+- Modify: `extensions/llm-wiki/lib/tools.ts`
+
+- [ ] **Step 1: Add the arg to `RunIngestSynthesisArgs`**
+
+In `ingest-worker.ts`, add to the `RunIngestSynthesisArgs` interface (after `synthesisMaxTokens?: number;`):
+
+```ts
+  /** Wikilink write-gate mode for the ingested source body (issue #172). */
+  wikilinkValidation?: WikilinkValidationMode;
+```
+
+- [ ] **Step 2: Thread it into `commitSynthesis`**
+
+In `runIngestSynthesis`, add `wikilinkValidation` to the `const { ... } = args;` destructuring block, and pass it as the 7th argument in the `commitSynthesis(...)` call inside `commitTool.execute`:
+
+```ts
+      const outcome = commitSynthesis(
+        paths,
+        sourceId,
+        manifest,
+        params,
+        undefined,
+        synthesisLanguage,
+        wikilinkValidation,
+      );
+```
+
+- [ ] **Step 3: Pass the configured mode from the tool**
+
+In `tools.ts`, in the `runtime.launchTask(...)` callback where `runIngestSynthesis({...})` is called, add the arg alongside the existing `synthesisLanguage`:
+
+```ts
+                synthesisLanguage: runtime.config.synthesisLanguage,
+                wikilinkValidation: runtime.config.wikilinkValidation,
+```
+
+- [ ] **Step 4: Surface diagnostics in the report line**
+
+In `tools.ts`, in the same `launchTask` callback, update the summary so warn/normalize diagnostics are visible. Replace the `const summary = committed ? ... : ...` block with:
+
+```ts
+              const wl = committed?.wikilinkDiagnostics?.length ?? 0;
+              const wlNote = wl > 0 ? `, ${wl} wikilink issue${wl === 1 ? "" : "s"}` : "";
+              const summary = committed
+                ? `LLM Wiki: ingested ${s.id} → ${committed.entitiesCreated.length} entit${committed.entitiesCreated.length === 1 ? "y" : "ies"}, ${committed.conceptsCreated.length} concept${committed.conceptsCreated.length === 1 ? "" : "s"}${wlNote}`
+                : `LLM Wiki: ${s.id} produced no synthesis`;
+```
+
+- [ ] **Step 5: Verify types + run affected tests**
+
+Run: `pnpm typecheck && pnpm vitest run test/ingest-worker.test.ts test/ingest-tool.test.ts`
+Expected: typecheck clean; tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add extensions/llm-wiki/lib/ingest-worker.ts extensions/llm-wiki/lib/tools.ts
+git commit -m "feat(wikilink): thread wikilinkValidation through runIngestSynthesis + report"
+```
+
+---
+
+### Task 5: Full gates + deploy note
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Run the full suite + lint + typecheck**
+
+Run: `pnpm typecheck && pnpm lint && pnpm test`
+Expected: all green.
+
+- [ ] **Step 2: Verify `build:commands` parity is unaffected**
+
+Run: `pnpm build:commands && pnpm test`
+Expected: no new prompt/parite failures (no `prompts/` files touched).
+
+- [ ] **Step 3: Commit (if any test fixtures adjusted in Step 4 of Task 3)**
+
+```bash
+git add -A && git commit -m "test(wikilink): green full suite"
+```
+
+> **Deploy note (not a code step):** pi loads this extension from the source path (`../../code/pi-packages/pi-llm-wiki` in `~/.pi/agent/settings.json`). After merging, a **full pi restart** makes it live (a `/reload` does not swap the extension). Verify by ingesting a source whose summary contains a known-broken link and reading the **ingest report line** (`runtime.report(...)`) — it should now append `N wikilink issue(s)` (the Task 4 feature). Do NOT verify via `/wiki-lint`: lint already surfaced broken links before this change and will not behave differently. To enable blocking, set `"wikilinkValidation": "strict"` (or `"normalize"`) under the `llm-wiki` key in settings.
+
+---
+
+## Self-Review
+
+**Spec/roadmap coverage:**
+- #172 "pre-write wikilink validation and normalization" → Task 2 (helper) + Task 3 (gate at write) + Task 1 (config) + Task 4 (wiring/report). ✅
+- Modes `off|warn|strict|normalize` → Task 1 resolver + Task 2 helper + Task 3 gate. ✅
+- Default `warn` (user decision) → Task 1 resolver. ✅
+- **Settings → config flow** (so a user setting actually reaches the gate) → Task 1 Step 3(e) `readNamespacedConfig` branch + the settings-namespace flow test in Task 1 Step 1. ✅
+- Ingest-only scope, source-body-only gate (decided) → Task 3 (documented in scope). ✅
+
+**Placeholder scan:** All steps contain exact code, exact commands, and expected output. No "TBD"/"add appropriate handling". ✅
+
+**Type consistency:**
+- `WikilinkValidationMode` defined once (Task 1, `knowledge-links.ts`); Task 1 imports it into `task-config.ts`; Task 2 uses it in `auditWikilinks`; Task 3 imports it into `ingest-worker.ts`. One definition, no drift. ✅
+- `auditWikilinks(body, index, sourceId, mode): WikilinkAuditResult` signature identical in Task 2 def and Task 3 usage. ✅
+- `commitSynthesis` 7th param `wikilinkValidation?: WikilinkValidationMode` consistent across def (Task 3) and `runIngestSynthesis` call (Task 4). ✅
+- `CommitResult.wikilinkDiagnostics?: KnowledgeDiagnostic[]` consistent across Task 3 (def + set) and Task 4 (report read `committed?.wikilinkDiagnostics?.length`). ✅
+- `resolveWikilinkValidation(config?)` Task 1 def; Task 3 calls `resolveWikilinkValidation({ wikilinkValidation })` — valid (accepts `TaskConfig | undefined`). ✅
+- `resolveWikilink` API: Task 2 uses the real `kind`/`id` union (NOT `status`/`canonicalId`) — matches `knowledge-links.ts` `WikilinkResolution`. ✅
+- `readNamespacedConfig` branch (Task 1 Step 3e) uses the same `WIKILINK_VALIDATION_MODES` const and sets `out.wikilinkValidation`, matching the `TaskConfig` field. ✅
+
+**Phase boundary health:** Single plan; after Task 5 the feature is complete, default `warn` is non-destructive (writes always proceed, only reports), and all gates are green. No half-migrations: the new config field is optional with a default; the new `commitSynthesis` param is optional; `CommitResult.wikilinkDiagnostics` is optional. Existing callers omitting the new params keep prior behavior (default `warn`, which still writes). ✅

--- a/extensions/llm-wiki/lib/ingest-worker.ts
+++ b/extensions/llm-wiki/lib/ingest-worker.ts
@@ -506,6 +506,8 @@ export interface RunIngestSynthesisArgs {
   synthesisLanguage?: string;
   /** Max output tokens for synthesizer sub-agent (issue #160). Default 16384. */
   synthesisMaxTokens?: number;
+  /** Wikilink write-gate mode for the ingested source body (issue #172). */
+  wikilinkValidation?: WikilinkValidationMode;
 }
 
 /**
@@ -528,6 +530,7 @@ export async function runIngestSynthesis(
     signal,
     synthesisLanguage,
     synthesisMaxTokens,
+    wikilinkValidation,
   } = args;
   const content = extracted.slice(0, maxChars ?? 24_000);
   if (!content.trim()) return undefined;
@@ -553,6 +556,7 @@ export async function runIngestSynthesis(
         params,
         undefined,
         synthesisLanguage,
+        wikilinkValidation,
       );
       if (!outcome.ok) {
         return {

--- a/extensions/llm-wiki/lib/ingest-worker.ts
+++ b/extensions/llm-wiki/lib/ingest-worker.ts
@@ -13,9 +13,15 @@ import {
   serializeKnowledgeDocument,
   writeKnowledgeDocumentFile,
 } from "./knowledge-document.js";
+import {
+  type WikilinkValidationMode,
+  auditWikilinks,
+  buildWikilinkIndex,
+} from "./knowledge-links.js";
 import { appendEvent, rebuildMetadataLight } from "./metadata.js";
 import { runSubAgent } from "./subagent.js";
-import { type VaultPaths, fmtDate, slugify } from "./utils.js";
+import { resolveWikilinkValidation } from "./task-config.js";
+import { type VaultPaths, fmtDate, readJson, slugify } from "./utils.js";
 import { VaultWriteError, assertWritableVault } from "./vault-format.js";
 
 /**
@@ -84,6 +90,8 @@ export interface CommitResult {
   entitiesLinked: string[];
   conceptsLinked: string[];
   contradictions: number;
+  /** Wikilink gate diagnostics from `commitSynthesis` (warn/normalize modes). */
+  wikilinkDiagnostics?: KnowledgeDiagnostic[];
 }
 
 export type CommitSynthesisOutcome =
@@ -302,6 +310,28 @@ export function buildIngestedSourcePage(
 }
 
 /**
+ * Build the wikilink index used by the pre-write gate: every existing page id
+ * (from the registry) plus the page ids this commit is about to create, so a
+ * link to a sibling created in the same ingest resolves instead of
+ * false-positiving as missing.
+ */
+function buildIngestAuditIndex(
+  paths: VaultPaths,
+  sourceId: string,
+  data: SynthesisData,
+): ReturnType<typeof buildWikilinkIndex> {
+  const registry = readJson<{ pages: Record<string, unknown> }>(join(paths.meta, "registry.json"), {
+    pages: {},
+  });
+  const newIds = [
+    `sources/${sourceId}`,
+    ...data.entities.filter((e) => slugify(e.title)).map((e) => `entities/${slugify(e.title)}`),
+    ...data.concepts.filter((c) => slugify(c.title)).map((c) => `concepts/${slugify(c.title)}`),
+  ];
+  return buildWikilinkIndex([...Object.keys(registry.pages), ...newIds]);
+}
+
+/**
  * Persist a synthesis deterministically: rewrite the source page (status →
  * ingested), create missing entity/concept pages (existing pages are linked,
  * never overwritten), and log the event. Pure file I/O — no LLM, no network.
@@ -313,6 +343,7 @@ export function commitSynthesis(
   data: SynthesisData,
   date: string = fmtDate(),
   lang?: string,
+  wikilinkValidation?: WikilinkValidationMode,
 ): CommitSynthesisOutcome {
   const result: CommitResult = {
     sourceId,
@@ -333,6 +364,24 @@ export function commitSynthesis(
     throw error;
   }
 
+  // Pre-write wikilink gate (issue #172, Layer 2). Applies only to the
+  // model-authored source body; entity/concept pages are generated templates.
+  const mode = resolveWikilinkValidation({ wikilinkValidation });
+  let sourceBody = buildIngestedSourcePageBody(manifest, data, date, lang);
+  if (mode !== "off") {
+    const audit = auditWikilinks(
+      sourceBody,
+      buildIngestAuditIndex(paths, sourceId, data),
+      sourceId,
+      mode,
+    );
+    if (mode === "strict" && audit.diagnostics.length > 0) {
+      return { ok: false, sourceId, diagnostics: audit.diagnostics };
+    }
+    if (mode === "normalize") sourceBody = audit.body;
+    if (audit.diagnostics.length > 0) result.wikilinkDiagnostics = audit.diagnostics;
+  }
+
   // Patch existing documents so unknown fields, legacy sources, and titles survive.
   let sourceDocument: KnowledgeDocument;
   if (existsSync(result.sourcePage)) {
@@ -340,7 +389,7 @@ export function commitSynthesis(
     if (!parsed.ok) return { ok: false, sourceId, diagnostics: parsed.diagnostics };
     sourceDocument = patchKnowledgeDocument(parsed.document, {
       fields: { status: "ingested", updated: date },
-      body: buildIngestedSourcePageBody(manifest, data, date, lang),
+      body: sourceBody,
     });
   } else {
     sourceDocument = createKnowledgeDocument(
@@ -355,7 +404,7 @@ export function commitSynthesis(
         status: "ingested",
         updated: date,
       },
-      buildIngestedSourcePageBody(manifest, data, date, lang),
+      sourceBody,
     );
   }
   mkdirSync(join(paths.wiki, "sources"), { recursive: true });

--- a/extensions/llm-wiki/lib/knowledge-document.ts
+++ b/extensions/llm-wiki/lib/knowledge-document.ts
@@ -21,6 +21,7 @@ export type DiagnosticCode =
   | "okf_version_mismatch"
   | "link_path_escape"
   | "link_unresolved"
+  | "link_ambiguous"
   | "event_source_missing"
   | "event_source_unreadable"
   | "event_invalid_json"

--- a/extensions/llm-wiki/lib/knowledge-links.ts
+++ b/extensions/llm-wiki/lib/knowledge-links.ts
@@ -346,6 +346,20 @@ export function buildResolvedBacklinks(
   return { targets: sorted, unresolved, diagnostics };
 }
 
+/**
+ * Pre-write wikilink gate mode (issue #172). Two independent behaviors, not a
+ * severity ladder:
+ *   1. resolvable-but-drifted links (target exists): leave vs. rewrite-to-canonical
+ *   2. unresolvable links (target absent — a forward reference / gap): ignore vs. report vs. reject
+ *
+ *   off       = leave + ignore   (opt-out; zero behavior change)
+ *   warn      = leave + report   (default; non-mutating, non-blocking, surfaces issues)
+ *   normalize = rewrite + report (fixes resolvable links; still reports gaps)
+ *   strict    = leave + reject   (blocks the write with the bad links named; agent retry signal)
+ *
+ * A link that RESOLVES is never flagged — only normalized. Only missing/ambiguous targets
+ * produce diagnostics.
+ */
 export type WikilinkValidationMode = "off" | "warn" | "strict" | "normalize";
 
 // ── Pre-write validation & normalization (issue #172, Layer 2) ─────────
@@ -410,4 +424,32 @@ export function auditWikilinks(
   }
 
   return { diagnostics, body: out, changed: out !== body };
+}
+export interface WikilinkGateResult {
+  /** false only when mode === "strict" AND there are unresolvable/ambiguous links. */
+  ok: boolean;
+  /** The body to write (normalized when mode === "normalize", else the input). */
+  body: string;
+  /** Unresolved / ambiguous link diagnostics (empty for "off" / clean bodies). */
+  diagnostics: KnowledgeDiagnostic[];
+}
+
+/**
+ * Apply the pre-write wikilink gate to a body. Wraps {@link auditWikilinks}:
+ * blocks (ok:false) only in strict mode with issues, rewrites in normalize mode,
+ * and always returns the diagnostics so callers can surface them (warn/normalize).
+ */
+export function applyWikilinkGate(
+  body: string,
+  index: WikilinkIndex,
+  sourceId: string,
+  mode: WikilinkValidationMode,
+): WikilinkGateResult {
+  if (mode === "off") return { ok: true, body, diagnostics: [] };
+  const audit = auditWikilinks(body, index, sourceId, mode);
+  return {
+    ok: !(mode === "strict" && audit.diagnostics.length > 0),
+    body: mode === "normalize" ? audit.body : body,
+    diagnostics: audit.diagnostics,
+  };
 }

--- a/extensions/llm-wiki/lib/knowledge-links.ts
+++ b/extensions/llm-wiki/lib/knowledge-links.ts
@@ -276,19 +276,10 @@ function resolveMarkdownTarget(
   return { kind: "empty" };
 }
 
-function resolveWikilinkTarget(
-  target: string,
-): { kind: "concept"; id: string } | { kind: "empty" } {
-  // Wikilinks are already bundle-relative concept IDs
-  const cleaned = target.trim();
-  if (!cleaned) return { kind: "empty" };
-  return { kind: "concept", id: cleaned };
-}
-
 export function buildResolvedBacklinks(
   sourceId: string,
   body: string,
-  knownIds: Set<string>,
+  index: WikilinkIndex,
 ): ResolvedBacklinks {
   const diagnostics: KnowledgeDiagnostic[] = [];
   const unresolved: UnresolvedKnowledgeLink[] = [];
@@ -317,37 +308,48 @@ export function buildResolvedBacklinks(
         ),
       );
     } else if (resolved.kind === "concept") {
-      const normalizedId = resolved.id.normalize("NFC");
-      if (knownIds.has(normalizedId)) {
-        targets.add(normalizedId);
+      const canonical = index.byExact.get(resolved.id.normalize("NFC"));
+      if (canonical) {
+        targets.add(canonical);
       } else {
-        unresolved.push({ target: normalizedId, syntax: "markdown" });
+        unresolved.push({ target: resolved.id, syntax: "markdown" });
         diagnostics.push(
-          diag("warning", "link_unresolved", `${sourceId}.md`, `Unresolved link: ${normalizedId}`),
+          diag(
+            "warning",
+            "link_unresolved",
+            `${sourceId}.md`,
+            `Unresolved link: ${resolved.id}`,
+          ),
         );
       }
     }
     // external and empty are silently ignored
   }
 
-  // Process wikilinks
+  // Process wikilinks (lenient: exact → normalized path → bare title)
   for (const link of allLinks.wikilinks) {
-    const resolved = resolveWikilinkTarget(link.target);
-    if (resolved.kind === "concept") {
-      const normalizedId = resolved.id.normalize("NFC");
-      if (knownIds.has(normalizedId)) {
-        targets.add(normalizedId);
-      } else {
-        unresolved.push({ target: normalizedId, syntax: "wikilink" });
-        diagnostics.push(
-          diag(
-            "warning",
-            "link_unresolved",
-            `${sourceId}.md`,
-            `Unresolved wikilink: ${normalizedId}`,
-          ),
-        );
-      }
+    const res = resolveWikilink(link.target, index);
+    if (res.kind === "resolved") {
+      targets.add(res.id);
+    } else if (res.kind === "ambiguous") {
+      diagnostics.push(
+        diag(
+          "warning",
+          "link_ambiguous",
+          `${sourceId}.md`,
+          `Ambiguous wikilink: ${res.target} (candidates: ${res.candidates.join(", ")})`,
+        ),
+      );
+    } else {
+      unresolved.push({ target: res.target, syntax: "wikilink" });
+      diagnostics.push(
+        diag(
+          "warning",
+          "link_unresolved",
+          `${sourceId}.md`,
+          `Unresolved wikilink: ${res.target}`,
+        ),
+      );
     }
   }
 

--- a/extensions/llm-wiki/lib/knowledge-links.ts
+++ b/extensions/llm-wiki/lib/knowledge-links.ts
@@ -1,6 +1,7 @@
 import type { Definition, Link, LinkReference, Nodes, Root } from "mdast";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import type { KnowledgeDiagnostic } from "./knowledge-document.js";
+import { slugify } from "./utils.js";
 import { compareCodePoint } from "./vault-format.js";
 
 export interface ExtractedLink {
@@ -118,6 +119,77 @@ export function extractLegacyWikilinks(body: string): ExtractedLink[] {
     links.push({ target: normalizeWikilinkTarget(match[1]), offset: match.index ?? 0 });
   }
   return links;
+}
+
+// ── Wikilink normalization ──────────────────────────────────────────
+
+export interface WikilinkIndex {
+  /** NFC-normalized id → canonical id. */
+  byExact: Map<string, string>;
+  /** Slugified full path → matching canonical ids. */
+  byNormPath: Map<string, string[]>;
+  /** Slugified basename (no folder) → matching canonical ids. */
+  byNormSlug: Map<string, string[]>;
+}
+
+export function buildWikilinkIndex(ids: Iterable<string>): WikilinkIndex {
+  const byExact = new Map<string, string>();
+  const byNormPath = new Map<string, string[]>();
+  const byNormSlug = new Map<string, string[]>();
+
+  function push<K>(map: Map<K, string[]>, key: K, value: string): void {
+    const existing = map.get(key);
+    if (existing) existing.push(value);
+    else map.set(key, [value]);
+  }
+
+  for (const id of ids) {
+    byExact.set(id.normalize("NFC"), id);
+    const segments = id.split("/");
+    const normFull = segments.map((s) => slugify(s)).join("/");
+    const normBase = slugify(segments[segments.length - 1]);
+    push(byNormPath, normFull, id);
+    push(byNormSlug, normBase, id);
+  }
+
+  return { byExact, byNormPath, byNormSlug };
+}
+
+export type WikilinkResolution =
+  | { kind: "resolved"; id: string }
+  | { kind: "ambiguous"; target: string; candidates: string[] }
+  | { kind: "missing"; target: string };
+
+export function resolveWikilink(
+  target: string,
+  index: WikilinkIndex,
+): WikilinkResolution {
+  const cleaned = target.trim().replace(/\\$/, "");
+  if (!cleaned) return { kind: "missing", target: "" };
+
+  // Fast path: exact NFC match
+  const exact = index.byExact.get(cleaned.normalize("NFC"));
+  if (exact) return { kind: "resolved", id: exact };
+
+  // Normalized full path (fixes case/space/slug drift in folder-qualified links)
+  const normFull = cleaned
+    .split("/")
+    .map((s) => slugify(s))
+    .join("/");
+  const pathHits = index.byNormPath.get(normFull);
+  if (pathHits && pathHits.length === 1) return { kind: "resolved", id: pathHits[0] };
+  if (pathHits && pathHits.length > 1)
+    return { kind: "ambiguous", target: cleaned, candidates: pathHits };
+
+  // Bare title: match by slugified basename (handles [[zosma harness]] → entities/zosma-harness)
+  if (!cleaned.includes("/")) {
+    const baseHits = index.byNormSlug.get(slugify(cleaned));
+    if (baseHits && baseHits.length === 1) return { kind: "resolved", id: baseHits[0] };
+    if (baseHits && baseHits.length > 1)
+      return { kind: "ambiguous", target: cleaned, candidates: baseHits };
+  }
+
+  return { kind: "missing", target: cleaned };
 }
 
 function resolveMarkdownTarget(

--- a/extensions/llm-wiki/lib/knowledge-links.ts
+++ b/extensions/llm-wiki/lib/knowledge-links.ts
@@ -160,10 +160,7 @@ export type WikilinkResolution =
   | { kind: "ambiguous"; target: string; candidates: string[] }
   | { kind: "missing"; target: string };
 
-export function resolveWikilink(
-  target: string,
-  index: WikilinkIndex,
-): WikilinkResolution {
+export function resolveWikilink(target: string, index: WikilinkIndex): WikilinkResolution {
   const cleaned = target.trim().replace(/\\$/, "");
   if (!cleaned) return { kind: "missing", target: "" };
 
@@ -314,12 +311,7 @@ export function buildResolvedBacklinks(
       } else {
         unresolved.push({ target: resolved.id, syntax: "markdown" });
         diagnostics.push(
-          diag(
-            "warning",
-            "link_unresolved",
-            `${sourceId}.md`,
-            `Unresolved link: ${resolved.id}`,
-          ),
+          diag("warning", "link_unresolved", `${sourceId}.md`, `Unresolved link: ${resolved.id}`),
         );
       }
     }
@@ -343,12 +335,7 @@ export function buildResolvedBacklinks(
     } else {
       unresolved.push({ target: res.target, syntax: "wikilink" });
       diagnostics.push(
-        diag(
-          "warning",
-          "link_unresolved",
-          `${sourceId}.md`,
-          `Unresolved wikilink: ${res.target}`,
-        ),
+        diag("warning", "link_unresolved", `${sourceId}.md`, `Unresolved wikilink: ${res.target}`),
       );
     }
   }

--- a/extensions/llm-wiki/lib/knowledge-links.ts
+++ b/extensions/llm-wiki/lib/knowledge-links.ts
@@ -345,3 +345,5 @@ export function buildResolvedBacklinks(
 
   return { targets: sorted, unresolved, diagnostics };
 }
+
+export type WikilinkValidationMode = "off" | "warn" | "strict" | "normalize";

--- a/extensions/llm-wiki/lib/knowledge-links.ts
+++ b/extensions/llm-wiki/lib/knowledge-links.ts
@@ -405,9 +405,7 @@ export function auditWikilinks(
   if (mode === "normalize") {
     out = body.replace(WIKILINK_REPLACE_RE, (full, raw: string, alias: string | undefined) => {
       const resolved = resolveWikilink(normalizeWikilinkTarget(raw), index);
-      return resolved.kind === "resolved"
-        ? `[[${resolved.id}${alias ?? ""}]]`
-        : full;
+      return resolved.kind === "resolved" ? `[[${resolved.id}${alias ?? ""}]]` : full;
     });
   }
 

--- a/extensions/llm-wiki/lib/knowledge-links.ts
+++ b/extensions/llm-wiki/lib/knowledge-links.ts
@@ -347,3 +347,69 @@ export function buildResolvedBacklinks(
 }
 
 export type WikilinkValidationMode = "off" | "warn" | "strict" | "normalize";
+
+// ── Pre-write validation & normalization (issue #172, Layer 2) ─────────
+
+export interface WikilinkAuditResult {
+  /** Unresolved / ambiguous link diagnostics (empty for "off" / clean bodies). */
+  diagnostics: KnowledgeDiagnostic[];
+  /** The body after normalization (identical to input unless normalize rewrote links). */
+  body: string;
+  /** True only when normalize changed the body. */
+  changed: boolean;
+}
+
+const WIKILINK_REPLACE_RE = /\[\[([^\]|]+)(\|[^\]]*)?\]\]/g;
+
+/**
+ * Audit a markdown body's wikilinks against the page index.
+ *
+ * - Collects `link_unresolved` / `link_ambiguous` diagnostics for every link
+ *   that does not resolve to exactly one page (skipped for "off").
+ * - In "normalize" mode, additionally rewrites each link that DOES resolve to
+ *   its canonical page id. Only the target token is replaced (the parser's own
+ *   regex is reused), so `|alias`, escaping, and surrounding text are preserved.
+ *
+ * Pure: no I/O. The caller supplies the index (typically `buildWikilinkIndex`
+ * over existing page ids plus the ids created by the same commit).
+ */
+export function auditWikilinks(
+  body: string,
+  index: WikilinkIndex,
+  sourceId: string,
+  mode: WikilinkValidationMode,
+): WikilinkAuditResult {
+  if (mode === "off") return { diagnostics: [], body, changed: false };
+
+  const diagnostics: KnowledgeDiagnostic[] = [];
+  for (const { target } of extractKnowledgeLinks(body).wikilinks) {
+    const resolved = resolveWikilink(target, index);
+    if (resolved.kind === "ambiguous") {
+      diagnostics.push({
+        severity: "warning",
+        code: "link_ambiguous",
+        path: sourceId,
+        message: `Wikilink target "${target}" matches multiple pages (${resolved.candidates.join(", ")}).`,
+      });
+    } else if (resolved.kind === "missing") {
+      diagnostics.push({
+        severity: "warning",
+        code: "link_unresolved",
+        path: sourceId,
+        message: `Wikilink target "${target}" does not match any page.`,
+      });
+    }
+  }
+
+  let out = body;
+  if (mode === "normalize") {
+    out = body.replace(WIKILINK_REPLACE_RE, (full, raw: string, alias: string | undefined) => {
+      const resolved = resolveWikilink(normalizeWikilinkTarget(raw), index);
+      return resolved.kind === "resolved"
+        ? `[[${resolved.id}${alias ?? ""}]]`
+        : full;
+    });
+  }
+
+  return { diagnostics, body: out, changed: out !== body };
+}

--- a/extensions/llm-wiki/lib/metadata.ts
+++ b/extensions/llm-wiki/lib/metadata.ts
@@ -11,7 +11,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import type { KnowledgeDiagnostic, KnowledgeDocument } from "./knowledge-document.js";
-import { buildResolvedBacklinks } from "./knowledge-links.js";
+import { buildResolvedBacklinks, buildWikilinkIndex, type WikilinkIndex } from "./knowledge-links.js";
 import { type VaultPaths, isPathWithin, readJson } from "./utils.js";
 import {
   assertWritableVault,
@@ -86,8 +86,8 @@ export function rebuildMetadata(paths: VaultPaths): ProjectionResult {
   const registry = buildRegistry(paths, documents);
 
   // Step 4: Build backlinks from discovered documents
-  const knownIds = new Set(documents.map((d) => d.id));
-  const backlinks = buildBacklinks(documents, knownIds, allDiagnostics);
+  const wikilinkIndex = buildWikilinkIndex(documents.map((d) => d.id));
+  const backlinks = buildBacklinks(documents, wikilinkIndex, allDiagnostics);
 
   const eventSource = readEventSource(join(paths.meta, "events.jsonl"));
   const eventLogResult = eventSource.available ? buildOkfLog(eventSource.content) : undefined;
@@ -245,7 +245,7 @@ function getSemanticTitle(doc: KnowledgeDocument): string {
 /** Build backlinks from discovered documents using shared link resolution. */
 function buildBacklinks(
   documents: KnowledgeDocument[],
-  knownIds: Set<string>,
+  index: WikilinkIndex,
   diagnostics: KnowledgeDiagnostic[],
 ): Backlinks {
   const inbound: Backlinks = {};
@@ -257,7 +257,7 @@ function buildBacklinks(
 
   // Resolve links for each document
   for (const doc of documents) {
-    const result = buildResolvedBacklinks(doc.id, doc.body, knownIds);
+    const result = buildResolvedBacklinks(doc.id, doc.body, index);
     diagnostics.push(...result.diagnostics);
     for (const target of result.targets) {
       if (inbound[target] && !inbound[target].includes(doc.id)) {

--- a/extensions/llm-wiki/lib/metadata.ts
+++ b/extensions/llm-wiki/lib/metadata.ts
@@ -11,7 +11,11 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import type { KnowledgeDiagnostic, KnowledgeDocument } from "./knowledge-document.js";
-import { buildResolvedBacklinks, buildWikilinkIndex, type WikilinkIndex } from "./knowledge-links.js";
+import {
+  type WikilinkIndex,
+  buildResolvedBacklinks,
+  buildWikilinkIndex,
+} from "./knowledge-links.js";
 import { type VaultPaths, isPathWithin, readJson } from "./utils.js";
 import {
   assertWritableVault,

--- a/extensions/llm-wiki/lib/retro.ts
+++ b/extensions/llm-wiki/lib/retro.ts
@@ -178,7 +178,10 @@ export function registerWikiRetro(pi: ExtensionAPI, runtime?: Runtime): void {
                   .join("\n")}`,
               },
             ],
-            details: { error: "link_validation", issues: wikilinkIssues } as Record<string, unknown>,
+            details: { error: "link_validation", issues: wikilinkIssues } as Record<
+              string,
+              unknown
+            >,
             isError: true,
           };
         }

--- a/extensions/llm-wiki/lib/retro.ts
+++ b/extensions/llm-wiki/lib/retro.ts
@@ -1,11 +1,13 @@
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import { scheduleReindex } from "./indexing.js";
 import { createKnowledgeDocument, writeKnowledgeDocumentFile } from "./knowledge-document.js";
+import { applyWikilinkGate, buildWikilinkIndex } from "./knowledge-links.js";
 import { appendEvent, rebuildMetadataLight } from "./metadata.js";
 import type { Runtime } from "./runtime.js";
-import { type VaultPaths, fmtDate, resolveVaultPaths } from "./utils.js";
+import { loadTaskConfig, resolveWikilinkValidation } from "./task-config.js";
+import { type VaultPaths, fmtDate, readJson, resolveVaultPaths } from "./utils.js";
 import { assertWritableVault, inspectWritableVault } from "./vault-format.js";
 
 // ─── Public API ────────────────────────────────────────
@@ -150,9 +152,41 @@ export function registerWikiRetro(pi: ExtensionAPI, runtime?: Runtime): void {
         };
       }
 
+      // Pre-write wikilink gate (#172): validate/normalize caller-supplied body.
+      const mode = resolveWikilinkValidation(loadTaskConfig(ctx.cwd ?? process.cwd()));
+      let body = params.body;
+      let wikilinkIssues: string[] = [];
+      if (mode !== "off") {
+        const registry = readJson<{ pages: Record<string, unknown> }>(
+          join(paths.meta, "registry.json"),
+          { pages: {} },
+        );
+        const gate = applyWikilinkGate(
+          body,
+          buildWikilinkIndex(Object.keys(registry.pages)),
+          `sources/${params.slug}`,
+          mode,
+        );
+        wikilinkIssues = gate.diagnostics.map((d) => d.message);
+        if (!gate.ok) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Rejected write — unresolved/ambiguous wikilinks:\n${wikilinkIssues
+                  .map((m) => `- ${m}`)
+                  .join("\n")}`,
+              },
+            ],
+            details: { error: "link_validation", issues: wikilinkIssues } as Record<string, unknown>,
+            isError: true,
+          };
+        }
+        if (mode === "normalize") body = gate.body;
+      }
       let result: RetroResult;
       try {
-        result = saveInsight(paths, params.slug, params.title, params.body, params.category, {
+        result = saveInsight(paths, params.slug, params.title, body, params.category, {
           rebuild: !runtime,
         });
       } catch (error: unknown) {
@@ -169,6 +203,9 @@ export function registerWikiRetro(pi: ExtensionAPI, runtime?: Runtime): void {
         scheduleReindex(runtime, { hasUI: ctx.hasUI, ui: ctx.ui }, paths);
       }
 
+      const gateNote = wikilinkIssues.length
+        ? `\n\n⚠️ ${wikilinkIssues.length} wikilink issue(s):\n${wikilinkIssues.map((m) => `- ${m}`).join("\n")}`
+        : "";
       return {
         content: [
           {
@@ -179,13 +216,17 @@ export function registerWikiRetro(pi: ExtensionAPI, runtime?: Runtime): void {
               `- Page: \`${result.sourcePagePath}\``,
               "",
               "This insight will be auto-surfaced by wiki_recall in future sessions.",
-            ].join("\n"),
+              gateNote,
+            ]
+              .filter(Boolean)
+              .join("\n"),
           },
         ],
         details: {
           slug: params.slug,
           title: params.title,
           category: params.category || null,
+          wikilinkIssues,
         } as Record<string, unknown>,
       };
     },

--- a/extensions/llm-wiki/lib/task-config.ts
+++ b/extensions/llm-wiki/lib/task-config.ts
@@ -288,7 +288,7 @@ function readNamespacedConfig(path: string): Partial<TaskConfig> {
       typeof wl === "string" &&
       (WIKILINK_VALIDATION_MODES as readonly string[]).includes(wl)
     ) {
-      out.wikilinkValidation = wl;
+      out.wikilinkValidation = wl as WikilinkValidationMode;
     }
 
     return out;

--- a/extensions/llm-wiki/lib/task-config.ts
+++ b/extensions/llm-wiki/lib/task-config.ts
@@ -183,9 +183,7 @@ const WIKILINK_VALIDATION_MODES: readonly WikilinkValidationMode[] = [
  * `warn` — ingest always writes and reports; only an explicit `strict` blocks.
  * Unknown values fall back to `warn` rather than failing the ingest.
  */
-export function resolveWikilinkValidation(
-  config: TaskConfig | undefined,
-): WikilinkValidationMode {
+export function resolveWikilinkValidation(config: TaskConfig | undefined): WikilinkValidationMode {
   const v = config?.wikilinkValidation;
   if (v && (WIKILINK_VALIDATION_MODES as readonly string[]).includes(v)) return v;
   return "warn";
@@ -284,10 +282,7 @@ function readNamespacedConfig(path: string): Partial<TaskConfig> {
     }
 
     const wl = section.wikilinkValidation;
-    if (
-      typeof wl === "string" &&
-      (WIKILINK_VALIDATION_MODES as readonly string[]).includes(wl)
-    ) {
+    if (typeof wl === "string" && (WIKILINK_VALIDATION_MODES as readonly string[]).includes(wl)) {
       out.wikilinkValidation = wl as WikilinkValidationMode;
     }
 

--- a/extensions/llm-wiki/lib/task-config.ts
+++ b/extensions/llm-wiki/lib/task-config.ts
@@ -9,6 +9,7 @@ import {
   resolveGlobalSettingsPath,
   resolveProjectSettingsPath,
 } from "./host.js";
+import type { WikilinkValidationMode } from "./knowledge-links.js";
 
 /**
  * Configuration for the background-task lane (issue #64, part of #63).
@@ -147,6 +148,17 @@ export interface TaskConfig {
    * response truncates before commit_synthesis can be called.
    */
   synthesisMaxTokens?: number;
+
+  /**
+   * Wikilink gate applied to the ingested source body before pages are
+   * written (issue #172, Layer 2). Reuses the Layer 1 resolver.
+   *   - "off"       : no-op.
+   *   - "warn"      : write proceeds; unresolved/ambiguous links are reported.
+   *   - "strict"    : block the write (commit returns ok:false) if any link is unresolvable.
+   *   - "normalize" : rewrite resolvable links to their canonical id, then write.
+   * Default "warn". See `resolveWikilinkValidation`.
+   */
+  wikilinkValidation?: WikilinkValidationMode;
 }
 
 export const TASK_DEFAULTS: TaskConfig = {};
@@ -157,6 +169,26 @@ export const TASK_DEFAULTS: TaskConfig = {};
  */
 export function noticesEnabled(config: TaskConfig | undefined): boolean {
   return config?.notices !== false;
+}
+
+const WIKILINK_VALIDATION_MODES: readonly WikilinkValidationMode[] = [
+  "off",
+  "warn",
+  "strict",
+  "normalize",
+];
+
+/**
+ * Resolve the wikilink write-gate mode (issue #172, Layer 2). Defaults to
+ * `warn` — ingest always writes and reports; only an explicit `strict` blocks.
+ * Unknown values fall back to `warn` rather than failing the ingest.
+ */
+export function resolveWikilinkValidation(
+  config: TaskConfig | undefined,
+): WikilinkValidationMode {
+  const v = config?.wikilinkValidation;
+  if (v && (WIKILINK_VALIDATION_MODES as readonly string[]).includes(v)) return v;
+  return "warn";
 }
 
 /**
@@ -249,6 +281,14 @@ function readNamespacedConfig(path: string): Partial<TaskConfig> {
     const maxTokens = section.synthesisMaxTokens;
     if (typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0) {
       out.synthesisMaxTokens = Math.floor(maxTokens);
+    }
+
+    const wl = section.wikilinkValidation;
+    if (
+      typeof wl === "string" &&
+      (WIKILINK_VALIDATION_MODES as readonly string[]).includes(wl)
+    ) {
+      out.wikilinkValidation = wl;
     }
 
     return out;
@@ -438,6 +478,7 @@ const KNOWN_KEYS = [
   "trajectories",
   "synthesisLanguage",
   "synthesisMaxTokens",
+  "wikilinkValidation",
 ] as const;
 
 export function loadTaskConfigSources(

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -415,6 +415,7 @@ export function registerWikiIngest(pi: ExtensionAPI, runtime?: Runtime): void {
                 manifest: s.manifest,
                 extracted: s.extracted,
                 synthesisLanguage: runtime.config.synthesisLanguage,
+                wikilinkValidation: runtime.config.wikilinkValidation,
               });
               if (committed) {
                 // Background semantic embeddings (#66): embed the pages this
@@ -428,8 +429,10 @@ export function registerWikiIngest(pi: ExtensionAPI, runtime?: Runtime): void {
                 ];
                 launchEmbedPages(runtime, launchCtx, paths, pageIds, `embed:ingest:${s.id}`);
               }
+              const wl = committed?.wikilinkDiagnostics?.length ?? 0;
+              const wlNote = wl > 0 ? `, ${wl} wikilink issue${wl === 1 ? "" : "s"}` : "";
               const summary = committed
-                ? `LLM Wiki: ingested ${s.id} → ${committed.entitiesCreated.length} entit${committed.entitiesCreated.length === 1 ? "y" : "ies"}, ${committed.conceptsCreated.length} concept${committed.conceptsCreated.length === 1 ? "" : "s"}`
+                ? `LLM Wiki: ingested ${s.id} → ${committed.entitiesCreated.length} entit${committed.entitiesCreated.length === 1 ? "y" : "ies"}, ${committed.conceptsCreated.length} concept${committed.conceptsCreated.length === 1 ? "" : "s"}${wlNote}`
                 : `LLM Wiki: ${s.id} produced no synthesis`;
               if (ctx.hasUI) {
                 ctx.ui.notify(summary, committed ? "info" : "warning");

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -11,12 +11,12 @@ import {
   serializeKnowledgeDocument,
   writeKnowledgeDocumentFile,
 } from "./knowledge-document.js";
-import { buildResolvedBacklinks, buildWikilinkIndex } from "./knowledge-links.js";
+import { applyWikilinkGate, buildResolvedBacklinks, buildWikilinkIndex } from "./knowledge-links.js";
 import { repairLegacyKnowledgeDocuments } from "./legacy-repair.js";
 import { type Registry, appendEvent, rebuildMetadata, rebuildMetadataLight } from "./metadata.js";
 import type { Runtime } from "./runtime.js";
 import { captureFile, captureText, captureUrl } from "./source-packet.js";
-import { parseModelRef } from "./task-config.js";
+import { parseModelRef, loadTaskConfig, resolveWikilinkValidation } from "./task-config.js";
 import {
   type VaultPaths,
   detectVaultFormat,
@@ -568,7 +568,39 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
       }
 
       const today = fmtDate();
-      const body = params.content ?? buildPageBody(type, params.title);
+      let body = params.content ?? buildPageBody(type, params.title);
+
+      // Pre-write wikilink gate (#172): validate/normalize caller-supplied content.
+      const mode = resolveWikilinkValidation(loadTaskConfig(ctx.cwd));
+      let wikilinkIssues: string[] = [];
+      if (mode !== "off") {
+        const registry = readJson<{ pages: Record<string, unknown> }>(
+          join(paths.meta, "registry.json"),
+          { pages: {} },
+        );
+        const gate = applyWikilinkGate(
+          body,
+          buildWikilinkIndex(Object.keys(registry.pages)),
+          `${folder}/${slug}`,
+          mode,
+        );
+        wikilinkIssues = gate.diagnostics.map((d) => d.message);
+        if (!gate.ok) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Rejected write — unresolved/ambiguous wikilinks:\n${wikilinkIssues
+                  .map((m) => `- ${m}`)
+                  .join("\n")}`,
+              },
+            ],
+            details: { error: "link_validation", issues: wikilinkIssues } as Record<string, unknown>,
+            isError: true,
+          };
+        }
+        if (mode === "normalize") body = gate.body;
+      }
       const doc = createKnowledgeDocument(
         `${folder}/${slug}.md`,
         {
@@ -598,9 +630,18 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
         rebuildMetadataLight(paths);
       }
 
+      const gateNote = wikilinkIssues.length
+        ? `\n\n⚠️ ${wikilinkIssues.length} wikilink issue(s):\n${wikilinkIssues.map((m) => `- ${m}`).join("\n")}`
+        : "";
       return {
-        content: [{ type: "text", text: `✅ Created ${type} page: \`${pagePath}\`` }],
-        details: { path: pagePath, created: true } as Record<string, unknown>,
+        content: [
+          { type: "text", text: `✅ Created ${type} page: \`${pagePath}\`${gateNote}` },
+        ],
+        details: {
+          path: pagePath,
+          created: true,
+          wikilinkIssues,
+        } as Record<string, unknown>,
       };
     },
   });

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -890,7 +890,7 @@ function runWikiLint(paths: VaultPaths, autoFix: boolean): string {
     }
     for (const d of resolved.diagnostics) {
       if (d.code === "link_ambiguous") {
-        findings.push(d.message.replace(`Ambiguous wikilink: `, `Ambiguous: `));
+        findings.push(d.message.replace("Ambiguous wikilink: ", "Ambiguous: "));
       }
     }
   }

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -11,12 +11,16 @@ import {
   serializeKnowledgeDocument,
   writeKnowledgeDocumentFile,
 } from "./knowledge-document.js";
-import { applyWikilinkGate, buildResolvedBacklinks, buildWikilinkIndex } from "./knowledge-links.js";
+import {
+  applyWikilinkGate,
+  buildResolvedBacklinks,
+  buildWikilinkIndex,
+} from "./knowledge-links.js";
 import { repairLegacyKnowledgeDocuments } from "./legacy-repair.js";
 import { type Registry, appendEvent, rebuildMetadata, rebuildMetadataLight } from "./metadata.js";
 import type { Runtime } from "./runtime.js";
 import { captureFile, captureText, captureUrl } from "./source-packet.js";
-import { parseModelRef, loadTaskConfig, resolveWikilinkValidation } from "./task-config.js";
+import { loadTaskConfig, parseModelRef, resolveWikilinkValidation } from "./task-config.js";
 import {
   type VaultPaths,
   detectVaultFormat,
@@ -595,7 +599,10 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
                   .join("\n")}`,
               },
             ],
-            details: { error: "link_validation", issues: wikilinkIssues } as Record<string, unknown>,
+            details: { error: "link_validation", issues: wikilinkIssues } as Record<
+              string,
+              unknown
+            >,
             isError: true,
           };
         }
@@ -634,9 +641,7 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
         ? `\n\n⚠️ ${wikilinkIssues.length} wikilink issue(s):\n${wikilinkIssues.map((m) => `- ${m}`).join("\n")}`
         : "";
       return {
-        content: [
-          { type: "text", text: `✅ Created ${type} page: \`${pagePath}\`${gateNote}` },
-        ],
+        content: [{ type: "text", text: `✅ Created ${type} page: \`${pagePath}\`${gateNote}` }],
         details: {
           path: pagePath,
           created: true,

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -11,7 +11,7 @@ import {
   serializeKnowledgeDocument,
   writeKnowledgeDocumentFile,
 } from "./knowledge-document.js";
-import { buildResolvedBacklinks } from "./knowledge-links.js";
+import { buildResolvedBacklinks, buildWikilinkIndex } from "./knowledge-links.js";
 import { repairLegacyKnowledgeDocuments } from "./legacy-repair.js";
 import { type Registry, appendEvent, rebuildMetadata, rebuildMetadataLight } from "./metadata.js";
 import type { Runtime } from "./runtime.js";
@@ -871,7 +871,7 @@ function runWikiLint(paths: VaultPaths, autoFix: boolean): string {
 
   const discovery = discoverKnowledgeDocuments(paths);
   const pages = discovery.documents;
-  const knownIds = new Set(pages.map((page) => page.id));
+  const wikilinkIndex = buildWikilinkIndex(pages.map((page) => page.id));
   const inbound = Object.fromEntries(pages.map((page) => [page.id, 0]));
   const gapSources = new Map<string, Set<string>>();
   const findings: string[] = [];
@@ -879,7 +879,7 @@ function runWikiLint(paths: VaultPaths, autoFix: boolean): string {
   let contradictions = 0;
 
   for (const page of pages) {
-    const resolved = buildResolvedBacklinks(page.id, page.body, knownIds);
+    const resolved = buildResolvedBacklinks(page.id, page.body, wikilinkIndex);
     for (const target of resolved.targets) inbound[target]++;
     for (const unresolved of resolved.unresolved) {
       const sources = gapSources.get(unresolved.target) ?? new Set<string>();
@@ -887,6 +887,11 @@ function runWikiLint(paths: VaultPaths, autoFix: boolean): string {
       gapSources.set(unresolved.target, sources);
       missingPages++;
       findings.push(`Missing page: ${unresolved.target} (in ${page.id})`);
+    }
+    for (const d of resolved.diagnostics) {
+      if (d.code === "link_ambiguous") {
+        findings.push(d.message.replace(`Ambiguous wikilink: `, `Ambiguous: `));
+      }
     }
   }
 

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -15,6 +15,10 @@ import { join } from "node:path";
 import { McpServer } from "@modelcontextprotocol/server";
 import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import * as z from "zod/v4";
+import {
+  loadTaskConfig,
+  resolveWikilinkValidation,
+} from "../extensions/llm-wiki/lib/task-config.js";
 import { getVaultPaths, resolveVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
 import { createExecApi } from "./exec.js";
 import {
@@ -265,7 +269,14 @@ server.registerTool(
     }
 
     const paths = getPaths();
-    const result = await retroOperation(paths, slug, title, body, category);
+    const result = await retroOperation(
+      paths,
+      slug,
+      title,
+      body,
+      category,
+      resolveWikilinkValidation(loadTaskConfig(process.cwd())),
+    );
 
     if (!result.ok) {
       return {

--- a/mcp/operations.ts
+++ b/mcp/operations.ts
@@ -6,13 +6,20 @@
  * registry entries, or builds page strings itself.
  */
 
+import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { bootstrapVault } from "../extensions/llm-wiki/lib/bootstrap.js";
+import {
+  type WikilinkValidationMode,
+  applyWikilinkGate,
+  buildWikilinkIndex,
+} from "../extensions/llm-wiki/lib/knowledge-links.js";
 import { type ProjectionResult, rebuildMetadata } from "../extensions/llm-wiki/lib/metadata.js";
 import { type RecallResult, searchWikiLayered } from "../extensions/llm-wiki/lib/recall.js";
 import { saveInsight } from "../extensions/llm-wiki/lib/retro.js";
 import { captureFile, captureText, captureUrl } from "../extensions/llm-wiki/lib/source-packet.js";
-import type { VaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+import { resolveWikilinkValidation } from "../extensions/llm-wiki/lib/task-config.js";
+import { type VaultPaths, readJson } from "../extensions/llm-wiki/lib/utils.js";
 import {
   VaultWriteError,
   inspectVaultFormat,
@@ -134,6 +141,7 @@ export async function retroOperation(
   title: string,
   body: string,
   category?: string,
+  wikilinkValidation?: WikilinkValidationMode,
 ): Promise<
   | { ok: true; slug: string; sourcePagePath: string }
   | { ok: false; diagnostics: Array<{ code: string; message: string }> }
@@ -145,8 +153,30 @@ export async function retroOperation(
       diagnostics: vaultCheck.diagnostics.map((d) => ({ code: d.code, message: d.message })),
     };
   }
+  // Pre-write wikilink gate (#172): validate/normalize caller-supplied body.
+  const mode = resolveWikilinkValidation({ wikilinkValidation });
+  let gateBody = body;
+  if (mode !== "off") {
+    const registry = readJson<{ pages: Record<string, unknown> }>(
+      join(paths.meta, "registry.json"),
+      { pages: {} },
+    );
+    const gate = applyWikilinkGate(
+      body,
+      buildWikilinkIndex(Object.keys(registry.pages)),
+      `sources/${slug}`,
+      mode,
+    );
+    if (!gate.ok) {
+      return {
+        ok: false,
+        diagnostics: gate.diagnostics.map((d) => ({ code: "link_validation", message: d.message })),
+      };
+    }
+    if (mode === "normalize") gateBody = gate.body;
+  }
   try {
-    const result = saveInsight(paths, slug, title, body, category, { rebuild: false });
+    const result = saveInsight(paths, slug, title, gateBody, category, { rebuild: false });
     const projection = projectionOutcome(rebuildMetadata(paths));
     if (!projection.ok) return projection;
     return { ok: true, slug: result.slug, sourcePagePath: result.sourcePagePath };

--- a/test/ingest-worker.test.ts
+++ b/test/ingest-worker.test.ts
@@ -241,4 +241,102 @@ describe("commitSynthesis", () => {
     if (!res.ok) return;
     expect(res.entitiesCreated).toEqual(["untitled"]);
   });
+
+  describe("commitSynthesis wikilink gate", () => {
+    function makeData(summary: string): SynthesisData {
+      return {
+        summary,
+        key_takeaways: ["a"],
+        entities: [{ title: "Alice", description: "A person." }],
+        concepts: [{ title: "Transformer", definition: "An architecture." }],
+      };
+    }
+
+    it("strict blocks the write and returns ok:false on an unresolved link", () => {
+      const paths = getVaultPaths(wikiDir);
+      const res = commitSynthesis(
+        paths,
+        "SRC-001",
+        MANIFEST,
+        makeData("See [[ghost-page]] for details."),
+        "2026-06-06",
+        undefined,
+        "strict",
+      );
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.diagnostics.map((d) => d.code)).toContain("link_unresolved");
+      }
+      // Nothing was written:
+      expect(existsSync(join(paths.wiki, "sources", "SRC-001.md"))).toBe(false);
+      expect(existsSync(join(paths.wiki, "entities", "alice.md"))).toBe(false);
+    });
+
+    it("warn writes and attaches wikilinkDiagnostics", () => {
+      const paths = getVaultPaths(wikiDir);
+      const res = commitSynthesis(
+        paths,
+        "SRC-001",
+        MANIFEST,
+        makeData("See [[ghost-page]] for details."),
+        "2026-06-06",
+        undefined,
+        "warn",
+      );
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.wikilinkDiagnostics?.map((d) => d.code)).toContain("link_unresolved");
+      }
+      expect(existsSync(join(paths.wiki, "sources", "SRC-001.md"))).toBe(true);
+    });
+
+    it("normalize rewrites resolvable links to canonical ids in the written page", () => {
+      const paths = getVaultPaths(wikiDir);
+      // [[transformer]] resolves because makeData() creates a "Transformer" concept
+      // in the SAME commit — buildIngestAuditIndex adds concepts/transformer to the
+      // index, so no pre-existing page is needed (this also proves same-batch links resolve).
+      const res = commitSynthesis(
+        paths,
+        "SRC-001",
+        MANIFEST,
+        makeData("The [[transformer|T]] changed everything."),
+        "2026-06-06",
+        undefined,
+        "normalize",
+      );
+      expect(res.ok).toBe(true);
+      const written = readFileSync(join(paths.wiki, "sources", "SRC-001.md"), "utf-8");
+      expect(written).toContain("[[concepts/transformer\\|T]]");
+    });
+
+    it("off is a no-op (writes verbatim, no diagnostics)", () => {
+      const paths = getVaultPaths(wikiDir);
+      const res = commitSynthesis(
+        paths,
+        "SRC-001",
+        MANIFEST,
+        makeData("See [[ghost-page]] for details."),
+        "2026-06-06",
+        undefined,
+        "off",
+      );
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.wikilinkDiagnostics).toBeUndefined();
+      const written = readFileSync(join(paths.wiki, "sources", "SRC-001.md"), "utf-8");
+      expect(written).toContain("[[ghost-page]]");
+    });
+
+    it("defaults to warn when mode is omitted", () => {
+      const paths = getVaultPaths(wikiDir);
+      const res = commitSynthesis(
+        paths,
+        "SRC-001",
+        MANIFEST,
+        makeData("See [[ghost-page]] for details."),
+        "2026-06-06",
+      );
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.wikilinkDiagnostics?.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/test/knowledge-links.test.ts
+++ b/test/knowledge-links.test.ts
@@ -176,4 +176,44 @@ describe("resolveWikilink normalization", () => {
     );
     expect(result.targets).toEqual(["concepts/retrieval-augmented-generation"]);
   });
+
+  it("exact match is returned even when normalization would find a different page", () => {
+    // Page exists at exactly `concepts/ibm` AND at `entities/ibm`
+    // The link `[[concepts/ibm]]` should resolve to `concepts/ibm` (exact)
+    // without ambiguity — normalization is only consulted when exact fails.
+    const index = buildWikilinkIndex(["concepts/ibm", "entities/ibm"]);
+    const result = buildResolvedBacklinks("sources/src-1", "[[concepts/ibm]]", index);
+    expect(result.targets).toEqual(["concepts/ibm"]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("existing slash-less link with whitespace matches by slug path", () => {
+    const index = buildWikilinkIndex(["entities/zosma-harness"]);
+    const result = buildResolvedBacklinks(
+      "sources/src-1",
+      "[[entities/zosma harness]]",
+      index,
+    );
+    expect(result.targets).toEqual(["entities/zosma-harness"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("ambiguous bare title does not resolve to any target", () => {
+    const index = buildWikilinkIndex(["entities/ibm", "concepts/ibm", "notes/ibm"]);
+    const result = buildResolvedBacklinks("sources/src-1", "[[ibm]]", index);
+    expect(result.targets).toEqual([]);
+    expect(result.unresolved).toEqual([]);
+    expect(result.diagnostics[0].code).toBe("link_ambiguous");
+    expect(result.diagnostics[0].message).toContain("entities/ibm");
+    expect(result.diagnostics[0].message).toContain("concepts/ibm");
+    expect(result.diagnostics[0].message).toContain("notes/ibm");
+  });
+
+  it("bare title that matches zero pages is reported as unresolved", () => {
+    const index = buildWikilinkIndex(["entities/ibm"]);
+    const result = buildResolvedBacklinks("sources/src-1", "[[nonexistent]]", index);
+    expect(result.targets).toEqual([]);
+    expect(result.unresolved).toEqual([{ target: "nonexistent", syntax: "wikilink" }]);
+    expect(result.diagnostics[0].code).toBe("link_unresolved");
+  });
 });

--- a/test/knowledge-links.test.ts
+++ b/test/knowledge-links.test.ts
@@ -6,7 +6,7 @@ import {
   extractLegacyWikilinks,
 } from "../extensions/llm-wiki/lib/knowledge-links.js";
 
-const known = new Set([
+const knownIds = [
   "concepts/source",
   "concepts/inline",
   "concepts/full",
@@ -14,7 +14,8 @@ const known = new Set([
   "concepts/shortcut",
   "concepts/encoded name",
   "shared/root",
-]);
+];
+const index = buildWikilinkIndex(knownIds);
 
 describe("knowledge links", () => {
   it("extracts inline and used full/collapsed/shortcut references only", () => {
@@ -50,7 +51,7 @@ describe("knowledge links", () => {
       "[[concepts/inline\\|Inline]]",
       "[external](https://example.com/x.md)",
     ].join("\n");
-    const result = buildResolvedBacklinks("concepts/source", body, known);
+    const result = buildResolvedBacklinks("concepts/source", body, index);
     expect(result.targets).toEqual(["concepts/encoded name", "concepts/inline", "shared/root"]);
     expect(result.diagnostics).toEqual([]);
   });
@@ -67,7 +68,7 @@ describe("knowledge links", () => {
     const result = buildResolvedBacklinks(
       "concepts/source",
       "[escape](../../outside.md) [missing](missing.md)",
-      known,
+      index,
     );
     expect(result.targets).toEqual([]);
     expect(result.diagnostics.map((d) => d.code).sort()).toEqual([
@@ -78,9 +79,9 @@ describe("knowledge links", () => {
 
   it("turns malformed percent encoding into a diagnostic instead of throwing", () => {
     expect(() =>
-      buildResolvedBacklinks("concepts/source", "[bad](bad%ZZ.md)", known),
+      buildResolvedBacklinks("concepts/source", "[bad](bad%ZZ.md)", index),
     ).not.toThrow();
-    const result = buildResolvedBacklinks("concepts/source", "[bad](bad%ZZ.md)", known);
+    const result = buildResolvedBacklinks("concepts/source", "[bad](bad%ZZ.md)", index);
     expect(result.targets).toEqual([]);
     expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(["link_unresolved"]);
   });
@@ -89,7 +90,7 @@ describe("knowledge links", () => {
     const result = buildResolvedBacklinks(
       "concepts/source",
       "[missing suffix](/shared/root)",
-      known,
+      index,
     );
     expect(result.targets).toEqual([]);
   });
@@ -98,7 +99,7 @@ describe("knowledge links", () => {
     const result = buildResolvedBacklinks(
       "concepts/source",
       "[one](inline.md) [[concepts/inline]] [two](./inline.md)",
-      known,
+      index,
     );
     expect(result.targets).toEqual(["concepts/inline"]);
   });

--- a/test/knowledge-links.test.ts
+++ b/test/knowledge-links.test.ts
@@ -108,11 +108,7 @@ describe("knowledge links", () => {
 describe("resolveWikilink normalization", () => {
   it("resolves bare title against a unique page by slugified basename", () => {
     const index = buildWikilinkIndex(["entities/zosma-harness", "concepts/other"]);
-    const result = buildResolvedBacklinks(
-      "sources/some-source",
-      "[[zosma harness]]",
-      index,
-    );
+    const result = buildResolvedBacklinks("sources/some-source", "[[zosma harness]]", index);
     expect(result.targets).toEqual(["entities/zosma-harness"]);
     expect(result.unresolved).toEqual([]);
   });
@@ -130,11 +126,7 @@ describe("resolveWikilink normalization", () => {
 
   it("reports ambiguous when bare title matches multiple pages", () => {
     const index = buildWikilinkIndex(["entities/ibm", "concepts/ibm"]);
-    const result = buildResolvedBacklinks(
-      "sources/some-source",
-      "[[ibm]]",
-      index,
-    );
+    const result = buildResolvedBacklinks("sources/some-source", "[[ibm]]", index);
     expect(result.targets).toEqual([]);
     expect(result.unresolved).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
@@ -146,11 +138,7 @@ describe("resolveWikilink normalization", () => {
   it("prefers exact match over normalized match", () => {
     const index = buildWikilinkIndex(["entities/ibm", "concepts/ibm"]);
     // Exact match wins even though normalized would be ambiguous for the bare slug
-    const result = buildResolvedBacklinks(
-      "sources/some-source",
-      "[[entities/ibm]]",
-      index,
-    );
+    const result = buildResolvedBacklinks("sources/some-source", "[[entities/ibm]]", index);
     expect(result.targets).toEqual(["entities/ibm"]);
     expect(result.unresolved).toEqual([]);
     expect(result.diagnostics).toEqual([]);
@@ -189,11 +177,7 @@ describe("resolveWikilink normalization", () => {
 
   it("existing slash-less link with whitespace matches by slug path", () => {
     const index = buildWikilinkIndex(["entities/zosma-harness"]);
-    const result = buildResolvedBacklinks(
-      "sources/src-1",
-      "[[entities/zosma harness]]",
-      index,
-    );
+    const result = buildResolvedBacklinks("sources/src-1", "[[entities/zosma harness]]", index);
     expect(result.targets).toEqual(["entities/zosma-harness"]);
     expect(result.unresolved).toEqual([]);
   });

--- a/test/knowledge-links.test.ts
+++ b/test/knowledge-links.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  auditWikilinks,
   buildResolvedBacklinks,
   buildWikilinkIndex,
   extractKnowledgeLinks,
@@ -199,5 +200,53 @@ describe("resolveWikilink normalization", () => {
     expect(result.targets).toEqual([]);
     expect(result.unresolved).toEqual([{ target: "nonexistent", syntax: "wikilink" }]);
     expect(result.diagnostics[0].code).toBe("link_unresolved");
+  });
+});
+const idx = buildWikilinkIndex([
+  "entities/alice",
+  "concepts/transformer",
+  "concepts/attention",
+  "concepts/other-page",
+]);
+
+describe("auditWikilinks", () => {
+  it("off returns no diagnostics and unchanged body", () => {
+    const r = auditWikilinks("see [[ghost]]", idx, "SRC-001", "off");
+    expect(r.diagnostics).toEqual([]);
+    expect(r.body).toBe("see [[ghost]]");
+    expect(r.changed).toBe(false);
+  });
+
+  it("warn reports an unresolved link and leaves the body untouched", () => {
+    const r = auditWikilinks("bad [[ghost]]", idx, "SRC-001", "warn");
+    expect(r.body).toBe("bad [[ghost]]");
+    expect(r.diagnostics.map((d) => d.code)).toContain("link_unresolved");
+  });
+
+  it("warn flags ambiguous when a bare target matches multiple pages", () => {
+    const ambiguous = buildWikilinkIndex(["entities/alice", "concepts/alice"]);
+    const r = auditWikilinks("who is [[alice]]?", ambiguous, "SRC-001", "warn");
+    const amb = r.diagnostics.find((d) => d.code === "link_ambiguous");
+    expect(amb).toBeDefined();
+    expect(r.body).toBe("who is [[alice]]?");
+  });
+
+  it("normalize rewrites resolvable targets to canonical id, preserves alias", () => {
+    const body = "see [[transformer|TF]] and [[alice]]";
+    const r = auditWikilinks(body, idx, "SRC-001", "normalize");
+    expect(r.body).toBe("see [[concepts/transformer|TF]] and [[entities/alice]]");
+    expect(r.changed).toBe(true);
+  });
+
+  it("normalize leaves unresolvable links verbatim", () => {
+    const r = auditWikilinks("see [[ghost]]", idx, "SRC-001", "normalize");
+    expect(r.body).toBe("see [[ghost]]");
+    expect(r.changed).toBe(false);
+  });
+
+  it("normalize is a no-op when every link is already canonical", () => {
+    const r = auditWikilinks("see [[concepts/attention]]", idx, "SRC-001", "normalize");
+    expect(r.body).toBe("see [[concepts/attention]]");
+    expect(r.changed).toBe(false);
   });
 });

--- a/test/knowledge-links.test.ts
+++ b/test/knowledge-links.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildResolvedBacklinks,
+  buildWikilinkIndex,
   extractKnowledgeLinks,
   extractLegacyWikilinks,
 } from "../extensions/llm-wiki/lib/knowledge-links.js";
@@ -100,5 +101,78 @@ describe("knowledge links", () => {
       known,
     );
     expect(result.targets).toEqual(["concepts/inline"]);
+  });
+});
+
+describe("resolveWikilink normalization", () => {
+  it("resolves bare title against a unique page by slugified basename", () => {
+    const index = buildWikilinkIndex(["entities/zosma-harness", "concepts/other"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[zosma harness]]",
+      index,
+    );
+    expect(result.targets).toEqual(["entities/zosma-harness"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("resolves folder-qualified link with case/space drift", () => {
+    const index = buildWikilinkIndex(["concepts/attention-is-all-you-need"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[concepts/Attention Is All You Need]]",
+      index,
+    );
+    expect(result.targets).toEqual(["concepts/attention-is-all-you-need"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("reports ambiguous when bare title matches multiple pages", () => {
+    const index = buildWikilinkIndex(["entities/ibm", "concepts/ibm"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[ibm]]",
+      index,
+    );
+    expect(result.targets).toEqual([]);
+    expect(result.unresolved).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].code).toBe("link_ambiguous");
+    expect(result.diagnostics[0].message).toContain("entities/ibm");
+    expect(result.diagnostics[0].message).toContain("concepts/ibm");
+  });
+
+  it("prefers exact match over normalized match", () => {
+    const index = buildWikilinkIndex(["entities/ibm", "concepts/ibm"]);
+    // Exact match wins even though normalized would be ambiguous for the bare slug
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[entities/ibm]]",
+      index,
+    );
+    expect(result.targets).toEqual(["entities/ibm"]);
+    expect(result.unresolved).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("resolves link with case drift in folder-qualified path", () => {
+    const index = buildWikilinkIndex(["entities/google-brain"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[Entities/Google-Brain]]",
+      index,
+    );
+    expect(result.targets).toEqual(["entities/google-brain"]);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("resolves slugified trailing slash variant", () => {
+    const index = buildWikilinkIndex(["concepts/retrieval-augmented-generation"]);
+    const result = buildResolvedBacklinks(
+      "sources/some-source",
+      "[[concepts/Retrieval Augmented Generation]]",
+      index,
+    );
+    expect(result.targets).toEqual(["concepts/retrieval-augmented-generation"]);
   });
 });

--- a/test/knowledge-links.test.ts
+++ b/test/knowledge-links.test.ts
@@ -250,3 +250,44 @@ describe("auditWikilinks", () => {
     expect(r.changed).toBe(false);
   });
 });
+import { applyWikilinkGate } from "../extensions/llm-wiki/lib/knowledge-links.js";
+
+const gateIdx = buildWikilinkIndex(["concepts/transformer"]);
+
+describe("applyWikilinkGate", () => {
+  const body = "see [[transformer]] and [[ghost]]";
+
+  it("off → ok, unchanged body, no diagnostics", () => {
+    const r = applyWikilinkGate(body, gateIdx, "x", "off");
+    expect(r.ok).toBe(true);
+    expect(r.body).toBe(body);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("warn → ok, unchanged body, reports only the missing link", () => {
+    const r = applyWikilinkGate(body, gateIdx, "x", "warn");
+    expect(r.ok).toBe(true);
+    expect(r.body).toBe(body); // not rewritten
+    const codes = r.diagnostics.map((d) => d.code);
+    expect(codes).toEqual(["link_unresolved"]); // [[ghost]] only; [[transformer]] resolves
+  });
+
+  it("strict → not ok when a link is missing", () => {
+    const r = applyWikilinkGate(body, gateIdx, "x", "strict");
+    expect(r.ok).toBe(false);
+    expect(r.diagnostics.length).toBe(1);
+  });
+
+  it("strict → ok when every link resolves", () => {
+    const r = applyWikilinkGate("see [[transformer]]", gateIdx, "x", "strict");
+    expect(r.ok).toBe(true);
+    expect(r.diagnostics).toEqual([]);
+  });
+
+  it("normalize → rewrites resolvable links, still reports missing", () => {
+    const r = applyWikilinkGate(body, gateIdx, "x", "normalize");
+    expect(r.ok).toBe(true);
+    expect(r.body).toBe("see [[concepts/transformer]] and [[ghost]]");
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["link_unresolved"]);
+  });
+});

--- a/test/mcp-parity.test.ts
+++ b/test/mcp-parity.test.ts
@@ -128,7 +128,7 @@ describe("MCP parity with shared services", () => {
       rmSync(personalPagePath);
       rebuildMetadata(personalVault);
     }
-  });
+  }, 30_000);
 
   it("retro parity: MCP uses same saveInsight as Pi", async () => {
     // Pi-style call

--- a/test/mcp-wikilink-gate.test.ts
+++ b/test/mcp-wikilink-gate.test.ts
@@ -1,0 +1,87 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+import { retroOperation } from "../mcp/operations.js";
+
+let tmpDir: string;
+let paths: ReturnType<typeof getVaultPaths>;
+
+beforeEach(() => {
+  tmpDir = join(import.meta.dirname, "..", "tmp", `mcp-gate-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+  paths = getVaultPaths(tmpDir);
+  ensureVaultStructure(paths);
+  writeFileSync(
+    join(paths.dotWiki, "config.json"),
+    JSON.stringify({ topic: "Test", mode: "personal", knowledge_format: "legacy" }),
+  );
+  // Seed the registry with one resolvable target so [[transformer]] resolves and [[ghost]] does not.
+  writeFileSync(
+    join(paths.meta, "registry.json"),
+    JSON.stringify({
+      version: "1.0",
+      last_updated: "",
+      pages: {
+        "concepts/transformer": {
+          id: "concepts/transformer",
+          title: "Transformer",
+          type: "concept",
+        },
+      },
+    }),
+  );
+});
+
+afterEach(() => {
+  try {
+    rmSync(tmpDir, { recursive: true, force: true }); // only this test's own root
+  } catch {}
+});
+
+describe("retroOperation wikilink gate", () => {
+  const body = "Learned about [[transformer]] and [[ghost]]";
+  const pagePath = () => join(paths.wiki, "sources", "mcp-gate-note.md");
+
+  it("default (warn) → saves, does not fail", async () => {
+    const res = await retroOperation(paths, "mcp-gate-note", "MCP Gate Note", body);
+    expect(res.ok).toBe(true);
+    expect(existsSync(pagePath())).toBe(true);
+  });
+
+  it("off → saves verbatim", async () => {
+    const res = await retroOperation(paths, "mcp-gate-note", "MCP Gate Note", body, "test", "off");
+    expect(res.ok).toBe(true);
+    expect(existsSync(pagePath())).toBe(true);
+  });
+
+  it("strict → rejects with link_validation, writes nothing", async () => {
+    const res = await retroOperation(
+      paths,
+      "mcp-gate-note",
+      "MCP Gate Note",
+      body,
+      "test",
+      "strict",
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.diagnostics.some((d) => d.code === "link_validation")).toBe(true);
+    expect(existsSync(pagePath())).toBe(false);
+  });
+
+  it("normalize → saves with the resolvable link rewritten", async () => {
+    const res = await retroOperation(
+      paths,
+      "mcp-gate-note",
+      "MCP Gate Note",
+      body,
+      "test",
+      "normalize",
+    );
+    expect(res.ok).toBe(true);
+    const text = existsSync(pagePath()) ? readFileSync(pagePath(), "utf-8") : "";
+    expect(text).toContain("[[concepts/transformer]]");
+    expect(text).toContain("[[ghost]]");
+  });
+});

--- a/test/task-config.test.ts
+++ b/test/task-config.test.ts
@@ -1,0 +1,43 @@
+import { mkdirSync, rmSync, writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  loadTaskConfig,
+  resolveWikilinkValidation,
+  type TaskConfig,
+} from "../extensions/llm-wiki/lib/task-config.js";
+
+describe("resolveWikilinkValidation", () => {
+  it("defaults to warn when unset/undefined", () => {
+    expect(resolveWikilinkValidation(undefined)).toBe("warn");
+    expect(resolveWikilinkValidation({})).toBe("warn");
+  });
+
+  it("returns an explicit valid mode", () => {
+    for (const m of ["off", "warn", "strict", "normalize"] as const) {
+      const config: TaskConfig = { wikilinkValidation: m };
+      expect(resolveWikilinkValidation(config)).toBe(m);
+    }
+  });
+
+  it("falls back to warn on an invalid value", () => {
+    const config = { wikilinkValidation: "bogus" } as unknown as TaskConfig;
+    expect(resolveWikilinkValidation(config)).toBe("warn");
+  });
+
+  it("reads wikilinkValidation from the llm-wiki settings namespace", () => {
+    const project = mkdtempSync(join(tmpdir(), "wl-"));
+    try {
+      mkdirSync(join(project, ".omp"), { recursive: true });
+      writeFileSync(
+        join(project, ".omp", "settings.json"),
+        JSON.stringify({ "llm-wiki": { wikilinkValidation: "strict" } }),
+      );
+      // The settings value must flow through readNamespacedConfig into TaskConfig.
+      expect(resolveWikilinkValidation(loadTaskConfig(project))).toBe("strict");
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/task-config.test.ts
+++ b/test/task-config.test.ts
@@ -1,11 +1,11 @@
-import { mkdirSync, rmSync, writeFileSync, mkdtempSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  type TaskConfig,
   loadTaskConfig,
   resolveWikilinkValidation,
-  type TaskConfig,
 } from "../extensions/llm-wiki/lib/task-config.js";
 
 describe("resolveWikilinkValidation", () => {

--- a/test/wikilink-gate.test.ts
+++ b/test/wikilink-gate.test.ts
@@ -12,12 +12,20 @@ interface Tool {
     s: undefined,
     u: undefined,
     ctx: unknown,
-  ) => Promise<{ isError?: boolean; content: Array<{ text: string }>; details: Record<string, unknown> }>;
+  ) => Promise<{
+    isError?: boolean;
+    content: Array<{ text: string }>;
+    details: Record<string, unknown>;
+  }>;
 }
 
 function capture(fn: (pi: ExtensionAPI) => void): Tool {
   let tool: Tool | undefined;
-  const pi = { registerTool: (def: unknown) => (tool = def as Tool) } as unknown as ExtensionAPI;
+  const pi = {
+    registerTool: (def: unknown) => {
+      tool = def as Tool;
+    },
+  } as unknown as ExtensionAPI;
   fn(pi);
   if (!tool) throw new Error("tool not registered");
   return tool;
@@ -38,10 +46,7 @@ beforeEach(() => {
   }
   // config.json is required — both tools call inspectWritableVault, which hard-blocks
   // on an absent/unreadable config (config_invalid_knowledge_format). Mirror retro.test.ts.
-  writeFileSync(
-    join(llm, "config.json"),
-    JSON.stringify({ topic: "Test", mode: "personal" }),
-  );
+  writeFileSync(join(llm, "config.json"), JSON.stringify({ topic: "Test", mode: "personal" }));
   ensureVaultStructure(getVaultPaths(wikiDir));
   // Seed the registry with one resolvable target so [[transformer]] resolves and [[ghost]] does not.
   writeFileSync(
@@ -49,7 +54,13 @@ beforeEach(() => {
     JSON.stringify({
       version: "1.0",
       last_updated: "",
-      pages: { "concepts/transformer": { id: "concepts/transformer", title: "Transformer", type: "concept" } },
+      pages: {
+        "concepts/transformer": {
+          id: "concepts/transformer",
+          title: "Transformer",
+          type: "concept",
+        },
+      },
     }),
   );
   // No .pi/settings.json here → default mode is "warn".
@@ -64,7 +75,10 @@ afterEach(() => {
 function setMode(mode: string): void {
   const cfg = join(wikiDir, ".pi");
   mkdirSync(cfg, { recursive: true });
-  writeFileSync(join(cfg, "settings.json"), JSON.stringify({ "llm-wiki": { wikilinkValidation: mode } }));
+  writeFileSync(
+    join(cfg, "settings.json"),
+    JSON.stringify({ "llm-wiki": { wikilinkValidation: mode } }),
+  );
 }
 
 describe("wiki_ensure_page wikilink gate", () => {
@@ -113,7 +127,9 @@ describe("wiki_ensure_page wikilink gate", () => {
     );
     expect(res.isError).toBe(true);
     expect(res.details.error).toBe("link_validation");
-    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "concepts", "ghost-concept.md"))).toBe(false);
+    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "concepts", "ghost-concept.md"))).toBe(
+      false,
+    );
   });
 
   it("normalize → rewrites resolvable link, reports the missing one", async () => {
@@ -151,7 +167,9 @@ describe("wiki_retro wikilink gate", () => {
     const issues = res.details.wikilinkIssues as string[];
     expect(issues.length).toBe(1);
     expect(issues[0]).toContain("ghost");
-    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"))).toBe(true);
+    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"))).toBe(
+      true,
+    );
   });
 
   it("strict → rejects, writes nothing", async () => {
@@ -166,7 +184,9 @@ describe("wiki_retro wikilink gate", () => {
     );
     expect(res.isError).toBe(true);
     expect(res.details.error).toBe("link_validation");
-    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"))).toBe(false);
+    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"))).toBe(
+      false,
+    );
   });
 
   it("normalize → saves with the resolvable link rewritten", async () => {
@@ -180,7 +200,10 @@ describe("wiki_retro wikilink gate", () => {
       { cwd: wikiDir, hasUI: false },
     );
     expect(res.isError).toBeFalsy();
-    const text = readFileSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"), "utf-8");
+    const text = readFileSync(
+      join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"),
+      "utf-8",
+    );
     expect(text).toContain("[[concepts/transformer]]");
     expect(text).toContain("[[ghost]]");
   });

--- a/test/wikilink-gate.test.ts
+++ b/test/wikilink-gate.test.ts
@@ -1,0 +1,135 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerWikiEnsurePage } from "../extensions/llm-wiki/lib/tools.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+
+interface Tool {
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+    s: undefined,
+    u: undefined,
+    ctx: unknown,
+  ) => Promise<{ isError?: boolean; content: Array<{ text: string }>; details: Record<string, unknown> }>;
+}
+
+function capture(fn: (pi: ExtensionAPI) => void): Tool {
+  let tool: Tool | undefined;
+  const pi = { registerTool: (def: unknown) => (tool = def as Tool) } as unknown as ExtensionAPI;
+  fn(pi);
+  if (!tool) throw new Error("tool not registered");
+  return tool;
+}
+
+let wikiDir: string;
+
+beforeEach(() => {
+  wikiDir = join(
+    import.meta.dirname,
+    "..",
+    "tmp",
+    `wg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  const llm = join(wikiDir, ".llm-wiki");
+  for (const d of ["wiki/entities", "wiki/concepts", "wiki/sources", "meta", "outputs"]) {
+    mkdirSync(join(llm, d), { recursive: true });
+  }
+  // config.json is required — both tools call inspectWritableVault, which hard-blocks
+  // on an absent/unreadable config (config_invalid_knowledge_format). Mirror retro.test.ts.
+  writeFileSync(
+    join(llm, "config.json"),
+    JSON.stringify({ topic: "Test", mode: "personal" }),
+  );
+  ensureVaultStructure(getVaultPaths(wikiDir));
+  // Seed the registry with one resolvable target so [[transformer]] resolves and [[ghost]] does not.
+  writeFileSync(
+    join(llm, "meta", "registry.json"),
+    JSON.stringify({
+      version: "1.0",
+      last_updated: "",
+      pages: { "concepts/transformer": { id: "concepts/transformer", title: "Transformer", type: "concept" } },
+    }),
+  );
+  // No .pi/settings.json here → default mode is "warn".
+});
+
+afterEach(() => {
+  try {
+    rmSync(wikiDir, { recursive: true, force: true }); // only this test's own root, never the shared test/tmp
+  } catch {}
+});
+
+function setMode(mode: string): void {
+  const cfg = join(wikiDir, ".pi");
+  mkdirSync(cfg, { recursive: true });
+  writeFileSync(join(cfg, "settings.json"), JSON.stringify({ "llm-wiki": { wikilinkValidation: mode } }));
+}
+
+describe("wiki_ensure_page wikilink gate", () => {
+  const content = "see [[transformer]] and [[ghost]]";
+
+  it("off → writes verbatim, no issues surfaced", async () => {
+    setMode("off");
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Ghost Concept", content },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const file = join(getVaultPaths(wikiDir).wiki, "concepts", "ghost-concept.md");
+    expect(existsSync(file)).toBe(true);
+    expect(res.details.wikilinkIssues).toEqual([]);
+  });
+
+  it("warn → writes, reports the missing link (transformer resolves, not reported)", async () => {
+    const tool = capture((pi) => registerWikiEnsurePage(pi)); // default warn
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Ghost Concept", content },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const issues = res.details.wikilinkIssues as string[];
+    expect(issues.length).toBe(1);
+    expect(issues[0]).toContain("ghost");
+  });
+
+  it("strict → rejects, writes nothing", async () => {
+    setMode("strict");
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Ghost Concept", content },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.details.error).toBe("link_validation");
+    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "concepts", "ghost-concept.md"))).toBe(false);
+  });
+
+  it("normalize → rewrites resolvable link, reports the missing one", async () => {
+    setMode("normalize");
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Ghost Concept", content },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const file = join(getVaultPaths(wikiDir).wiki, "concepts", "ghost-concept.md");
+    const text = readFileSync(file, "utf-8");
+    expect(text).toContain("[[concepts/transformer]]");
+    expect(text).toContain("[[ghost]]");
+  });
+});

--- a/test/wikilink-gate.test.ts
+++ b/test/wikilink-gate.test.ts
@@ -133,3 +133,55 @@ describe("wiki_ensure_page wikilink gate", () => {
     expect(text).toContain("[[ghost]]");
   });
 });
+import { registerWikiRetro } from "../extensions/llm-wiki/lib/retro.js";
+
+describe("wiki_retro wikilink gate", () => {
+  const body = "Learned about [[transformer]] and [[ghost]]";
+
+  it("warn (default) → saves, reports the missing link", async () => {
+    const tool = capture((pi) => registerWikiRetro(pi));
+    const res = await tool.execute(
+      "t",
+      { slug: "transformer-note", title: "Transformer Note", body },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const issues = res.details.wikilinkIssues as string[];
+    expect(issues.length).toBe(1);
+    expect(issues[0]).toContain("ghost");
+    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"))).toBe(true);
+  });
+
+  it("strict → rejects, writes nothing", async () => {
+    setMode("strict");
+    const tool = capture((pi) => registerWikiRetro(pi));
+    const res = await tool.execute(
+      "t",
+      { slug: "transformer-note", title: "Transformer Note", body },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.details.error).toBe("link_validation");
+    expect(existsSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"))).toBe(false);
+  });
+
+  it("normalize → saves with the resolvable link rewritten", async () => {
+    setMode("normalize");
+    const tool = capture((pi) => registerWikiRetro(pi));
+    const res = await tool.execute(
+      "t",
+      { slug: "transformer-note", title: "Transformer Note", body },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const text = readFileSync(join(getVaultPaths(wikiDir).wiki, "sources", "transformer-note.md"), "utf-8");
+    expect(text).toContain("[[concepts/transformer]]");
+    expect(text).toContain("[[ghost]]");
+  });
+});


### PR DESCRIPTION
## Pre-write wikilink gate (#172)

Validates/normalizes wikilinks in agent- and user-supplied page content **before** write, across all four write paths, controlled by a new `wikilinkValidation` setting (default `warn`).

### The mode — two independent axes, not a severity ladder
- **resolvable-but-drifted link** (target exists): *leave* vs. *rewrite-to-canonical*
- **unresolvable link** (target absent — a forward reference / gap): *ignore* vs. *report* vs. *reject*

| mode | drifted links | missing/ambiguous | effect |
|---|---|---|---|
| `off` | leave | ignore | zero behavior change |
| `warn` *(default)* | leave | report | non-mutating, non-blocking, surfaces issues |
| `normalize` | **rewrite** | report | fixes resolvable links; still reports gaps |
| `strict` | leave | **reject** | blocks the write, bad links named (agent retry signal) |

A link that **resolves** is never flagged — only normalized. Only genuinely missing or ambiguous targets produce diagnostics. So `strict` blocks only on real gaps, never on cosmetic drift.

### Gated write paths
- `commitSynthesis` (ingest) — Layer 2a
- `wiki_ensure_page` — caller-supplied `content`
- `wiki_retro` (pi tool) — caller-supplied `body`
- MCP `wiki_retro` — same gate at the MCP boundary

### Architecture
New pure helper `applyWikilinkGate(body, index, sourceId, mode)` in `knowledge-links.ts` wraps the existing `auditWikilinks` resolver and returns `{ ok, body, diagnostics }`. Each tool builds the index from `meta/registry.json` (same source as the ingest gate), runs the gate on the caller-supplied body, and per result: `strict` → return `isError` (no write); `normalize` → write the normalized body; `warn` → write and append a `wikilinkIssues` detail + ⚠️ note. Mode resolved via `resolveWikilinkValidation(loadTaskConfig(cwd))`.

### Verification
- **TDD throughout** — every task: failing test → confirm FAIL → implement → confirm PASS → commit.
- `pnpm typecheck` ✓ · `pnpm lint` ✓ (107 files) · `pnpm test` → **725 passed** (709 prior + 12 pi-tool gate tests + 4 MCP gate tests).
- **Live smoke test in restarted pi:** `wiki_ensure_page` with `[[smoke-gate-probe]]` (resolvable) + `[[ghost-not-a-page-strict-xyz]]` (dangling) → wrote, flagged **only** the dangling link, correctly ignored the resolvable one. Same for `wiki_retro`.
- Pre-existing `wiki_retro`/`wiki_ensure_page`/`commitSynthesis` tests still pass — `warn` never blocks or mutates.

### Docs
`wikilinkValidation` row added to `docs/configuration.md`; two-axis mode documented on the `WikilinkValidationMode` type.

### Deploy note
pi loads this from the source path — a **full pi restart** makes it live. To block writes, set `"wikilinkValidation": "strict"` under the `llm-wiki` settings key.
