### PR TITLE
feat: overlay popup for wiki-settings and wiki-dashboard

### DIFF
--- a/extensions/llm-wiki/lib/dashboard-command.ts
+++ b/extensions/llm-wiki/lib/dashboard-command.ts
@@ -84,6 +84,12 @@ export class DashboardScreen extends Container {
   }
 }
 
+// ponytail: overlay options matching pi-blackhole's config modal style
+const OVERLAY_OPTS = {
+  overlay: true,
+  overlayOptions: { anchor: "center", width: "92%", maxHeight: "95%" } as const,
+};
+
 /**
  * Register the /wiki-dashboard command.
  */
@@ -100,7 +106,7 @@ export function registerWikiDashboardCommand(pi: ExtensionAPI, runtime: Runtime)
       const stats = await collectDashboardStats(ctx.cwd);
       await ctx.ui.custom((_tui, _theme, _keybindings, close) => {
         return new DashboardScreen(renderStatsLines(stats), close);
-      });
+      }, OVERLAY_OPTS);
     },
   });
 }

--- a/extensions/llm-wiki/lib/settings-command.ts
+++ b/extensions/llm-wiki/lib/settings-command.ts
@@ -49,6 +49,7 @@ interface Ui {
       keybindings: unknown,
       done: (result?: unknown) => void,
     ) => unknown,
+    options?: { overlay?: boolean; overlayOptions?: Record<string, unknown> },
   ): Promise<unknown>;
 }
 
@@ -363,6 +364,12 @@ function scopeTitle(scope: SettingScope): string {
   return `\u{1F9E0} LLM Wiki Settings \u2014 ${scope === "global" ? "Global" : "Project"} (Esc to close)`;
 }
 
+// ponytail: overlay options matching pi-blackhole's config modal style
+const OVERLAY_OPTS = {
+  overlay: true,
+  overlayOptions: { anchor: "center", width: "92%", maxHeight: "95%" },
+};
+
 async function showSettingsTui(ui: Ui, cwd: string, scope: SettingScope): Promise<void> {
   if (typeof ui.custom !== "function") {
     ui.notify(
@@ -445,7 +452,7 @@ async function showSettingsTui(ui: Ui, cwd: string, scope: SettingScope): Promis
     );
     screenRef = new SettingsScreen(scopeTitle(writeScope), list);
     return screenRef;
-  });
+  }, OVERLAY_OPTS);
 }
 
 /**


### PR DESCRIPTION
Add overlay options to `ui.custom()` in both commands, matching pi-blackhole's config modal style (anchor: center, width: 92%, maxHeight: 95%).

Previously these rendered as full-screen takeovers. Now they appear as centered popup overlays like `/blackhole settings`.