### PR TITLE
fix: escape wikilink alias pipes only inside Markdown table rows

### DIFF
--- a/extensions/llm-wiki/lib/knowledge-document.ts
+++ b/extensions/llm-wiki/lib/knowledge-document.ts
@@ -589,7 +589,15 @@ export function serializeKnowledgeDocument(document: KnowledgeDocument): string 
   return body ? `---\n${yaml}---\n\n${body}\n` : `---\n${yaml}---\n`;
 }
 
-/** Escape wikilink alias pipes so generated content remains valid in Markdown tables. */
+const TABLE_ROW = /^\s*\|.*\|\s*$/;
+
+/** Escape wikilink alias pipes only inside Markdown table rows.
+ *
+ * A bare `|` inside `[[target|alias]]` would be read as a table cell
+ * delimiter when the row renders, so table rows need the pipe escaped as
+ * `[[target\|alias]]`. Prose, lists, headings, and fenced code keep their
+ * pipes literal, so the written file stays valid for external readers
+ * (Obsidian, VS Code Wiki Links) that don't understand the escaped form. */
 function escapeWikilinkAliasPipes(body: string): string {
   let inFence = false;
   return body
@@ -600,7 +608,9 @@ function escapeWikilinkAliasPipes(body: string): string {
         return line;
       }
       if (inFence) return line;
-      return line.replace(/\[\[([^\]\n]*?)(?<!\\)\|([^\]\n]*?)\]\]/g, "[[$1\\|$2]]");
+      return TABLE_ROW.test(line)
+        ? line.replace(/\[\[([^\]\n]*?)(?<!\\)\|([^\]\n]*?)\]\]/g, "[[$1\\|$2]]")
+        : line;
     })
     .join("\n");
 }

--- a/test/ingest-worker.test.ts
+++ b/test/ingest-worker.test.ts
@@ -306,7 +306,7 @@ describe("commitSynthesis", () => {
       );
       expect(res.ok).toBe(true);
       const written = readFileSync(join(paths.wiki, "sources", "SRC-001.md"), "utf-8");
-      expect(written).toContain("[[concepts/transformer\\|T]]");
+      expect(written).toContain("[[concepts/transformer|T]]");
     });
 
     it("off is a no-op (writes verbatim, no diagnostics)", () => {

--- a/test/knowledge-document.test.ts
+++ b/test/knowledge-document.test.ts
@@ -66,6 +66,34 @@ describe("KnowledgeDocument", () => {
     expect(doc.body).toContain("[[entities/raw|Raw]]");
   });
 
+  it("escopes alias-pipe escaping to Markdown table rows only", () => {
+    const table = createKnowledgeDocument(
+      "concepts/table.md",
+      { type: "concept" },
+      "| Name |\n| --- |\n| [[entities/gildan|Gildan]] |",
+    );
+    // Table row: alias pipe MUST be escaped so the cell isn't split.
+    expect(table.body).toContain("[[entities/gildan\\|Gildan]]");
+
+    const prose = createKnowledgeDocument(
+      "concepts/prose.md",
+      { type: "concept" },
+      "See [[entities/peanut-cat|Peanut]] and [[entities/alice|Alice]] here.",
+    );
+    // Prose: alias pipes MUST stay literal so external readers follow the link.
+    expect(prose.body).toContain("[[entities/peanut-cat|Peanut]]");
+    expect(prose.body).toContain("[[entities/alice|Alice]]");
+    expect(prose.body).not.toContain("\\|");
+
+    // Fenced code stays verbatim (existing behavior, keep asserting).
+    const fenced = createKnowledgeDocument(
+      "concepts/fenced.md",
+      { type: "concept" },
+      "```md\n[[entities/raw|Raw]]\n```",
+    );
+    expect(fenced.body).toContain("[[entities/raw|Raw]]");
+  });
+
   it.each([
     ["frontmatter_duplicate_key", "---\ntype: concept\ntype: entity\n---\n"],
     ["frontmatter_alias_forbidden", "---\ntype: concept\nx: &x [1]\ny: *x\n---\n"],


### PR DESCRIPTION
Closes #214

## Problem

`escapeWikilinkAliasPipes` ran its escaping regex on **every** non-fenced line, so aliased wikilinks in prose - e.g. `[[entities/peanut-cat|Peanut]]` - were persisted to the `.md` file as `[[entities/peanut-cat\|Peanut]]`.

pi tolerates the escaped form (`normalizeWikilinkTarget` strips the backslash), but external readers that parse the raw file (Obsidian, VS Code Wiki Links, etc.) treat `\\|` literally and report *Unresolved or ambiguous wiki-link*.

## Fix

Guard the escape behind a table-row test so only table rows get escaped (a bare `|` inside `[[...|...]]` is a table cell delimiter in GFM, so it must be escaped there). Prose, lists, headings, and fenced code keep their pipes literal, so the written file stays valid for external readers.

Both write paths inherit the fix:
- `createKnowledgeDocument` (`create_page`, `wiki_ensure_page`, stub concepts)
- `patchKnowledgeDocument` (ingest source updates)

## Test

- New regression test `escopes alias-pipe escaping to Markdown table rows only` asserts prose stays literal, table rows still escape, and fenced code is untouched.
- Corrected the one assertion that encoded the old behavior (`ingest-worker.test.ts` prose source page now expects the unescaped form).

Full suite: 754/754. `tsc --noEmit` clean. `biome check` clean (only pre-existing warnings).