### PR TITLE
fix: match status in registry search

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -154,7 +154,7 @@ scoring, no PRF, no vault layering. Use for lookups when you already know what y
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `query` | `string` | ✅ | Search term matched against page IDs, titles, types, states, categories, domains, tags, aliases, and recall triggers |
+| `query` | `string` | ✅ | Search term matched against page IDs, titles, types, states, statuses, categories, domains, tags, aliases, and recall triggers |
 | `type` | `string` | — | Filter results to a specific page type (e.g. `"concept"`, `"entity"`) |
 
 **Returns**

--- a/extensions/llm-wiki/lib/wiki-service.ts
+++ b/extensions/llm-wiki/lib/wiki-service.ts
@@ -46,7 +46,7 @@ export interface WikiStatusSnapshot {
 /**
  * Search the registry for matching concepts.
  *
- * Matches ID, semantic title, type, category, domain, tags, aliases, and recall triggers.
+ * Matches ID, title, type, state, status, category, domain, tags, aliases, and recall triggers.
  * Preserves unknown types as strings.
  */
 export function searchRegistry(
@@ -117,6 +117,14 @@ function matchesField(id: string, entry: Record<string, unknown>, query: string)
   // Match state
   if (
     String(entry.state || "")
+      .toLowerCase()
+      .includes(query)
+  )
+    return true;
+
+  // Match status
+  if (
+    String(entry.status || "")
       .toLowerCase()
       .includes(query)
   )

--- a/test/mcp-parity.test.ts
+++ b/test/mcp-parity.test.ts
@@ -56,7 +56,7 @@ describe("MCP parity with shared services", () => {
     mkdirSync(join(paths.wiki, "concepts"), { recursive: true });
     writeFileSync(
       join(paths.wiki, "concepts", "nested.md"),
-      "---\ntype: concept\ntitle: Nested Concept\nstate: needs-review\ndescription: A nested concept about trees\n---\n\n# Nested Concept\n\nTree content.",
+      "---\ntype: concept\ntitle: Nested Concept\nstate: NEEDS-REVIEW\nstatus: edge-case\ndescription: A nested concept about trees\n---\n\n# Nested Concept\n\nTree content.",
     );
     rebuildMetadata(paths);
 
@@ -75,6 +75,15 @@ describe("MCP parity with shared services", () => {
       { id: "concepts/nested", title: "Nested Concept", type: "concept" },
     ]);
     expect(mcpStateSearch.matches).toEqual(piStateSearch.matches);
+
+    // Status matching (status is a standard frontmatter field)
+    const piStatusSearch = searchRegistry(paths, "edge-case");
+    const mcpStatusSearch = await searchOperation(paths, "edge-case");
+
+    expect(piStatusSearch.matches).toEqual([
+      { id: "concepts/nested", title: "Nested Concept", type: "concept" },
+    ]);
+    expect(mcpStatusSearch.matches).toEqual(piStatusSearch.matches);
   });
 
   it("status parity: MCP matches shared getWikiStatus", async () => {


### PR DESCRIPTION
Follow-up to #240 and #242.

- `searchRegistry()` now matches the `status` frontmatter field (same pattern as `state` from #240). `status` is a **standard** field the registry already copies — pages with e.g. `status: insight` are now findable by it.
- Mixed-case state fixture (`state: NEEDS-REVIEW`) pins case-insensitivity for the #240 behavior.
- Updated the stale `searchRegistry()` jsdoc and `docs/api.md` field list (which also covers `state` from #240).

Verified: new status assertions fail without the `status` block; full suite 885 tests green, typecheck and biome clean.

Closes #242