### PR TITLE
fix: include state in wiki search

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -154,7 +154,7 @@ scoring, no PRF, no vault layering. Use for lookups when you already know what y
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `query` | `string` | ✅ | Search term matched against page IDs, titles, and types |
+| `query` | `string` | ✅ | Search term matched against page IDs, titles, types, states, categories, domains, tags, aliases, and recall triggers |
 | `type` | `string` | — | Filter results to a specific page type (e.g. `"concept"`, `"entity"`) |
 
 **Returns**

--- a/extensions/llm-wiki/lib/wiki-service.ts
+++ b/extensions/llm-wiki/lib/wiki-service.ts
@@ -114,6 +114,14 @@ function matchesField(id: string, entry: Record<string, unknown>, query: string)
   )
     return true;
 
+  // Match state
+  if (
+    String(entry.state || "")
+      .toLowerCase()
+      .includes(query)
+  )
+    return true;
+
   // Match category/domain
   if (
     String(entry.category || "")

--- a/test/mcp-parity.test.ts
+++ b/test/mcp-parity.test.ts
@@ -56,7 +56,7 @@ describe("MCP parity with shared services", () => {
     mkdirSync(join(paths.wiki, "concepts"), { recursive: true });
     writeFileSync(
       join(paths.wiki, "concepts", "nested.md"),
-      "---\ntype: concept\ntitle: Nested Concept\ndescription: A nested concept about trees\n---\n\n# Nested Concept\n\nTree content.",
+      "---\ntype: concept\ntitle: Nested Concept\nstate: needs-review\ndescription: A nested concept about trees\n---\n\n# Nested Concept\n\nTree content.",
     );
     rebuildMetadata(paths);
 
@@ -67,6 +67,14 @@ describe("MCP parity with shared services", () => {
     expect(mcpSearch.diagnostics).toEqual(
       piSearch.diagnostics.map((d) => ({ code: d.code, message: d.message })),
     );
+
+    const piStateSearch = searchRegistry(paths, "needs-review");
+    const mcpStateSearch = await searchOperation(paths, "needs-review");
+
+    expect(piStateSearch.matches).toEqual([
+      { id: "concepts/nested", title: "Nested Concept", type: "concept" },
+    ]);
+    expect(mcpStateSearch.matches).toEqual(piStateSearch.matches);
   });
 
   it("status parity: MCP matches shared getWikiStatus", async () => {


### PR DESCRIPTION
## Problem

`wiki_search` doesn't currently match on `state` even though `state` is included in the registry.

For example, a page with:

```yaml
type: open-loop
state: open
```

won't show up via `wiki_search(query="open", type="open-loop")` based on state.

## Root cause

`searchRegistry()` uses `matchesField()` to check if the query has ID, title, type, category, domain, tags, aliases, and `recall_triggers`, but not `entry.state`.

This PR adds `state` to matchesField() & updates the corresponding documentation and tests.

(Regression tests were created with LLM assistance, but they LGTM & correctly break if I comment out the state matching. No other tests fail in either case.)