### PR TITLE
feat: support custom wiki page types via config (closes #169)

### DIFF
--- a/extensions/llm-wiki/lib/task-config.ts
+++ b/extensions/llm-wiki/lib/task-config.ts
@@ -159,6 +159,16 @@ export interface TaskConfig {
    * Default "warn". See `resolveWikilinkValidation`.
    */
   wikilinkValidation?: WikilinkValidationMode;
+
+  /**
+   * User-defined page types for wiki_ensure_page (issue #169). Merges with
+   * the 7 built-in types (entity, concept, synthesis, analysis, requirement,
+   * skill, case). Each key is the type name; each value is the folder name
+   * inside wiki/. Example: { "decision": "decisions", "metric": "metrics" }
+   * → wiki_ensure_page(type="decision") creates wiki/decisions/<slug>.md.
+   * Custom types use a generic page template (no per-type templates).
+   */
+  customTypes?: Record<string, string>;
 }
 
 export const TASK_DEFAULTS: TaskConfig = {};
@@ -284,6 +294,18 @@ function readNamespacedConfig(path: string): Partial<TaskConfig> {
     const wl = section.wikilinkValidation;
     if (typeof wl === "string" && (WIKILINK_VALIDATION_MODES as readonly string[]).includes(wl)) {
       out.wikilinkValidation = wl as WikilinkValidationMode;
+    }
+
+    const ct = section.customTypes;
+    if (ct && typeof ct === "object" && !Array.isArray(ct)) {
+      const entries = Object.entries(ct as Record<string, unknown>);
+      const valid: Record<string, string> = {};
+      for (const [k, v] of entries) {
+        if (typeof k === "string" && typeof v === "string" && k && v) {
+          valid[k] = v;
+        }
+      }
+      if (Object.keys(valid).length) out.customTypes = valid;
     }
 
     return out;
@@ -474,6 +496,7 @@ const KNOWN_KEYS = [
   "synthesisLanguage",
   "synthesisMaxTokens",
   "wikilinkValidation",
+  "customTypes",
 ] as const;
 
 export function loadTaskConfigSources(

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -519,7 +519,7 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
     parameters: Type.Object({
       type: Type.String({
         description:
-          "Page type: entity | concept | synthesis | analysis | requirement | skill | case",
+          "Page type: entity | concept | synthesis | analysis | requirement | skill | case (built-in) or any user-defined type from llm-wiki.customTypes config",
       }),
       title: Type.String({ description: "Page title" }),
       content: Type.Optional(
@@ -542,17 +542,8 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
         };
       }
 
-      const type = params.type as
-        | "entity"
-        | "concept"
-        | "synthesis"
-        | "analysis"
-        | "requirement"
-        | "skill"
-        | "case";
-      const slug = slugify(params.title);
-
-      const folderMap: Record<string, string> = {
+      const config = loadTaskConfig(ctx.cwd);
+      const builtInFolderMap: Record<string, string> = {
         entity: "entities",
         concept: "concepts",
         synthesis: "syntheses",
@@ -561,6 +552,9 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
         skill: "skills",
         case: "cases",
       };
+      const folderMap = { ...builtInFolderMap, ...config.customTypes };
+      const type = params.type as string;
+      const slug = slugify(params.title);
       const folder = folderMap[type] || "concepts";
       const pagePath = join(paths.wiki, folder, `${slug}.md`);
 

--- a/test/custom-types.test.ts
+++ b/test/custom-types.test.ts
@@ -1,0 +1,159 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { registerWikiEnsurePage } from "../extensions/llm-wiki/lib/tools.js";
+import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
+
+interface Tool {
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+    s: undefined,
+    u: undefined,
+    ctx: unknown,
+  ) => Promise<{
+    isError?: boolean;
+    content: Array<{ text: string }>;
+    details: Record<string, unknown>;
+  }>;
+}
+
+function capture(fn: (pi: ExtensionAPI) => void): Tool {
+  let tool: Tool | undefined;
+  const pi = {
+    registerTool: (def: unknown) => {
+      tool = def as Tool;
+    },
+  } as unknown as ExtensionAPI;
+  fn(pi);
+  if (!tool) throw new Error("tool not registered");
+  return tool;
+}
+
+let wikiDir: string;
+
+beforeEach(() => {
+  wikiDir = join(
+    import.meta.dirname,
+    "..",
+    "tmp",
+    `ct-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  const llm = join(wikiDir, ".llm-wiki");
+  for (const d of ["wiki/entities", "wiki/concepts", "wiki/sources", "meta", "outputs"]) {
+    mkdirSync(join(llm, d), { recursive: true });
+  }
+  writeFileSync(join(llm, "config.json"), JSON.stringify({ topic: "Test", mode: "personal" }));
+  ensureVaultStructure(getVaultPaths(wikiDir));
+  writeFileSync(
+    join(llm, "meta", "registry.json"),
+    JSON.stringify({ version: "1.0", last_updated: "", pages: {} }),
+  );
+});
+
+afterEach(() => {
+  try {
+    rmSync(wikiDir, { recursive: true, force: true });
+  } catch {}
+});
+
+function writeSettings(customTypes: Record<string, string>): void {
+  const cfg = join(wikiDir, ".pi");
+  mkdirSync(cfg, { recursive: true });
+  writeFileSync(join(cfg, "settings.json"), JSON.stringify({ "llm-wiki": { customTypes } }));
+}
+
+describe("wiki_ensure_page custom types", () => {
+  it("creates a custom type in the correct folder", async () => {
+    writeSettings({ decision: "decisions" });
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "decision", title: "Auth Architecture" },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const expected = join(getVaultPaths(wikiDir).wiki, "decisions", "auth-architecture.md");
+    expect(existsSync(expected)).toBe(true);
+    expect(res.details.created).toBe(true);
+  });
+
+  it("built-in types still work alongside custom types", async () => {
+    writeSettings({ decision: "decisions" });
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "entity", title: "Test Entity" },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const expected = join(getVaultPaths(wikiDir).wiki, "entities", "test-entity.md");
+    expect(existsSync(expected)).toBe(true);
+  });
+
+  it("custom type uses generic template when no content provided", async () => {
+    writeSettings({ metric: "metrics" });
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "metric", title: "API Latency" },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const file = join(getVaultPaths(wikiDir).wiki, "metrics", "api-latency.md");
+    const body = readFileSync(file, "utf-8");
+    expect(body).toContain("# API Latency");
+    expect(body).toContain("## Links");
+  });
+
+  it("custom type with explicit content writes that content", async () => {
+    writeSettings({ decision: "decisions" });
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "decision", title: "Use Postgres", content: "# Use Postgres\n\nWe chose Postgres." },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const file = join(getVaultPaths(wikiDir).wiki, "decisions", "use-postgres.md");
+    const body = readFileSync(file, "utf-8");
+    expect(body).toContain("We chose Postgres.");
+  });
+
+  it("undefined customTypes (no config) falls back to built-ins only", async () => {
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Test Concept" },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const expected = join(getVaultPaths(wikiDir).wiki, "concepts", "test-concept.md");
+    expect(existsSync(expected)).toBe(true);
+  });
+
+  it("unrecognized type without config falls back to concepts folder", async () => {
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "nonexistent", title: "Fallback Page" },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const expected = join(getVaultPaths(wikiDir).wiki, "concepts", "fallback-page.md");
+    expect(existsSync(expected)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `customTypes` to `TaskConfig` so users can register project-specific page types (e.g. `decision`, `metric`) via `settings.json`. Custom types merge with the 7 built-in types and use a generic page template.

## Changes

- **`task-config.ts`**: Added `customTypes?: Record<string, string>` to `TaskConfig`, parsing in `readNamespacedConfig`, and `KNOWN_KEYS` entry
- **`tools.ts`**: `wiki_ensure_page` now loads config and spreads `customTypes` into the folder map; type param description updated
- **`test/custom-types.test.ts`**: 6 tests covering custom type creation, built-in coexistence, generic template, explicit content, no-config fallback, and unknown-type fallback

## Design

- Custom types are a flat `Record<string, string>` — key is type name, value is folder inside `wiki/`
- Validation rejects arrays, nested objects, and non-string values
- No per-type templates (YAGNI) — custom types hit the existing generic fallback in `buildPageBody`
- Zero-config: when `customTypes` is absent, behavior is identical to before

Closes #169
