### PR TITLE
fix(docs): correct obsidian vault root to .llm-wiki/ (#175)

### DIFF
--- a/docs/obsidian.md
+++ b/docs/obsidian.md
@@ -2,20 +2,20 @@
 
 ## Setup
 
-1. Open `.llm-wiki/wiki/` as an Obsidian vault
-2. The extension generates `.llm-wiki/meta/index.md` as a browsable catalog
-3. `.llm-wiki/meta/backlinks.json` is available for graph plugins
+1. Open `.llm-wiki/` as an Obsidian vault
+2. Your wiki pages live in `wiki/` — Graph View and Backlinks work on these automatically
+3. The extension generates `meta/index.md` (browsable catalog) and `meta/backlinks.json` (link map) — both are read-only, regenerated on each rebuild
 
 ## Recommended Plugins
 
 - [Dataview](https://github.com/blacksmithgu/obsidian-dataview) — Query pages by frontmatter
-- [Graph View](https://obsidian.md) (built-in) — Visualize `[[wikilink]]` connections
+- [Graph View](https://obsidian.md) (built-in) — Visualize `[[wikilink]]` connections in `wiki/`
 - [Backlinks](https://obsidian.md) (built-in) — See inbound links
 
 ## Web Clipper
 
-Use [Obsidian Web Clipper](https://obsidian.md/clipper) to save articles directly into `.llm-wiki/raw/articles/`.
+Use [Obsidian Web Clipper](https://obsidian.md/clipper) to save articles directly into `raw/articles/`.
 
 ## Dataview Dashboard
 
-The extension creates `.llm-wiki/meta/index.md` with page listings. For custom dashboards, use Dataview queries against frontmatter fields like `type`, `domain`, `category`, `sources`.
+For custom dashboards, use Dataview queries against frontmatter fields like `type`, `domain`, `category`, `sources`. Query the `wiki/` directory for knowledge pages.


### PR DESCRIPTION
## What

The Obsidian integration doc told users to open `.llm-wiki/wiki/` as the vault, then referenced `meta/index.md` and `meta/backlinks.json` — which live outside that root and are invisible to Obsidian.

## Fix

Changed the vault root to `.llm-wiki/` so meta files are visible. They remain read-only per the architecture.md guardrails (extension regenerates them on rebuild).

Also cleaned up path references throughout (removed redundant `.llm-wiki/` prefix since the vault root IS `.llm-wiki/`).

## Testing

- 725 tests pass (doc-only change, no code touched)
- Verified against actual `~/.llm-wiki/` directory structure

Closes #175