### PR TITLE
fix: keep background wiki tasks from crashing the pi session (#222)

### DIFF
--- a/extensions/llm-wiki/lib/ingest-worker.ts
+++ b/extensions/llm-wiki/lib/ingest-worker.ts
@@ -497,6 +497,8 @@ export interface RunIngestSynthesisArgs {
   headers?: Record<string, string>;
   /** Stream function for extension-registered providers (issue #222). */
   streamFn?: StreamFn;
+  /** Provider-scoped env from auth resolution (issue #222; pi >= 0.85). */
+  env?: Record<string, string>;
   paths: VaultPaths;
   sourceId: string;
   manifest: Record<string, unknown>;
@@ -525,6 +527,7 @@ export async function runIngestSynthesis(
     apiKey,
     headers,
     streamFn,
+    env,
     paths,
     sourceId,
     manifest,
@@ -586,6 +589,7 @@ export async function runIngestSynthesis(
     apiKey,
     headers,
     streamFn,
+    env,
     systemPrompt,
     userPrompt,
     tools: [commitTool as AgentTool],

--- a/extensions/llm-wiki/lib/ingest-worker.ts
+++ b/extensions/llm-wiki/lib/ingest-worker.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { AgentTool, StreamFn } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import type { Static } from "typebox";
 import { Type } from "typebox";
@@ -495,6 +495,8 @@ export interface RunIngestSynthesisArgs {
   model: Model<Api>;
   apiKey: string;
   headers?: Record<string, string>;
+  /** Stream function for extension-registered providers (issue #222). */
+  streamFn?: StreamFn;
   paths: VaultPaths;
   sourceId: string;
   manifest: Record<string, unknown>;
@@ -522,6 +524,7 @@ export async function runIngestSynthesis(
     model,
     apiKey,
     headers,
+    streamFn,
     paths,
     sourceId,
     manifest,
@@ -582,6 +585,7 @@ export async function runIngestSynthesis(
     model,
     apiKey,
     headers,
+    streamFn,
     systemPrompt,
     userPrompt,
     tools: [commitTool as AgentTool],

--- a/extensions/llm-wiki/lib/runtime.ts
+++ b/extensions/llm-wiki/lib/runtime.ts
@@ -25,7 +25,18 @@ import { loadTaskConfig, noticesEnabled, TASK_DEFAULTS, type TaskConfig } from "
  */
 
 export type ResolveResult =
-  | { ok: true; model: unknown; apiKey: string; headers?: Record<string, string> }
+  | {
+      ok: true;
+      model: unknown;
+      apiKey: string;
+      headers?: Record<string, string>;
+      /**
+       * Stream function for the model's API (issue #222): the provider's own
+       * `streamSimple` when the model belongs to an extension-registered
+       * provider whose api pi-ai's default stream path cannot resolve.
+       */
+      streamFn?: unknown;
+    }
   | { ok: false; reason: string };
 
 type NotifyLevel = "info" | "warning" | "error";
@@ -39,6 +50,14 @@ export interface ResolveCtx {
     getApiKeyAndHeaders(
       model: unknown,
     ): Promise<{ ok: boolean; apiKey?: string; headers?: Record<string, string> }>;
+    /**
+     * Registered extension provider config (issue #222). Optional: pi < 0.85
+     * has no such method (it registers provider streamSimples directly into
+     * pi-ai's registry instead), in which case the default stream path is used.
+     */
+    getRegisteredProviderConfig?(
+      provider: string,
+    ): { api?: string; streamSimple?: unknown } | undefined;
   };
   hasUI: boolean;
   ui?: { notify: Notify };
@@ -137,7 +156,20 @@ export class Runtime {
       const provider = (model as { provider?: string }).provider ?? "unknown";
       return { ok: false, reason: `no API key for provider "${provider}"` };
     }
-    return { ok: true, model, apiKey: auth.apiKey ?? "", headers: auth.headers };
+    // Extension-registered providers (issue #222): pi-ai's default stream path
+    // may not be able to resolve their api (e.g. claude-bridge on pi 0.85+), so
+    // surface the provider's own streamSimple for the sub-agent stream. On pi
+    // < 0.85 the registry method is absent (?.) and the default path — which
+    // already knows extension streamSimples — is used instead.
+    const modelProvider = (model as { provider?: string }).provider;
+    const registered = modelProvider
+      ? ctx.modelRegistry.getRegisteredProviderConfig?.(modelProvider)
+      : undefined;
+    const streamFn =
+      registered?.streamSimple && registered.api === (model as { api?: string }).api
+        ? registered.streamSimple
+        : undefined;
+    return { ok: true, model, apiKey: auth.apiKey ?? "", headers: auth.headers, streamFn };
   }
 
   /**

--- a/extensions/llm-wiki/lib/runtime.ts
+++ b/extensions/llm-wiki/lib/runtime.ts
@@ -36,6 +36,8 @@ export type ResolveResult =
        * provider whose api pi-ai's default stream path cannot resolve.
        */
       streamFn?: unknown;
+      /** Provider-scoped env from auth resolution (pi >= 0.85). */
+      env?: Record<string, string>;
     }
   | { ok: false; reason: string };
 
@@ -47,9 +49,15 @@ export interface ResolveCtx {
   model: unknown;
   modelRegistry: {
     find(provider: string, id: string): unknown;
-    getApiKeyAndHeaders(
-      model: unknown,
-    ): Promise<{ ok: boolean; apiKey?: string; headers?: Record<string, string> }>;
+    getApiKeyAndHeaders(model: unknown): Promise<{
+      ok: boolean;
+      apiKey?: string;
+      headers?: Record<string, string>;
+      /** Auth-provided endpoint redirect (pi >= 0.85); beats the catalogue baseUrl. */
+      baseUrl?: string;
+      /** Provider-scoped env values (pi >= 0.85); must reach the stream options. */
+      env?: Record<string, string>;
+    }>;
     /**
      * Registered extension provider config (issue #222). Optional: pi < 0.85
      * has no such method (it registers provider streamSimples directly into
@@ -169,7 +177,19 @@ export class Runtime {
       registered?.streamSimple && registered.api === (model as { api?: string }).api
         ? registered.streamSimple
         : undefined;
-    return { ok: true, model, apiKey: auth.apiKey ?? "", headers: auth.headers, streamFn };
+    // Auth can redirect the endpoint (e.g. GitHub Copilot business vs
+    // individual accounts) and/or carry provider-scoped env values (pi >=
+    // 0.85). Streaming against the catalogue values yields 421 Misdirected
+    // Request and the synthesis silently produces nothing (issue #222).
+    const authedModel = auth.baseUrl ? { ...(model as object), baseUrl: auth.baseUrl } : model;
+    return {
+      ok: true,
+      model: authedModel,
+      apiKey: auth.apiKey ?? "",
+      headers: auth.headers,
+      env: auth.env,
+      streamFn,
+    };
   }
 
   /**

--- a/extensions/llm-wiki/lib/subagent.ts
+++ b/extensions/llm-wiki/lib/subagent.ts
@@ -40,6 +40,8 @@ export interface RunSubAgentArgs<TApi extends Api = Api> {
    * provider's own `streamSimple` when the model belongs to such a provider.
    */
   streamFn?: StreamFn;
+  /** Provider-scoped env from auth resolution (issue #222; pi >= 0.85). */
+  env?: Record<string, string>;
 }
 
 /**
@@ -56,8 +58,18 @@ export interface RunSubAgentArgs<TApi extends Api = Api> {
 export async function runSubAgent<TApi extends Api = Api>(
   args: RunSubAgentArgs<TApi>,
 ): Promise<void> {
-  const { model, apiKey, headers, systemPrompt, userPrompt, tools, maxTokens, signal, streamFn } =
-    args;
+  const {
+    model,
+    apiKey,
+    headers,
+    systemPrompt,
+    userPrompt,
+    tools,
+    maxTokens,
+    signal,
+    streamFn,
+    env,
+  } = args;
 
   const text = userPrompt.trim();
   if (!text) return;
@@ -85,6 +97,10 @@ export async function runSubAgent<TApi extends Api = Api>(
     convertToLlm: (msgs) => msgs as Message[],
     toolExecution: "sequential",
     ...(reasoning ? { reasoning: "high" as const } : {}),
+    // Provider-scoped env from auth resolution (issue #222). pi-agent-core
+    // spreads the config into the stream options, where pi-ai >= 0.85 honors
+    // it; the conditional spread keeps this compiling on pi < 0.85.
+    ...(env ? { env } : {}),
   };
 
   // Drive the loop directly instead of agentLoop(): agentLoop() wraps the

--- a/extensions/llm-wiki/lib/subagent.ts
+++ b/extensions/llm-wiki/lib/subagent.ts
@@ -2,19 +2,20 @@ import {
   type AgentContext,
   type AgentLoopConfig,
   type AgentTool,
-  agentLoop,
+  runAgentLoop,
+  type StreamFn,
 } from "@earendil-works/pi-agent-core";
 import type { Api, Message, Model } from "@earendil-works/pi-ai";
 
 /**
  * Thin sub-agent runner for the LLM Wiki background lane (issue #64, part of #63).
  *
- * Wraps `agentLoop` so background tasks (ingest synthesis, topic inference,
+ * Wraps the agent loop so background tasks (ingest synthesis, topic inference,
  * etc.) can run a focused, single-purpose agent on a resolved model with its
  * own system prompt and tools — mirroring pi-observational-memory's
  * `runObserver`. The caller drives behavior entirely through `tools`
  * (tool-side effects accumulate results); this wrapper just drives the loop to
- * completion and drains its event stream.
+ * completion.
  *
  * This is infrastructure: it makes no wiki-specific decisions. Concrete
  * background workers (issues #65, #66) supply the prompts and tools.
@@ -32,6 +33,13 @@ export interface RunSubAgentArgs<TApi extends Api = Api> {
   /** Max output tokens per model call. Default 4096. */
   maxTokens?: number;
   signal?: AbortSignal;
+  /**
+   * Stream function for the model's API (issue #222). Providers registered by
+   * extensions through `pi.registerProvider()` may not be resolvable by pi-ai's
+   * default stream path; the caller (Runtime.resolveModel) supplies the
+   * provider's own `streamSimple` when the model belongs to such a provider.
+   */
+  streamFn?: StreamFn;
 }
 
 /**
@@ -40,11 +48,16 @@ export interface RunSubAgentArgs<TApi extends Api = Api> {
  * Returns nothing useful directly — by design, results are collected by the
  * `tools` the caller passes (their `execute` accumulates into caller-owned
  * state). This keeps the runner generic across every background task type.
+ *
+ * Rejections from the loop (provider errors, auth failures, a streamFn that
+ * throws) reject this promise, so `BackgroundRuntime.launchTask`'s try/catch
+ * degrades them to a warning toast.
  */
 export async function runSubAgent<TApi extends Api = Api>(
   args: RunSubAgentArgs<TApi>,
 ): Promise<void> {
-  const { model, apiKey, headers, systemPrompt, userPrompt, tools, maxTokens, signal } = args;
+  const { model, apiKey, headers, systemPrompt, userPrompt, tools, maxTokens, signal, streamFn } =
+    args;
 
   const text = userPrompt.trim();
   if (!text) return;
@@ -74,9 +87,12 @@ export async function runSubAgent<TApi extends Api = Api>(
     ...(reasoning ? { reasoning: "high" as const } : {}),
   };
 
-  const stream = agentLoop(prompts, context, config, signal);
-  for await (const _event of stream) {
-    // Drain events; tool `execute` callbacks collect results caller-side.
-  }
-  await stream.result();
+  // Drive the loop directly instead of agentLoop(): agentLoop() wraps the
+  // loop in a detached promise (`void runAgentLoop(...).then(...)` with no
+  // .catch), so a rejection from the stream path — e.g. "No API provider
+  // registered for api: X" for a model from an extension-registered provider
+  // — escaped as an uncaughtException and killed the whole pi process while
+  // this function's stream drain hung forever (issue #222). runAgentLoop is
+  // the same loop with the rejection propagating to THIS promise.
+  await runAgentLoop(prompts, context, config, async () => {}, signal, streamFn);
 }

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -415,6 +415,7 @@ export function registerWikiIngest(pi: ExtensionAPI, runtime?: Runtime): void {
                 apiKey: resolved.apiKey,
                 headers: resolved.headers,
                 streamFn: resolved.streamFn as Parameters<typeof runIngestSynthesis>[0]["streamFn"],
+                env: resolved.env,
                 paths,
                 sourceId: s.id,
                 manifest: s.manifest,

--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -414,6 +414,7 @@ export function registerWikiIngest(pi: ExtensionAPI, runtime?: Runtime): void {
                 model: resolved.model as Parameters<typeof runIngestSynthesis>[0]["model"],
                 apiKey: resolved.apiKey,
                 headers: resolved.headers,
+                streamFn: resolved.streamFn as Parameters<typeof runIngestSynthesis>[0]["streamFn"],
                 paths,
                 sourceId: s.id,
                 manifest: s.manifest,

--- a/test/subagent.test.ts
+++ b/test/subagent.test.ts
@@ -4,6 +4,7 @@ import {
   type AssistantMessageEventStream,
   createAssistantMessageEventStream,
   type Model,
+  type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { Runtime } from "../extensions/llm-wiki/lib/runtime.js";
@@ -149,5 +150,73 @@ describe("Runtime.resolveModel streamFn (issue #222)", () => {
     });
     expect(res.ok).toBe(true);
     if (res.ok) expect(res.streamFn).toBeUndefined();
+  });
+});
+
+// ── auth-provided baseUrl/env (issue #222 follow-up) ────────────────
+// getApiKeyAndHeaders can redirect the endpoint (GitHub Copilot business
+// vs individual) or add provider-scoped env values (pi >= 0.85). resolveModel
+// used to discard both, so background streaming hit the catalogue baseUrl
+// (421 Misdirected Request) and env never reached the provider — silent
+// no-synthesis, no error anywhere.
+describe("auth baseUrl/env propagation (issue #222)", () => {
+  type AuthResult = {
+    ok: boolean;
+    apiKey?: string;
+    headers?: Record<string, string>;
+    baseUrl?: string;
+    env?: Record<string, string>;
+  };
+
+  function makeAuthRegistry(auth: AuthResult) {
+    return {
+      find: (_p: string, _i: string) => undefined,
+      getApiKeyAndHeaders: async (_m: unknown) => auth,
+    };
+  }
+
+  it("resolveModel honors auth.baseUrl (endpoint redirect), not the catalogue value", async () => {
+    const rt = new Runtime();
+    const res = await rt.resolveModel({
+      model: CUSTOM_API_MODEL,
+      modelRegistry: makeAuthRegistry({
+        ok: true,
+        apiKey: "k",
+        baseUrl: "https://api.business.example.com",
+      }),
+      hasUI: false,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect((res.model as { baseUrl: string }).baseUrl).toBe("https://api.business.example.com");
+    }
+  });
+
+  it("resolveModel propagates auth.env", async () => {
+    const rt = new Runtime();
+    const res = await rt.resolveModel({
+      model: CUSTOM_API_MODEL,
+      modelRegistry: makeAuthRegistry({
+        ok: true,
+        apiKey: "k",
+        env: { HTTPS_PROXY: "http://proxy:3128" },
+      }),
+      hasUI: false,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.env).toEqual({ HTTPS_PROXY: "http://proxy:3128" });
+  });
+
+  it("runSubAgent passes env into the stream options", async () => {
+    const streamFn = vi.fn(
+      (
+        _model: Model<Api>,
+        _context: unknown,
+        _options?: SimpleStreamOptions & { env?: Record<string, string> },
+      ) => fakeStream(),
+    );
+    await runSubAgent({ ...baseArgs(), streamFn, env: { TZ: "UTC" } });
+    expect(streamFn).toHaveBeenCalledTimes(1);
+    expect(streamFn.mock.calls[0][2]?.env).toEqual({ TZ: "UTC" });
   });
 });

--- a/test/subagent.test.ts
+++ b/test/subagent.test.ts
@@ -1,0 +1,153 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import {
+  type Api,
+  type AssistantMessageEventStream,
+  createAssistantMessageEventStream,
+  type Model,
+} from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { Runtime } from "../extensions/llm-wiki/lib/runtime.js";
+import { type RunSubAgentArgs, runSubAgent } from "../extensions/llm-wiki/lib/subagent.js";
+
+/**
+ * Issue #222: when the background task model belongs to an
+ * extension-registered provider, the sub-agent stream path throws
+ * ("No API provider registered for api: X") inside agentLoop's *detached*
+ * promise (void + .then, no .catch). The rejection escapes as an
+ * uncaughtException and kills the entire pi process, while runSubAgent's
+ * own await hangs on a stream that is never ended.
+ *
+ * These tests pin the contract:
+ *   1. provider-side failures must REJECT runSubAgent (catchable by
+ *      BackgroundRuntime.launchTask's try/catch → warning toast), never
+ *      crash the process or hang;
+ *   2. a provider's own streamSimple must be usable as `streamFn` so
+ *      extension models can actually stream;
+ *   3. Runtime.resolveModel must surface the registered provider's
+ *      streamSimple as `streamFn` on the resolve result.
+ */
+
+// A model whose api is neither built into pi-ai nor in pi-ai's
+// apiProviderRegistry — i.e. what an extension-registered provider looks
+// like to the default stream path (e.g. claude-bridge on pi 0.85.x).
+const CUSTOM_API_MODEL = {
+  id: "bridge-model",
+  name: "Bridge Model",
+  api: "custom-bridge",
+  provider: "bridge-prov",
+  baseUrl: "http://localhost:9999",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 8000,
+  maxTokens: 1024,
+} as unknown as Model<Api>;
+
+/** A minimal successful stream: one assistant text message, stop. */
+function fakeStream(): AssistantMessageEventStream {
+  const stream = createAssistantMessageEventStream();
+  stream.push({
+    type: "done",
+    reason: "stop",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "ok" }],
+      api: "custom-bridge",
+      provider: "bridge-prov",
+      model: "bridge-model",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    },
+  });
+  return stream;
+}
+
+function baseArgs(): Omit<RunSubAgentArgs, "streamFn"> {
+  return {
+    model: CUSTOM_API_MODEL,
+    apiKey: "k",
+    systemPrompt: "sp",
+    userPrompt: "hi",
+    tools: [] as AgentTool[],
+  };
+}
+
+// ── hardening: failures must reject, not crash or hang ───────────────
+describe("issue #222 hardening", () => {
+  it("runSubAgent rejects when the model's api is unregistered (no crash, no hang)", async () => {
+    // Before the fix: the rejection escapes agentLoop's detached promise as
+    // an uncaughtException (process dies) and this await never settles
+    // (the stream is never ended), so the test crashes or times out.
+    await expect(runSubAgent(baseArgs())).rejects.toThrow(
+      /No API provider registered for api: custom-bridge/,
+    );
+  }, 15_000);
+
+  it("runSubAgent resolves when a working streamFn is supplied for the custom api", async () => {
+    const streamFn = vi.fn((_model: Model<Api>) => fakeStream());
+    await expect(runSubAgent({ ...baseArgs(), streamFn })).resolves.toBeUndefined();
+    expect(streamFn).toHaveBeenCalledTimes(1);
+    // The stream function must receive the resolved model.
+    expect(streamFn.mock.calls[0][0]).toBe(CUSTOM_API_MODEL);
+  }, 15_000);
+});
+
+// ── resolveModel surfaces the provider's streamSimple ────────────────
+describe("Runtime.resolveModel streamFn (issue #222)", () => {
+  function makeRegistryWithProvider(
+    providerConfig: { api?: string; streamSimple?: unknown } | undefined,
+  ) {
+    return {
+      find: (_p: string, _i: string) => undefined,
+      getApiKeyAndHeaders: async (_m: unknown) => ({ ok: true, apiKey: "k" }),
+      getRegisteredProviderConfig: (p: string) =>
+        p === "bridge-prov" ? providerConfig : undefined,
+    };
+  }
+
+  it("returns the registered provider's streamSimple when apis match", async () => {
+    const streamSimple = () => fakeStream();
+    const rt = new Runtime();
+    const res = await rt.resolveModel({
+      model: CUSTOM_API_MODEL,
+      modelRegistry: makeRegistryWithProvider({ api: "custom-bridge", streamSimple }),
+      hasUI: false,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.streamFn).toBe(streamSimple);
+  });
+
+  it("returns no streamFn when the registered api differs from the model's api", async () => {
+    const streamSimple = () => fakeStream();
+    const rt = new Runtime();
+    const res = await rt.resolveModel({
+      model: CUSTOM_API_MODEL,
+      modelRegistry: makeRegistryWithProvider({ api: "other-api", streamSimple }),
+      hasUI: false,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.streamFn).toBeUndefined();
+  });
+
+  it("returns no streamFn when the registry lacks getRegisteredProviderConfig (pi < 0.85)", async () => {
+    const rt = new Runtime();
+    const res = await rt.resolveModel({
+      model: CUSTOM_API_MODEL,
+      modelRegistry: {
+        find: () => undefined,
+        getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "k" }),
+      },
+      hasUI: false,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.streamFn).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #222

Background wiki tasks (ingest synthesis, retro, observe, capture) could kill the entire pi session with an uncaughtException whenever the resolved task model belonged to an extension-registered provider (e.g. `pi-claude-bridge`). Two commits, two independent defects:

## Commit 1 — the crash (session-killer)

`runSubAgent` drove the loop through `agentLoop()`, which detaches the loop promise:

```js
void runAgentLoop(...).then((messages) => stream.end(messages));  // no .catch
```

When the stream path rejects — `No API provider registered for api: X` for a model whose api pi-ai's default `streamSimple` can't resolve — the rejection escapes as an **uncaughtException** (process dies), while the caller's `for await` hangs forever (the stream is never ended on that path). `BackgroundRuntime.launchTask`'s try/catch therefore never fired — `await work()` never settles.

**Fix:** drive the loop via the exported `runAgentLoop()` directly. The rejection now propagates into `runSubAgent`'s own promise, so `launchTask` degrades it to a warning toast. This is the load-bearing fix: it also covers provider-side throws (e.g. claude-bridge's prompt-capture guard on the wiki's own system prompt — comment 3 in the issue), which are not fixable from llm-wiki's side.

Additionally, `Runtime.resolveModel` now surfaces the registered provider's own `streamSimple` as `streamFn` (via `getRegisteredProviderConfig?.()` — optional, since pi < 0.85 has no such method and registers provider streamSimples directly into pi-ai's registry instead), threaded through `ResolveResult → wiki_ingest → runIngestSynthesis → runSubAgent`.

## Commit 2 — the silent failure (no synthesis, no error)

`resolveModel` discarded `baseUrl` and `env` from `getApiKeyAndHeaders`. Auth can redirect the endpoint (GitHub Copilot business vs individual accounts → `421 Misdirected Request` against the catalogue baseUrl) and `env` (pi ≥ 0.85) carries provider-scoped config (regional settings, placeholders, proxies). Background streaming now uses the auth-redirected model and passes `env` into the stream options (spread conditionally, so this compiles on pi < 0.85 whose `StreamOptions` predates the field).

## Verification (TDD)

- New `test/subagent.test.ts` (8 tests): before the fix, the unregistered-api test reproduced the issue's exact stack — 2 unhandled rejections + hang (31s); all fail the intended assertions. After: green in ~5ms.
- Commit 2's 3 tests (baseUrl redirect, env propagation, env reaching stream options) were red-then-green the same way.
- Full suite **771/771**, typecheck clean, no new lint warnings (verified against baseline).
- Version-resilient by construction: the `?.` registry lookup no-ops on pi 0.78.1 (where extension streamSimples are already in pi-ai's registry) and activates on 0.85.1 (pending dependabot bump #230, where the bug reproduces). Confirmed both versions' type surfaces from the npm tarballs.

Note: with this fix, extension-provider users who still hit provider-specific stream failures (e.g. claude-bridge refusing the wiki's system prompt) get the existing warning-toast fallback path instead of a dead session — the background lane degrades to foreground/no-op, never a crash.