### PR TITLE
fix: ignore wikilinks inside code spans, code blocks, and HTML

### DIFF
--- a/extensions/llm-wiki/lib/knowledge-links.ts
+++ b/extensions/llm-wiki/lib/knowledge-links.ts
@@ -38,22 +38,54 @@ function normalizeWikilinkTarget(target: string): string {
   return target.trim().replace(/\\$/, "");
 }
 
+// Blank out code spans, fenced/indented code blocks, and raw HTML (the same
+// node types the link walk skips), preserving length so offsets stay valid.
+function maskCodeRegions(tree: Root | null, body: string): string {
+  if (!tree) return body;
+  const ranges: Array<[number, number]> = [];
+  function visit(node: Nodes): void {
+    const position = (node as { position?: { start: { offset: number }; end: { offset: number } } })
+      .position;
+    if (node.type === "inlineCode" || node.type === "code" || node.type === "html") {
+      if (position) ranges.push([position.start.offset, position.end.offset]);
+    }
+    if ("children" in node && Array.isArray((node as { children?: Nodes[] }).children)) {
+      for (const child of (node as { children: Nodes[] }).children) {
+        visit(child);
+      }
+    }
+  }
+  visit(tree);
+  if (ranges.length === 0) return body;
+  const chars = body.split("");
+  for (const [start, end] of ranges) {
+    for (let i = start; i < end && i < chars.length; i++) {
+      if (i >= 0) chars[i] = " ";
+    }
+  }
+  return chars.join("");
+}
+
 export function extractKnowledgeLinks(body: string): KnowledgeLinks {
   const markdown: ExtractedLink[] = [];
   const wikilinks: ExtractedLink[] = [];
 
-  // Extract legacy wikilinks. A table-safe alias uses an escaped pipe: [[target\\|alias]].
-  for (const match of body.matchAll(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g)) {
-    wikilinks.push({ target: normalizeWikilinkTarget(match[1]), offset: match.index ?? 0 });
-  }
-
   // Parse with CommonMark AST
-  let tree: Root;
+  let tree: Root | null = null;
   try {
     tree = fromMarkdown(body);
   } catch {
-    return { markdown, wikilinks };
+    tree = null;
   }
+
+  // Extract legacy wikilinks. A table-safe alias uses an escaped pipe: [[target\\|alias]].
+  // Scan the code-masked body so [[...]] inside code is not a real link.
+  const scanBody = maskCodeRegions(tree, body);
+  for (const match of scanBody.matchAll(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g)) {
+    wikilinks.push({ target: normalizeWikilinkTarget(match[1]), offset: match.index ?? 0 });
+  }
+
+  if (!tree) return { markdown, wikilinks };
 
   // Build definition map (case-insensitive)
   const defs = new Map<string, Definition>();

--- a/test/knowledge-links.test.ts
+++ b/test/knowledge-links.test.ts
@@ -65,6 +65,34 @@ describe("knowledge links", () => {
     expect(extractLegacyWikilinks(body)).toEqual([{ target: "entities/gildan", offset: 0 }]);
   });
 
+  it("does not extract wikilinks from code spans, fenced blocks, or raw HTML (issue #224)", () => {
+    // Inline code span (reporter's exact case)
+    const inline =
+      "To avoid creating orphaned pages, ensure we include a source link in Wikilink format, i.e. `[[page]]`.";
+    expect(extractKnowledgeLinks(inline).wikilinks).toEqual([]);
+
+    // Fenced code block
+    const fenced = "```md\nSee [[page]] for details.\n```";
+    expect(extractKnowledgeLinks(fenced).wikilinks).toEqual([]);
+
+    // Indented code block
+    const indented = "    [[page]]";
+    expect(extractKnowledgeLinks(indented).wikilinks).toEqual([]);
+
+    // HTML comments and HTML blocks swallow their content
+    const comment = "<!-- [[page]] -->";
+    expect(extractKnowledgeLinks(comment).wikilinks).toEqual([]);
+
+    const block = "<div>\n[[page]]\n</div>";
+    expect(extractKnowledgeLinks(block).wikilinks).toEqual([]);
+
+    // Real wikilinks outside code are still extracted, with valid offsets
+    const mixed = "See [[concepts/inline]] and `[[not-a-link]]`.";
+    expect(extractKnowledgeLinks(mixed).wikilinks).toEqual([
+      { target: "concepts/inline", offset: 4 },
+    ]);
+  });
+
   it("rejects bundle escape and reports unresolved internal targets", () => {
     const result = buildResolvedBacklinks(
       "concepts/source",


### PR DESCRIPTION
## Summary

`wiki_lint` reported false-positive missing pages for wikilinks written inside code, e.g. documenting the format itself:

> To avoid creating orphaned pages, ensure we include a source link in Wikilink format, i.e. \`[[page]]\`.

→ lint flagged `page` as a missing page.

## Root cause

In `extensions/llm-wiki/lib/knowledge-links.ts`, the markdown-link path skips code via the micromark AST walk (inlineCode / code / html nodes), but the legacy wikilink regex ran over the **raw body** with no code awareness.

## Fix

Parse the AST first, then run the wikilink regex against a **code-masked** copy of the body: every `inlineCode` / `code` (fenced + indented) / `html` node range is blanked out. Masking preserves string length, so reported offsets stay valid. If the AST parse throws, we fall back to the previous raw-body behavior.

`extractLegacyWikilinks` (exported raw helper, test-only usage) is intentionally unchanged.

## Tests

- New regression test in `test/knowledge-links.test.ts` covering inline code spans (the reporter's exact case), fenced blocks, indented blocks, HTML comments, HTML blocks, and that real wikilinks outside code are still extracted with correct offsets.
- Full suite: 763 passed. Typecheck + biome clean.

Closes #224