### PR TITLE
ci: install @earendil-works/pi-server in consumer smoke-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,10 @@ jobs:
 
           cd "$consumer"
           npm init -y > /dev/null
-          npm install --no-package-lock --no-audit --no-fund "$RUNNER_TEMP/$tarball"
+          # @earendil-works/pi-coding-agent (a dep of this package) imports
+          # @earendil-works/pi-server at runtime but does not declare it, so a
+          # lockfile-free consumer install can resolve nothing for it.
+          npm install --no-package-lock --no-audit --no-fund "$RUNNER_TEMP/$tarball" "@earendil-works/pi-server"
 
           installed="$consumer/node_modules/@zosmaai/pi-llm-wiki"
           test -f "$installed/dist/mcp/index.js"


### PR DESCRIPTION
## Problem

The `packaged-mcp-consumer` CI job does a lockfile-free install of the packed tarball and runs the MCP server. That install resolves `@earendil-works/pi-coding-agent` (a dependency of this package, range `>=0.78.1`) to its latest release.

`@earendil-works/pi-coding-agent@0.85.0` imports `@earendil-works/pi-server` at runtime but does not declare it as a dependency. With `pnpm install --frozen-lockfile` in this repo, `pi-server` resolves transitively and the server starts. With a consumer lockfile-free `npm install` of just the tarball, `pi-server` never gets installed, so the server crashes on startup:

    Error [ERR_MODULE_NOT_FOUND]: Cannot find package
    "@earendil-works/pi-server" imported from .../@earendil-works/pi-coding-agent/dist/experimental/server.js

## Fix

Install `@earendil-works/pi-server` explicitly alongside the tarball in the consumer smoke-test, so the lockfile-free install can resolve it. This mirrors the CI intent (issue #128) of exercising the newest versions a consumer actually resolves, with `pi-server` added to whatever version of `pi-coding-agent` the tarball pulls.

Unrelated to #214; kept as its own PR so the wikilink fix stays self-contained.