### PR TITLE
fix: accept keyless providers in resolveModel (closes #174)

### DIFF
--- a/extensions/llm-wiki/lib/runtime.ts
+++ b/extensions/llm-wiki/lib/runtime.ts
@@ -133,11 +133,11 @@ export class Runtime {
     }
 
     const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-    if (!auth.ok || !auth.apiKey) {
+    if (!auth.ok) {
       const provider = (model as { provider?: string }).provider ?? "unknown";
       return { ok: false, reason: `no API key for provider "${provider}"` };
     }
-    return { ok: true, model, apiKey: auth.apiKey, headers: auth.headers };
+    return { ok: true, model, apiKey: auth.apiKey ?? "", headers: auth.headers };
   }
 
   /**

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -33,13 +33,15 @@ const CONFIG_MODEL = { provider: "cfg-prov", id: "cfg-model" };
 function makeRegistry(opts: {
   found?: unknown;
   authOk?: boolean;
-  apiKey?: string;
+  apiKey?: string | undefined;
+  _apiKeySet?: boolean;
 }) {
+  const apiKeyExplicit = opts._apiKeySet ?? false;
   return {
     find: (_p: string, _i: string) => opts.found,
     getApiKeyAndHeaders: async (_m: unknown) => ({
       ok: opts.authOk ?? true,
-      apiKey: opts.apiKey ?? (opts.authOk === false ? undefined : "key-123"),
+      apiKey: apiKeyExplicit ? opts.apiKey : opts.authOk === false ? undefined : "key-123",
       headers: { "x-test": "1" },
     }),
   };
@@ -179,6 +181,23 @@ describe("Runtime.resolveModel", () => {
     const res = await rt.resolveModel({ model: SESSION_MODEL, modelRegistry: reg, hasUI: false });
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.reason).toMatch(/no API key/);
+  });
+
+  it("accepts a keyless provider (authOk, no apiKey)", async () => {
+    const rt = new Runtime();
+    const reg = makeRegistry({
+      found: undefined,
+      authOk: true,
+      apiKey: undefined,
+      _apiKeySet: true,
+    });
+    const res = await rt.resolveModel({ model: SESSION_MODEL, modelRegistry: reg, hasUI: false });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.model).toBe(SESSION_MODEL);
+      expect(res.apiKey).toBe("");
+      expect(res.headers).toEqual({ "x-test": "1" });
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

`Runtime.resolveModel()` rejected providers where `getApiKeyAndHeaders` returns `{ ok: true }` without an `apiKey` field — that is the correct response for keyless local servers like llama.cpp or self-hosted. The `|| !auth.apiKey` guard wrongly treated "no key needed" as "key required but missing".

Consequence: `wiki_ingest` background synthesis silently no-op for keyless providers. The synchronous fallback path returned a success-looking message, so both agent and user thought ingestion was progressing. Sources stayed as skeleton stubs.

## Fix

Removed `|| !auth.apiKey` from the auth gate in `resolveModel()`. The `!auth.ok` clause alone is sufficient — providers requiring auth return `{ ok: false }` when no key is present. Keyless providers now receive `apiKey: ""` which is harmless to local servers.

**Files changed:** `extensions/llm-wiki/lib/runtime.ts` (+2/-2), `test/runtime.test.ts` (+23/-2)

## Tests

- 726 passing (725 prior + 1 new keyless provider test)
- New test: `makeRegistry({ authOk: true, apiKey: undefined, _apiKeySet: true })` produces `resolveModel` returning `ok: true` with `apiKey: ""`
- Existing test: `authOk: false` still rejected (unchanged behavior for providers requiring auth)

## Verified by

Reported by **ackalker** in #174 with root cause analysis and proposed fix. The fix matches the proposed solution exactly.