### PR TITLE
fix: route /wiki-model picker cancel through keybindings

### DIFF
--- a/extensions/llm-wiki/lib/model-command.ts
+++ b/extensions/llm-wiki/lib/model-command.ts
@@ -3,7 +3,6 @@ import {
   Container,
   getKeybindings,
   Input,
-  matchesKey,
   type SelectItem,
   SelectList,
   type SelectListTheme,
@@ -132,11 +131,6 @@ class ModelPickerScreen extends Container {
   }
 
   handleInput(data: string): void {
-    // Esc cancels immediately even with a query; it does not first clear the filter.
-    if (matchesKey(data, "escape")) {
-      this.finish(undefined);
-      return;
-    }
     const kb = getKeybindings();
     if (
       kb.matches(data, "tui.select.up") ||
@@ -146,6 +140,9 @@ class ModelPickerScreen extends Container {
       this.list.handleInput(data);
       return;
     }
+    // tui.select.cancel defaults to escape + ctrl+c and the kitty CSI-u Esc
+    // form, so one keybinding check covers every cancel keypath (no hardcoded Esc,
+    // so a remapped binding is honored).
     if (kb.matches(data, "tui.select.cancel")) {
       this.finish(undefined);
       return;

--- a/test/model-command.test.ts
+++ b/test/model-command.test.ts
@@ -28,6 +28,7 @@ const DOWN = "\x1b[B";
 const ENTER = "\r";
 const ESC = "\x1b";
 const KITTY_ESC = "\u001b[27u";
+const CTRL_C = "\x03"; // ctrl+c resolves to tui.select.cancel in pi-tui
 const BACKSPACE = "\x7f";
 
 const fakeTheme = { fg: (_color: string, text: string) => text };
@@ -347,5 +348,16 @@ describe("/wiki-model interactive picker", () => {
     screen.handleInput(ENTER);
     await pending;
     expect(loadTaskConfig(tmp).taskModel).toEqual({ provider: "anthropic", id: "claude-haiku" });
+  });
+
+  it("cancels with ctrl+c via the keybinding path", async () => {
+    const tmp = project("ctrl-c");
+    const h = makeCtx({ cwd: tmp, models: namedModels });
+    const pending = handler("", h.ctx);
+    await tick();
+    const screen = h.screen.current!;
+    screen.handleInput(CTRL_C);
+    await pending;
+    expect(loadTaskConfig(tmp).taskModel).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Problem

The /wiki-model picker (PR #219) routes its keys through `getKeybindings()` —so a user's remapped select keys are honored. One exception remained:`handleInput` matched Esc via a hardcoded `matchesKey(data, "escape")` branch\nthat ran **before** the keybinding checks. That branch was redundant\n(`tui.select.cancel` already covers it) and prevented a remapped cancel\nbinding from taking effect.\n\n## Fix

Route Esc through the same `kb.matches(data, "tui.select.cancel")` check the\npicker already uses, and drop the now-unused `matchesKey` import. Esc,\nctrl+c and the kitty CSI-u Esc form all resolve to the cancel binding\n(verified against `@earendil-works/pi-tui@0.84.4`), so this is behaviorally\nidentical for the default keybindings while making Esc honor keybinding\nremaps — consistent with the rest of the picker.\n\n## Tests

- `test/model-command.test.ts`: added a ctrl+c-cancel regression test.- Existing raw-Esc and kitty-CSI-u-Esc cancel tests still pass (they now run\n  through the keybinding path).\n- `tsc` clean; `biome check` clean (pre-existing `noDelete` suppression warning\n  on line 142, unrelated).