### PR TITLE
fix(#241): consume YAML frontmatter passed in wiki_ensure_page content

### DIFF
--- a/extensions/llm-wiki/lib/tools.ts
+++ b/extensions/llm-wiki/lib/tools.ts
@@ -8,6 +8,8 @@ import { scheduleReindex } from "./indexing.js";
 import { runIngestSynthesis } from "./ingest-worker.js";
 import {
   createKnowledgeDocument,
+  type KnowledgeValue,
+  parseMarkdownFrontmatter,
   serializeKnowledgeDocument,
   writeKnowledgeDocumentFile,
 } from "./knowledge-document.js";
@@ -509,6 +511,11 @@ export function registerWikiIngest(pi: ExtensionAPI, runtime?: Runtime): void {
 
 // ─── 4. wiki_ensure_page ────────────────────────────────
 
+// Frontmatter fields wiki_ensure_page generates or derives itself (title also
+// determines the filename). Model-supplied values for these are ignored rather
+// than merged (issue #241).
+const RESERVED_FRONTMATTER = new Set(["type", "title", "created", "updated", "sources", "id"]);
+
 export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): void {
   pi.registerTool({
     name: "wiki_ensure_page",
@@ -518,6 +525,7 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
     promptGuidelines: [
       "Use wiki_ensure_page before creating pages to avoid duplicates.",
       "Search existing pages first with wiki_search.",
+      "Content may begin with a YAML frontmatter block; its fields are merged into the page frontmatter, and generated fields are reserved.",
     ],
     parameters: Type.Object({
       type: Type.String({
@@ -526,7 +534,10 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
       }),
       title: Type.String({ description: "Page title" }),
       content: Type.Optional(
-        Type.String({ description: "Optional initial content (otherwise uses template)" }),
+        Type.String({
+          description:
+            "Optional Markdown body. May begin with a YAML frontmatter block, whose fields are merged into the page frontmatter; generated fields (type, title, created, updated, sources) are reserved and ignored.",
+        }),
       ),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -571,6 +582,25 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
       const today = fmtDate();
       let body = params.content ?? buildPageBody(type, params.title);
 
+      // #241: models sometimes pass a YAML frontmatter block inside content.
+      // Consume it (with the same hardened parser used for page reads) and merge
+      // its fields into the generated frontmatter, instead of writing the block
+      // verbatim into the body (duplicate frontmatter, and the model's fields
+      // silently never took effect). Generated fields are reserved; a
+      // frontmatter-only content falls back to the template body.
+      const extraFrontmatter: Record<string, KnowledgeValue> = {};
+      if (body.trimStart().startsWith("---")) {
+        const parsed = parseMarkdownFrontmatter(body, `${folder}/${slug}.md`);
+        if (parsed.ok) {
+          for (const [key, value] of Object.entries(parsed.mapping)) {
+            if (!RESERVED_FRONTMATTER.has(key)) {
+              extraFrontmatter[key] = value;
+            }
+          }
+          body = parsed.body.trim() ? parsed.body : buildPageBody(type, params.title);
+        }
+      }
+
       // Pre-write wikilink gate (#172): validate/normalize caller-supplied content.
       const mode = resolveWikilinkValidation(loadTaskConfig(ctx.cwd));
       let wikilinkIssues: string[] = [];
@@ -612,6 +642,7 @@ export function registerWikiEnsurePage(pi: ExtensionAPI, runtime?: Runtime): voi
           title: params.title,
           created: today,
           updated: today,
+          ...extraFrontmatter,
         },
         body,
       );

--- a/test/wikilink-gate.test.ts
+++ b/test/wikilink-gate.test.ts
@@ -150,6 +150,50 @@ describe("wiki_ensure_page wikilink gate", () => {
   });
 });
 
+describe("wiki_ensure_page content frontmatter (#241)", () => {
+  it("consumes a leading YAML block, merges non-reserved fields, ignores reserved ones", async () => {
+    setMode("off"); // wikilink gate irrelevant here
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const content =
+      "---\ntags: [llm, wikis]\nstatus: active\ntitle: Wrong Title\nsources: nope\n---\n\nSome notes about wikis.";
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Wikis", content },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const file = join(getVaultPaths(wikiDir).wiki, "concepts", "wikis.md");
+    const text = readFileSync(file, "utf-8");
+    // exactly one frontmatter block, not a duplicate
+    expect(text.split("\n").filter((l) => l === "---")).toHaveLength(2);
+    expect(text).toContain("tags:\n  - llm\n  - wikis");
+    expect(text).toContain("status: active");
+    expect(text).toContain("title: Wikis"); // param title wins over content's
+    expect(text).not.toContain("Wrong Title");
+    expect(text).not.toContain("sources");
+    expect(text).toContain("Some notes about wikis.");
+  });
+
+  it("falls back to the template body when content is frontmatter-only", async () => {
+    setMode("off");
+    const tool = capture((pi) => registerWikiEnsurePage(pi));
+    const res = await tool.execute(
+      "t",
+      { type: "concept", title: "Tags Only", content: "---\ntags: [meta]\n---\n" },
+      undefined,
+      undefined,
+      { cwd: wikiDir, hasUI: false },
+    );
+    expect(res.isError).toBeFalsy();
+    const file = join(getVaultPaths(wikiDir).wiki, "concepts", "tags-only.md");
+    const text = readFileSync(file, "utf-8");
+    expect(text).toContain("tags:\n  - meta");
+    expect(text).toContain("# Tags Only"); // template body filled in
+  });
+});
+
 import { registerWikiRetro } from "../extensions/llm-wiki/lib/retro.js";
 
 describe("wiki_retro wikilink gate", () => {


### PR DESCRIPTION
Closes #241

## What

When the model passes a YAML frontmatter block inside `content` to `wiki_ensure_page`, the tool now **consumes it** (using the existing hardened frontmatter parser) instead of writing it verbatim into the body:

- Block fields are merged into the generated page frontmatter
- Generated fields (`type`, `title`, `created`, `updated`, `sources`, `id`) are reserved — model values for them are ignored (title determines the filename)
- Frontmatter-only content falls back to the template body
- `content` param description + promptGuidelines updated to match

## Why

Reproduced: content with a leading YAML block produced a file with **two** frontmatter blocks (4 `---` fences) — the generated header plus the model's block stranded inside the body. On re-read only the first block is parsed, so the model's fields (e.g. `tags`) silently never took effect — the exact confusion in #241.

## Verified

- 2 new tests: duplicate blocks eliminated / fields merged / reserved keys ignored; template fallback for frontmatter-only content
- Full suite: 887 passed
- `pnpm typecheck` clean; biome clean (only pre-existing warning in QMD code, untouched)

Skipped the alternative from the issue (a new `frontmatter` param) — the consume-and-merge covers it with no new API surface.
