### PR TITLE
fix: keep non-Latin titles in observation slugs; never overwrite same-day observations

### DIFF
--- a/extensions/llm-wiki/lib/observation.ts
+++ b/extensions/llm-wiki/lib/observation.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
@@ -56,15 +57,25 @@ export function saveObservation(
   const today = fmtDate();
   const timestamp = new Date().toISOString();
 
-  // Generate a slug from title
-  const slugBase = input.title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "")
-    .slice(0, 60);
+  // Generate a slug from title. \p{L}\p{N} keeps non-Latin letters (CJK titles
+  // used to collapse to an empty slug and collide on one filename per day);
+  // every other character run becomes a separator, as before.
+  const slugBase =
+    input.title
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}]+/gu, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 60) || "untitled";
   const slug = `obs-${today}-${slugBase}`;
 
-  const pagePath = join(paths.wiki, "sources", `${slug}.md`);
+  // Never overwrite an existing observation: same-day identical slugs get a
+  // -2, -3, … suffix instead of silently replacing the earlier file.
+  let finalSlug = slug;
+  let pagePath = join(paths.wiki, "sources", `${finalSlug}.md`);
+  for (let n = 2; existsSync(pagePath); n++) {
+    finalSlug = `${slug}-${n}`;
+    pagePath = join(paths.wiki, "sources", `${finalSlug}.md`);
+  }
 
   const relevanceEmoji = RELEVANCE_EMOJIS[input.relevance] ?? "📝";
   const tags = input.tags ?? "";
@@ -80,11 +91,11 @@ ${input.content}
 *Observed: ${timestamp}*`;
 
   const doc = createKnowledgeDocument(
-    `sources/${slug}.md`,
+    `sources/${finalSlug}.md`,
     {
       type: "source",
       title: `Observation: ${input.title}`,
-      slug,
+      slug: finalSlug,
       status: "observation",
       created: today,
       updated: today,
@@ -100,7 +111,7 @@ ${input.content}
   // Log event
   appendEvent(paths, {
     kind: "observe",
-    slug,
+    slug: finalSlug,
     title: input.title,
     relevance: input.relevance,
   });
@@ -110,7 +121,7 @@ ${input.content}
   // a non-blocking reindex instead.
   if (opts?.rebuild !== false) rebuildMetadataLight(paths);
 
-  return { slug, pagePath };
+  return { slug: finalSlug, pagePath };
 }
 
 // ─── Shared Reminder State ────────────────────────────

--- a/test/observation.test.ts
+++ b/test/observation.test.ts
@@ -178,6 +178,38 @@ describe("wiki observation", () => {
     expect(result.slug).not.toContain("//");
     expect(result.slug).not.toContain("_");
   });
+
+  it("should keep non-Latin titles in the slug instead of collapsing to an empty one", () => {
+    const paths = getVaultPaths(vaultDir);
+    const result = saveObservation(paths, {
+      title: "中文标题观察",
+      content: "中文内容",
+      relevance: "low",
+    });
+
+    expect(result.slug).toContain("中文标题观察");
+    expect(existsSync(result.pagePath)).toBe(true);
+  });
+
+  it("should not overwrite an existing same-day observation with an identical title", () => {
+    const paths = getVaultPaths(vaultDir);
+    const first = saveObservation(paths, {
+      title: "重复标题",
+      content: "first call",
+      relevance: "low",
+    });
+    const second = saveObservation(paths, {
+      title: "重复标题",
+      content: "second call",
+      relevance: "low",
+    });
+
+    expect(second.slug).not.toBe(first.slug);
+    expect(existsSync(first.pagePath)).toBe(true);
+    expect(existsSync(second.pagePath)).toBe(true);
+    expect(readFileSync(first.pagePath, "utf-8")).toContain("first call");
+    expect(readFileSync(second.pagePath, "utf-8")).toContain("second call");
+  });
 });
 
 // ─── registerObservationReminder (retry deduplication) ──────────────────────


### PR DESCRIPTION
## Problem

`wiki_observe` generates its filename with the ASCII-only character class `/[^a-z0-9]+/g`. For any title without Latin letters (e.g. Chinese/Japanese/Korean) this strips the **whole** title: `slugBase` becomes `""` and the slug collapses to `obs-YYYY-MM-DD-`.

Consequences:
- The filename carries no title information.
- Two observations saved on the same day silently collide on the same path, and the second `writeKnowledgeDocumentFile` overwrites the first — data loss. (Hit in production: two same-day observations lost.)

## Fix

- Widen the slug character class to `[^\p{L}\p{N}]+` so Unicode letters/digits (CJK included) survive; every other character run still becomes `-`, so existing ASCII behavior is unchanged.
- Fall back to `untitled` for symbol-only titles (previously also produced an empty slug).
- Add a collision guard: if the target file already exists, suffix `-2`, `-3`, … instead of overwriting the previous observation.

## Tests

Added two regression tests in `test/observation.test.ts`:
- CJK title produces a slug containing the title and creates the file.
- Same title saved twice on the same day → distinct slugs/files, both contents preserved.

`vitest run test/observation.test.ts test/slugify.test.ts`: 29/29 pass. Full suite: the only failures are the 5 pre-existing macOS-environment cases (symlinked `/tmp`, APFS NFC normalization), which fail identically on unmodified `main`.
