### PR TITLE
fix: lint ENOENT on fresh vaults (#203) + Windows capture basename (#204)

### DIFF
--- a/extensions/llm-wiki/lib/source-packet.ts
+++ b/extensions/llm-wiki/lib/source-packet.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { copyFile } from "node:fs/promises";
-import { extname, join } from "node:path";
+import { basename, extname, join } from "node:path";
 import { createKnowledgeDocument, serializeKnowledgeDocument } from "./knowledge-document.js";
 import { appendEvent } from "./metadata.js";
 import {
@@ -111,7 +111,7 @@ function urlCaptureSource(pi: ExecApi, url: string, signal?: AbortSignal): Captu
 }
 
 function fileCaptureSource(pi: ExecApi, filePath: string, signal?: AbortSignal): CaptureSource {
-  const fileName = filePath.split("/").pop() || "unknown";
+  const fileName = originalFileNameForPath(filePath);
   const extractor = fileExtractorFor(filePath);
   const content = extractor.shouldReadText ? readText(filePath) : "";
 
@@ -253,6 +253,15 @@ function originalFileNameForUrl(url: string): string {
   }
 
   return "source.html";
+}
+
+/**
+ * Original-artifact name for a local file capture. Uses platform basename so
+ * Windows absolute paths (drive colon + backslashes) cannot leak into the
+ * packet/original file name (issue #204).
+ */
+export function originalFileNameForPath(filePath: string): string {
+  return basename(filePath) || "unknown";
 }
 
 function contentExtractionFailureMessage(source: string): string {

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -1013,6 +1013,9 @@ function runWikiLint(paths: VaultPaths, autoFix: boolean): string {
   // The gap snapshot is generated discovery metadata consumed by wiki_status:
   // persist it on every successful lint so status never reports a stale count.
   // Corrective actions below (report, event, meta rebuild) stay autoFix-only.
+  // mkdir mirrors the autoFix report write below: on a fresh checkout the
+  // gitignored .discoveries dir does not exist yet (issue #203).
+  mkdirSync(paths.discoveries, { recursive: true });
   writeJson(join(paths.discoveries, "gaps.json"), {
     gaps,
     generated: new Date().toISOString(),

--- a/test/lint-okf.test.ts
+++ b/test/lint-okf.test.ts
@@ -180,6 +180,35 @@ it("refreshes a stale gap snapshot to empty on audit-only lint", async () => {
   expect(status.content[0].text).toContain("Gaps: 0");
 });
 
+it("completes on a fresh checkout where .discoveries is not yet created (issue #203)", async () => {
+  const paths = getVaultPaths(root);
+  ensureVaultStructure(paths);
+  // Fresh checkouts / worktrees of an existing vault do not have the
+  // gitignored .discoveries directory — simulate that.
+  rmSync(paths.discoveries, { recursive: true, force: true });
+  writeFileSync(join(paths.dotWiki, "config.json"), JSON.stringify({ name: "Fresh lint" }));
+  writeFileSync(join(paths.wiki, "concepts", "valid.md"), "---\ntype: concept\n---\n\nValid.\n");
+
+  let tool: TestTool | undefined;
+  registerWikiLint({
+    registerTool: (definition: unknown) => {
+      tool = definition as TestTool;
+    },
+  } as unknown as ExtensionAPI);
+  if (!tool) throw new Error("wiki_lint was not registered");
+  const result = await tool.execute("test", { auto_fix: false }, undefined, undefined, {
+    cwd: root,
+    hasUI: false,
+  });
+
+  expect(result.isError).not.toBe(true);
+  // auto_fix:false returns the run summary (not the reportLines file content).
+  expect(result.content[0].text).toContain("LLM Wiki lint complete");
+  expect(existsSync(join(paths.discoveries, "gaps.json"))).toBe(true);
+  const snapshot = JSON.parse(readFileSync(join(paths.discoveries, "gaps.json"), "utf8"));
+  expect(snapshot.gaps).toEqual([]);
+});
+
 it("persists non-empty gaps on audit-only lint", async () => {
   const paths = getVaultPaths(root);
   ensureVaultStructure(paths);

--- a/test/source-capture.test.ts
+++ b/test/source-capture.test.ts
@@ -2,7 +2,12 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { rebuildMetadata } from "../extensions/llm-wiki/lib/metadata.js";
-import { captureFile, captureText, captureUrl } from "../extensions/llm-wiki/lib/source-packet.js";
+import {
+  captureFile,
+  captureText,
+  captureUrl,
+  originalFileNameForPath,
+} from "../extensions/llm-wiki/lib/source-packet.js";
 import { ensureVaultStructure, getVaultPaths } from "../extensions/llm-wiki/lib/utils.js";
 import { mockPi, mockPiWithMarkItDown, readFile } from "./helpers.js";
 
@@ -164,6 +169,12 @@ describe("source packet capture", () => {
     expect(extracted).toContain("Hello world.");
 
     expect(existsSync(join(result.packetPath, "original", "notes.md"))).toBe(true);
+  });
+
+  it("derives the original artifact name with platform basename so drive letters stay out of file names (issue #204)", () => {
+    const absPath =
+      process.platform === "win32" ? "D:\\any\\dir\\doc.md" : "/home/user/any/dir/doc.md";
+    expect(originalFileNameForPath(absPath)).toBe("doc.md");
   });
 
   it("keeps a local capture path in the raw manifest but out of events and the OKF log", async () => {


### PR DESCRIPTION
Fixes #203. Fixes #204.

Two one-line fixes with regression tests:
- wiki_lint: mkdirSync the gitignored .discoveries dir before persisting the gap snapshot (mirrors the autoFix report write in the same function).
- wiki_capture_source: derive the original artifact name with platform basename instead of split('/').pop() so Windows absolute paths no longer embed a drive colon in the file name.
