### PR TITLE
fix(codeql): resolve code scanning alerts #66, #38

### DIFF
--- a/extensions/llm-wiki/lib/ingest-worker.ts
+++ b/extensions/llm-wiki/lib/ingest-worker.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import type { Api, Model } from "@mariozechner/pi-ai";

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -51,9 +51,9 @@ fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
 // Update CHANGELOG
 const changelogPath = path.join(__dirname, "..", "CHANGELOG.md");
 let changelog = "";
-if (fs.existsSync(changelogPath)) {
+try {
   changelog = fs.readFileSync(changelogPath, "utf-8");
-}
+} catch {}
 const today = new Date().toISOString().split("T")[0];
 const newSection = `## [${next}] - ${today}\n\n### Added\n- Release ${next}\n`;
 if (changelog.includes("## [Unreleased]")) {


### PR DESCRIPTION
Closes CodeQL alerts:

- **#66** `js/unused-local-variable` in `extensions/llm-wiki/lib/ingest-worker.ts:1` — removed unused `writeFileSync` import (note severity)
- **#38** `js/file-system-race` in `scripts/release.js:54-55` (flagged at :64) — replaced `existsSync+readFileSync` TOCTOU with `try/catch` (same pattern as prior fixes for alerts #10-13)

**Dismissed as intended (no code change):**
- **#44, #50** `js/file-access-to-http` in `embeddings.ts:404,438` — dismissed via API as `false positive`. Embedding is opt-in only (`resolveEmbedder` returns undefined unless `embeddingProvider` set); sending wiki text to `/v1/embeddings` behind `embeddingApiKey` is the feature's purpose.

Checks: `pnpm lint` ✅ `pnpm typecheck` ✅ `pnpm test` 751 passed ✅

Auto-closes #66 and #38 on merge after CodeQL rescan.